### PR TITLE
Improve CivitAI browser and downloader

### DIFF
--- a/shared/civitai_download.py
+++ b/shared/civitai_download.py
@@ -11,6 +11,10 @@ import urllib.error
 import time
 import uuid
 import threading
+import shutil
+import subprocess
+import json
+import socket
 from pathlib import Path
 from typing import Optional, Dict, Any, Callable
 from dataclasses import dataclass, field
@@ -95,7 +99,7 @@ MODEL_TYPE_TO_FOLDER = {
     "LORA": "loras",
     "LoCon": "loras",
     "DoRA": "loras",
-    "Checkpoint": "checkpoints",
+    "Checkpoint": "diffusion_models",
     "TextualInversion": "embeddings",
     "Hypernetwork": "hypernetworks",
     "AestheticGradient": "loras",  # No specific folder, use loras
@@ -124,6 +128,12 @@ def get_model_folder(model_type: str) -> str:
     """
     folder_name = MODEL_TYPE_TO_FOLDER.get(model_type, "loras")
 
+    # Keep checkpoints in the physical diffusion_models folder
+    # instead of ComfyUI's diffusion_models -> unet alias.
+    if model_type == "Checkpoint" and HAS_FOLDER_PATHS:
+        return os.path.join(folder_paths.models_dir, "diffusion_models")
+
+
     if HAS_FOLDER_PATHS:
         try:
             paths = folder_paths.get_folder_paths(folder_name)
@@ -140,7 +150,13 @@ def get_model_folder(model_type: str) -> str:
     return os.path.join(os.path.dirname(os.path.dirname(os.path.dirname(__file__))), "models", folder_name)
 
 
-def get_download_path(model_type: str, base_model: str, filename: str, use_subfolder: bool = True) -> str:
+def get_download_path(
+    model_type: str,
+    base_model: str,
+    filename: str,
+    use_subfolder: bool = True,
+    selected_folder: Optional[str] = None
+) -> str:
     """
     Get the full download path for a model.
 
@@ -148,16 +164,36 @@ def get_download_path(model_type: str, base_model: str, filename: str, use_subfo
         model_type: CivitAI model type (LORA, Checkpoint, etc.)
         base_model: CivitAI base model (SDXL 1.0, Pony, etc.)
         filename: Original filename from CivitAI
-        use_subfolder: Whether to organize into base model subfolders (default True for LoRAs)
+        use_subfolder: Whether to organize into base model subfolders
+        selected_folder: Optional folder relative to the model-type root.
+            An empty string selects the root folder itself. None keeps the
+            existing automatic destination behavior.
 
     Returns:
         Full path where the file should be saved
     """
-    base_dir = get_model_folder(model_type)
+    base_dir = os.path.abspath(get_model_folder(model_type))
 
-    # For LoRAs/LoCon/DoRA, organize by base model subfolder
-    # For other types (checkpoints, VAE, etc.), put directly in folder
-    if use_subfolder and model_type in ("LORA", "LoCon", "DoRA"):
+    if selected_folder is not None:
+        # The browser sends a path relative to the correct model root.
+        # Reject absolute paths and anything that tries to escape that root.
+        if os.path.isabs(selected_folder):
+            raise ValueError("Selected download folder must be relative")
+
+        normalized_folder = os.path.normpath(selected_folder)
+
+        if normalized_folder in ("", "."):
+            full_dir = base_dir
+        else:
+            full_dir = os.path.abspath(
+                os.path.join(base_dir, normalized_folder)
+            )
+
+            if os.path.commonpath([base_dir, full_dir]) != base_dir:
+                raise ValueError("Selected download folder is outside the model directory")
+
+    # Preserve the existing automatic organization when no override is sent.
+    elif use_subfolder and model_type in ("LORA", "LoCon", "DoRA"):
         subfolder = normalize_base_model(base_model)
         if subfolder:
             full_dir = os.path.join(base_dir, subfolder)
@@ -166,9 +202,7 @@ def get_download_path(model_type: str, base_model: str, filename: str, use_subfo
     else:
         full_dir = base_dir
 
-    # Create directory if needed
     Path(full_dir).mkdir(parents=True, exist_ok=True)
-
     return os.path.join(full_dir, filename)
 
 
@@ -222,7 +256,8 @@ class CivitAIDownloader:
     def __init__(self):
         self.downloads: Dict[str, DownloadStatus] = {}
         self._lock = threading.Lock()
-
+        self._aria2_processes = {}
+        
     def start_download(
         self,
         download_url: str,
@@ -312,6 +347,273 @@ class CivitAIDownloader:
             # Create directory if needed
             Path(save_path).parent.mkdir(parents=True, exist_ok=True)
 
+            # Use aria2c when available for faster multi-connection downloads
+            aria2_path = shutil.which("aria2c")
+
+            if aria2_path:
+                print("[CivitAI Download] aria2c found - using accelerated download")
+
+                # Resolve CivitAI's authenticated URL to the final CDN URL
+                aria2_download_url = download_url
+
+                try:
+                    resolve_request = urllib.request.Request(
+                        download_url,
+                        headers=headers
+                    )
+
+                    with civitai_urlopen(resolve_request, timeout=30) as resolve_response:
+                        aria2_download_url = resolve_response.geturl()
+                        total_size = int(
+                            resolve_response.headers.get("Content-Length", 0)
+                        )
+
+                    with self._lock:
+                        status.total_size = total_size
+
+                    print(
+                        "[CivitAI Download] Resolved authenticated download "
+                        "to CDN URL"
+                    )
+
+                except Exception as e:
+                    print(
+                        f"[CivitAI Download] Could not resolve CDN URL: {e}"
+                    )
+
+                save_directory = str(Path(save_path).parent)
+                save_filename = Path(save_path).name
+
+                # Give this aria2 process its own temporary local RPC port.
+                with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+                    sock.bind(("127.0.0.1", 0))
+                    rpc_port = sock.getsockname()[1]
+
+                rpc_secret = uuid.uuid4().hex
+                rpc_url = f"http://127.0.0.1:{rpc_port}/jsonrpc"
+
+                command = [
+                    aria2_path,
+                    "--continue=true",
+                    "--max-connection-per-server=16",
+                    "--split=16",
+                    "--min-split-size=4M",
+                    "--file-allocation=none",
+                    "--allow-overwrite=true",
+                    "--auto-file-renaming=false",
+                    "--console-log-level=warn",
+                    "--summary-interval=0",
+                    "--user-agent=ComfyUI-DonutNodes/1.0",
+                    "--enable-rpc=true",
+                    "--rpc-listen-all=false",
+                    f"--rpc-listen-port={rpc_port}",
+                    f"--rpc-secret={rpc_secret}",
+                    "--dir", save_directory,
+                    "--out", save_filename,
+                    aria2_download_url
+                ]
+
+                process = subprocess.Popen(
+                    command,
+                    stdout=subprocess.DEVNULL,
+                    stderr=subprocess.DEVNULL
+                )
+
+                with self._lock:
+                    self._aria2_processes[download_id] = process
+
+                def aria2_rpc(method, params=None):
+                    rpc_params = [f"token:{rpc_secret}"]
+
+                    if params:
+                        rpc_params.extend(params)
+
+                    payload = {
+                        "jsonrpc": "2.0",
+                        "id": download_id,
+                        "method": method,
+                        "params": rpc_params
+                    }
+
+                    rpc_request = urllib.request.Request(
+                        rpc_url,
+                        data=json.dumps(payload).encode("utf-8"),
+                        headers={"Content-Type": "application/json"}
+                    )
+
+                    with urllib.request.urlopen(
+                        rpc_request,
+                        timeout=2
+                    ) as rpc_response:
+                        rpc_data = json.loads(
+                            rpc_response.read().decode("utf-8")
+                        )
+
+                    return rpc_data.get("result")
+
+                stat_keys = [
+                    "completedLength",
+                    "totalLength",
+                    "downloadSpeed",
+                    "status",
+                    "errorCode",
+                    "errorMessage"
+                ]
+
+                aria2_finished = False
+
+                while process.poll() is None:
+                    with self._lock:
+                        was_cancelled = status.status == "cancelled"
+
+                    if was_cancelled:
+                        try:
+                            aria2_rpc("aria2.forceShutdown")
+                        except Exception:
+                            process.terminate()
+
+                        try:
+                            process.wait(timeout=5)
+                        except subprocess.TimeoutExpired:
+                            process.kill()
+
+                        if os.path.exists(save_path):
+                            os.remove(save_path)
+
+                        aria2_control_file = save_path + ".aria2"
+                        if os.path.exists(aria2_control_file):
+                            os.remove(aria2_control_file)
+
+                        with self._lock:
+                            self._aria2_processes.pop(download_id, None)
+
+                        return
+
+                    aria2_status = None
+
+                    try:
+                        active = aria2_rpc(
+                            "aria2.tellActive",
+                            [stat_keys]
+                        )
+
+                        if active:
+                            aria2_status = active[0]
+                        else:
+                            waiting = aria2_rpc(
+                                "aria2.tellWaiting",
+                                [0, 1, stat_keys]
+                            )
+
+                            if waiting:
+                                aria2_status = waiting[0]
+                            else:
+                                # Completed/error downloads move out of the active
+                                # list. This dedicated aria2 instance has only one
+                                # download, so the newest stopped result is ours.
+                                stopped = aria2_rpc(
+                                    "aria2.tellStopped",
+                                    [-1, 1, stat_keys]
+                                )
+
+                                if stopped:
+                                    aria2_status = stopped[0]
+
+                    except Exception:
+                        # RPC may need a moment to start.
+                        aria2_status = None
+
+                    if aria2_status:
+                        aria2_state = aria2_status.get("status", "")
+                        completed_length = int(
+                            aria2_status.get("completedLength", 0)
+                        )
+                        total_length = int(
+                            aria2_status.get("totalLength", 0)
+                        )
+                        download_speed = float(
+                            aria2_status.get("downloadSpeed", 0)
+                        )
+
+                        with self._lock:
+                            status.downloaded_size = completed_length
+                            status.speed_bps = download_speed
+
+                            if total_length > 0:
+                                status.total_size = total_length
+
+                        if on_progress:
+                            on_progress(status)
+
+                        if aria2_state == "complete":
+                            aria2_finished = True
+
+                            try:
+                                aria2_rpc("aria2.shutdown")
+                            except Exception:
+                                process.terminate()
+
+                            break
+
+                        if aria2_state in ("error", "removed"):
+                            error_code = aria2_status.get("errorCode", "")
+                            error_message = aria2_status.get(
+                                "errorMessage",
+                                "Unknown aria2 download error"
+                            )
+                            raise RuntimeError(
+                                f"aria2 download failed ({error_code}): "
+                                f"{error_message}"
+                            )
+
+                    time.sleep(0.5)
+
+                if aria2_finished and process.poll() is None:
+                    try:
+                        process.wait(timeout=5)
+                    except subprocess.TimeoutExpired:
+                        process.kill()
+                        process.wait(timeout=5)
+
+                return_code = process.returncode
+
+                with self._lock:
+                    self._aria2_processes.pop(download_id, None)
+
+                if return_code != 0:
+                    raise RuntimeError(
+                        f"aria2c exited with error code {return_code}"
+                    )
+
+                final_size = (
+                    os.path.getsize(save_path)
+                    if os.path.exists(save_path)
+                    else 0
+                )
+
+                with self._lock:
+                    status.downloaded_size = final_size
+                    status.total_size = final_size
+                    status.speed_bps = 0.0
+                    status.status = "completed"
+                    status.completed_at = datetime.now().isoformat()
+
+                if on_progress:
+                    on_progress(status)
+
+                # Save the SHA256 hash cache when provided
+                if sha256:
+                    self._save_hash_file(save_path, sha256)
+
+                # Make the downloaded model visible in ComfyUI
+                folder_name = MODEL_TYPE_TO_FOLDER.get(
+                    model_type,
+                    "loras"
+                )
+                invalidate_folder_cache(folder_name)
+
+                return
+            
             # Open connection
             with civitai_urlopen(request, timeout=30) as response:
                 total_size = int(response.headers.get('Content-Length', 0))
@@ -350,22 +652,43 @@ class CivitAIDownloader:
                             on_progress(status)
 
                 # Check final status
+                cancelled = False
+
                 with self._lock:
                     if status.status == "cancelled":
-                        # Clean up partial file
-                        if os.path.exists(save_path):
-                            os.remove(save_path)
+                        cancelled = True
                     else:
+                        final_size = (
+                            os.path.getsize(save_path)
+                            if os.path.exists(save_path)
+                            else downloaded
+                        )
+
+                        status.downloaded_size = final_size
+                        status.total_size = final_size
+                        status.speed_bps = 0.0
                         status.status = "completed"
                         status.completed_at = datetime.now().isoformat()
 
-                        # Save the SHA256 hash to a .hash file if provided
-                        if sha256:
-                            self._save_hash_file(save_path, sha256)
+                if cancelled:
+                    # Clean up partial file
+                    if os.path.exists(save_path):
+                        os.remove(save_path)
+                else:
+                    # Force one final completed/100% update to the UI
+                    if on_progress:
+                        on_progress(status)
 
-                        # Invalidate folder cache so the new file is visible in dropdowns
-                        folder_name = MODEL_TYPE_TO_FOLDER.get(model_type, "loras")
-                        invalidate_folder_cache(folder_name)
+                    # Save the SHA256 hash to a .hash file if provided
+                    if sha256:
+                        self._save_hash_file(save_path, sha256)
+
+                    # Invalidate folder cache so the new file is visible
+                    folder_name = MODEL_TYPE_TO_FOLDER.get(
+                        model_type,
+                        "loras"
+                    )
+                    invalidate_folder_cache(folder_name)
 
         except urllib.error.HTTPError as e:
             error_msg = f"HTTP {e.code}: {e.reason}"

--- a/shared/server_routes.py
+++ b/shared/server_routes.py
@@ -35,7 +35,7 @@ except ImportError:
 
 # Import download manager
 try:
-    from .civitai_download import get_downloader, get_download_path, normalize_base_model, invalidate_folder_cache, MODEL_TYPE_TO_FOLDER
+    from .civitai_download import get_downloader, get_download_path, get_model_folder, normalize_base_model, invalidate_folder_cache, MODEL_TYPE_TO_FOLDER
     HAS_DOWNLOADER = True
 except ImportError:
     HAS_DOWNLOADER = False
@@ -612,6 +612,56 @@ def register_routes():
             traceback.print_exc()
             return web.json_response({"error": str(e)}, status=500)
 
+    @routes.get('/donut/civitai/download/folders')
+    async def civitai_download_folders(request):
+        """List valid download folders for a CivitAI model type."""
+        if not HAS_DOWNLOADER:
+            return web.json_response(
+                {"error": "Download module not available"},
+                status=500
+            )
+
+        try:
+            model_type = request.query.get("modelType", "LORA")
+            base_model = request.query.get("baseModel", "")
+            base_dir = os.path.abspath(get_model_folder(model_type))
+            root_name = os.path.basename(base_dir.rstrip(os.sep))
+
+            folders = {""}
+            if os.path.isdir(base_dir):
+                for root, dirs, _files in os.walk(base_dir):
+                    for directory in dirs:
+                        full_path = os.path.join(root, directory)
+                        relative_path = os.path.relpath(full_path, base_dir)
+                        folders.add(relative_path.replace(os.sep, "/"))
+
+            default_folder = ""
+            if model_type in ("LORA", "LoCon", "DoRA"):
+                default_folder = normalize_base_model(base_model)
+                if default_folder:
+                    folders.add(default_folder)
+
+            ordered_folders = sorted(
+                folders,
+                key=lambda value: (value != "", value.lower())
+            )
+
+            return web.json_response({
+                "rootName": root_name,
+                "defaultFolder": default_folder,
+                "folders": [
+                    {
+                        "value": value,
+                        "label": root_name if not value
+                        else f"{root_name}/{value}"
+                    }
+                    for value in ordered_folders
+                ]
+            })
+
+        except Exception as e:
+            return web.json_response({"error": str(e)}, status=500)
+
     @routes.post('/donut/civitai/download')
     async def civitai_download(request):
         """Start a model download."""
@@ -626,6 +676,7 @@ def register_routes():
             filename = data.get("filename", "model.safetensors")
             sha256 = data.get("sha256")  # Pre-known hash from CivitAI
             skip_duplicate_check = data.get("skipDuplicateCheck", False)
+            selected_folder = data.get("selectedFolder", None)
 
             if not download_url:
                 return web.json_response({"error": "No download URL provided"}, status=400)
@@ -643,7 +694,12 @@ def register_routes():
                     }, status=409)  # 409 Conflict
 
             # Get download path based on model type and base model
-            save_path = get_download_path(model_type, base_model, filename)
+            save_path = get_download_path(
+                model_type,
+                base_model,
+                filename,
+                selected_folder=selected_folder
+            )
 
             # Get API key for authenticated downloads
             config = load_config(force_reload=True)  # Force reload to get latest API key

--- a/web/donut_civitai_browser.js
+++ b/web/donut_civitai_browser.js
@@ -914,11 +914,11 @@ class DonutCivitaiBrowser {
         this.updateLoadingState();
     }
 
-    async startDownload(modelVersion, loadToSlot = null, buttonElement = null) {
+    async startDownload(modelVersion, loadToSlot = null, buttonElement = null, selectedFile = null) {
         const model = this.currentModel;
         if (!model || !modelVersion) return;
 
-        const file = modelVersion.files?.[0];
+        const file = selectedFile || modelVersion.files?.[0];
         if (!file) {
             alert("No downloadable file found");
             return;
@@ -954,6 +954,9 @@ class DonutCivitaiBrowser {
             if (textSpan) textSpan.style.cssText = "position: relative; z-index: 1;";
         }
 
+        const folderSelect = document.getElementById("donut-civitai-folder");
+        const selectedFolder = folderSelect ? folderSelect.value : null;
+
         try {
             const response = await api.fetchApi("/donut/civitai/download", {
                 method: "POST",
@@ -963,6 +966,7 @@ class DonutCivitaiBrowser {
                     modelType: model.type,
                     baseModel: modelVersion.baseModel,
                     filename: file.name,
+                    selectedFolder: selectedFolder,
                     sha256: file.hashes?.SHA256  // Pass hash to save after download
                 })
             });
@@ -1129,7 +1133,7 @@ class DonutCivitaiBrowser {
                 "LORA": "loras",
                 "LoCon": "loras",
                 "DoRA": "loras",
-                "Checkpoint": "checkpoints",
+                "Checkpoint": "diffusion_models",
                 "TextualInversion": "embeddings",
                 "Controlnet": "controlnet",
                 "Upscaler": "upscale_models",
@@ -3005,6 +3009,74 @@ class DonutCivitaiBrowser {
         await this.startQuickDownload(downloadUrl, filename, modelType, baseModel, modelName, slot, sha256);
     }
 
+    populateFileDropdown(modelVersion) {
+        const fileSelect = document.getElementById("donut-civitai-file");
+        const savePath = document.getElementById("donut-civitai-save-path");
+
+        if (!fileSelect || !modelVersion) return;
+
+        fileSelect.innerHTML = "";
+
+        const files = modelVersion.files || [];
+
+        if (files.length === 0) {
+            const option = document.createElement("option");
+            option.value = "0";
+            option.textContent = "No files found";
+            fileSelect.appendChild(option);
+            fileSelect.disabled = true;
+            return;
+        }
+
+        fileSelect.disabled = false;
+
+        files.forEach((file, index) => {
+            const option = document.createElement("option");
+            option.value = index.toString();
+
+            const size = file.sizeKB
+                ? ` - ${(file.sizeKB / 1024 / 1024).toFixed(2)} GB`
+                : "";
+
+            const format = file.metadata?.format
+                ? ` - ${file.metadata.format}`
+                : "";
+
+            const fp = file.metadata?.fp
+                ? ` - ${file.metadata.fp}`
+                : "";
+
+            const type = file.type
+                ? ` - ${file.type}`
+                : "";
+
+            option.textContent =
+                `${file.name}${fp || format || type}${size}`;
+
+            fileSelect.appendChild(option);
+        });
+
+        if (savePath && files[0]) {
+            this.updateDownloadPathPreview(modelVersion);
+        }
+
+        fileSelect.onchange = () => {
+            this.updateDownloadPathPreview(modelVersion);
+        };
+    }
+
+    getSelectedCivitaiFile(modelVersion) {
+        const fileSelect =
+            document.getElementById("donut-civitai-file");
+
+        const fileIndex = fileSelect
+            ? parseInt(fileSelect.value)
+            : 0;
+
+        return modelVersion?.files?.[fileIndex]
+            || modelVersion?.files?.[0];
+    }
+    
     renderDetailView() {
         const content = this.dialog?.querySelector("#donut-civitai-content");
         if (!content || !this.currentModel) return;
@@ -3291,12 +3363,45 @@ class DonutCivitaiBrowser {
                 versionSelect.appendChild(opt);
             }
 
+            versionSelect.onchange = () => {
+                const selectedVersion =
+                    model.modelVersions[parseInt(versionSelect.value)];
+
+                this.populateFileDropdown(selectedVersion);
+                this.populateFolderDropdown(selectedVersion);
+            };
+            
             versionSection.appendChild(versionSelect);
             rightSide.appendChild(versionSection);
-        }
+                      
+            }
+            // File selector
+            const fileSection = document.createElement("div");
+            fileSection.style.cssText = "margin-bottom: 20px;";
 
+            const fileLabel = document.createElement("div");
+            fileLabel.textContent = "File";
+            fileLabel.style.cssText = "font-size: 12px; font-weight: 600; color: #888; text-transform: uppercase; margin-bottom: 8px;";
+            fileSection.appendChild(fileLabel);
+
+            const fileSelect = document.createElement("select");
+            fileSelect.id = "donut-civitai-file";
+            fileSelect.style.cssText = `
+                width: 100%;
+                padding: 10px;
+                background: #0d0d1a;
+                border: 1px solid #333;
+                border-radius: 6px;
+                color: #eee;
+                font-size: 14px;
+                cursor: pointer;
+            `;
+
+            fileSection.appendChild(fileSelect);
+            rightSide.appendChild(fileSection);
+            
         // File info & Download
-        const file = version?.files?.[0];
+        const file = this.getSelectedCivitaiFile(version);
         if (file) {
             const downloadSection = document.createElement("div");
             downloadSection.style.cssText = `
@@ -3356,7 +3461,7 @@ class DonutCivitaiBrowser {
                         const versionSelect = document.getElementById("donut-civitai-version");
                         const versionIndex = versionSelect ? parseInt(versionSelect.value) : 0;
                         const selectedVersion = model.modelVersions[versionIndex];
-                        const selectedFile = selectedVersion?.files?.[0];
+                        const selectedFile = this.getSelectedCivitaiFile(selectedVersion);
                         const selectedSha256 = selectedFile?.hashes?.SHA256;
 
                         if (this.isModelDownloaded(selectedVersion) && selectedSha256) {
@@ -3368,7 +3473,7 @@ class DonutCivitaiBrowser {
                                 baseModel: selectedVersion.baseModel
                             });
                         } else {
-                            this.startDownload(selectedVersion, slot, slotBtn);
+                            this.startDownload(selectedVersion, slot, slotBtn, selectedFile);
                         }
                     };
                     slotBtnContainer.appendChild(slotBtn);
@@ -3399,7 +3504,8 @@ class DonutCivitaiBrowser {
                         const versionSelect = document.getElementById("donut-civitai-version");
                         const versionIndex = versionSelect ? parseInt(versionSelect.value) : 0;
                         const selectedVersion = model.modelVersions[versionIndex];
-                        const selectedSha256 = selectedVersion?.files?.[0]?.hashes?.SHA256;
+                        const selectedSha256 =
+                            this.getSelectedCivitaiFile(selectedVersion)?.hashes?.SHA256;
                         if (selectedSha256) {
                             this.deleteLora(selectedSha256, model.name);
                         }
@@ -3440,6 +3546,35 @@ class DonutCivitaiBrowser {
                 downloadSection.appendChild(apiWarning);
             }
 
+            // Download folder selector
+            const folderSection = document.createElement("div");
+            folderSection.style.cssText = "margin-bottom: 12px;";
+
+            const folderLabel = document.createElement("div");
+            folderLabel.textContent = "Folder";
+            folderLabel.style.cssText = "font-size: 12px; font-weight: 600; color: #888; text-transform: uppercase; margin-bottom: 8px;";
+            folderSection.appendChild(folderLabel);
+
+            const folderSelect = document.createElement("select");
+            folderSelect.id = "donut-civitai-folder";
+            folderSelect.style.cssText = `
+                width: 100%;
+                padding: 10px;
+                background: #0d0d1a;
+                border: 1px solid #333;
+                border-radius: 6px;
+                color: #eee;
+                font-size: 13px;
+                cursor: pointer;
+            `;
+
+            const loadingFolderOption = document.createElement("option");
+            loadingFolderOption.value = "";
+            loadingFolderOption.textContent = "Loading folders...";
+            folderSelect.appendChild(loadingFolderOption);
+            folderSection.appendChild(folderSelect);
+            downloadSection.appendChild(folderSection);
+
             const downloadBtn = document.createElement("button");
             downloadBtn.innerHTML = "&#8595; Download Only";
             downloadBtn.style.cssText = `
@@ -3460,13 +3595,16 @@ class DonutCivitaiBrowser {
                 const versionSelect = document.getElementById("donut-civitai-version");
                 const versionIndex = versionSelect ? parseInt(versionSelect.value) : 0;
                 const selectedVersion = model.modelVersions[versionIndex];
-                this.startDownload(selectedVersion, null, downloadBtn);
+                const selectedFile = this.getSelectedCivitaiFile(selectedVersion);
+                
+                this.startDownload(selectedVersion, null, downloadBtn, selectedFile);
             };
 
             downloadSection.appendChild(downloadBtn);
 
             // Show where it will be saved
             const savePath = document.createElement("div");
+            savePath.id = "donut-civitai-save-path";
             savePath.style.cssText = "font-size: 11px; color: #666; margin-top: 10px; word-break: break-all;";
             savePath.textContent = `Will save to: ${this.getExpectedPath(model.type, version?.baseModel, file.name)}`;
             downloadSection.appendChild(savePath);
@@ -3484,6 +3622,83 @@ class DonutCivitaiBrowser {
 
         container.appendChild(rightSide);
         content.appendChild(container);
+
+        this.populateFileDropdown(version);
+        this.populateFolderDropdown(version);
+    }
+
+    async populateFolderDropdown(modelVersion) {
+        const folderSelect = document.getElementById("donut-civitai-folder");
+        if (!folderSelect || !modelVersion || !this.currentModel) return;
+
+        const params = new URLSearchParams({
+            modelType: this.currentModel.type,
+            baseModel: modelVersion.baseModel || ""
+        });
+
+        folderSelect.disabled = true;
+
+        try {
+            const response = await api.fetchApi(
+                `/donut/civitai/download/folders?${params}`
+            );
+
+            if (!response.ok) {
+                throw new Error(await response.text());
+            }
+
+            const data = await response.json();
+            folderSelect.innerHTML = "";
+            folderSelect.dataset.rootName = data.rootName || "models";
+
+            for (const folder of data.folders || []) {
+                const option = document.createElement("option");
+                option.value = folder.value;
+                option.textContent = folder.label;
+                if (folder.value === (data.defaultFolder || "")) {
+                    option.selected = true;
+                }
+                folderSelect.appendChild(option);
+            }
+
+            folderSelect.disabled = false;
+            folderSelect.onchange = () => {
+                this.updateDownloadPathPreview(modelVersion);
+            };
+            this.updateDownloadPathPreview(modelVersion);
+
+        } catch (error) {
+            console.error("[CivitAI Browser] Could not load folders:", error);
+            folderSelect.innerHTML = "";
+
+            const option = document.createElement("option");
+            option.value = "";
+            option.textContent = "Default folder";
+            folderSelect.appendChild(option);
+            folderSelect.disabled = true;
+            this.updateDownloadPathPreview(modelVersion);
+        }
+    }
+
+    updateDownloadPathPreview(modelVersion) {
+        const savePath = document.getElementById("donut-civitai-save-path");
+        const folderSelect = document.getElementById("donut-civitai-folder");
+        const selectedFile = this.getSelectedCivitaiFile(modelVersion);
+
+        if (!savePath || !selectedFile) return;
+
+        if (folderSelect && folderSelect.dataset.rootName) {
+            const selectedFolder = folderSelect.value;
+            const folderPart = selectedFolder ? `/${selectedFolder}` : "";
+            savePath.textContent =
+                `Will save to: models/${folderSelect.dataset.rootName}${folderPart}/${selectedFile.name}`;
+        } else {
+            savePath.textContent = `Will save to: ${this.getExpectedPath(
+                this.currentModel.type,
+                modelVersion.baseModel,
+                selectedFile.name
+            )}`;
+        }
     }
 
     getExpectedPath(modelType, baseModel, filename) {
@@ -3492,7 +3707,7 @@ class DonutCivitaiBrowser {
             "LORA": "loras",
             "LoCon": "loras",
             "DoRA": "loras",
-            "Checkpoint": "checkpoints",
+            "Checkpoint": "diffusion_models",
             "TextualInversion": "embeddings",
             "Controlnet": "controlnet",
             "Upscaler": "upscale_models",


### PR DESCRIPTION
## Summary

This pull request improves the CivitAI browser and download workflow, especially for model versions that contain multiple files and for users running ComfyUI in environments such as RunPod.

## Changes

- Added a file-selection dropdown beneath the version selector.
- Model versions containing multiple files, such as BF16, FP8, INT8, and other variants, can now be selected individually.
- Added a download-folder selector that begins at the model category’s parent folder and displays its available subfolders.
- The selected download location is shown and updated live beneath the download button.
- Changed the default checkpoint download location to `diffusion_models`, which works better with newer ComfyUI layouts and RunPod environments where the traditional `checkpoints` directory may not be accessible.
- Added aria2 download support for significantly faster downloads.
- Fixed aria2 progress reporting so the progress bar, percentage, and download speed accurately reflect the full download instead of jumping ahead near completion.

## Files changed

- `web/donut_civitai_browser.js`
- `shared/civitai_download.py`
- `shared/server_routes.py`