### PR TITLE
Add fusion-aware Safe LoRA Stack

### DIFF
--- a/DonutKrea2FusionControl.py
+++ b/DonutKrea2FusionControl.py
@@ -20,6 +20,7 @@ import comfy.patcher_extension
 
 WRAPPER_KEY = "donut_krea2_fusion_control"
 CONFIG_KEY = "donut_krea2_fusion_control"
+FUSION_BUDGET_KEY = "donut_krea2_fusion_budget"
 
 KREA2_TAP_COUNT = 12
 KREA2_TAP_DIM = 2560
@@ -410,6 +411,20 @@ def _attach_runtime_wrapper(model, config):
     return patched
 
 
+def _attach_fusion_budget(model, original_model, metadata):
+    """Publish resolved fusion gains for downstream fusion-aware LoRA safety.
+
+    The metadata is deliberately separate from the runtime-wrapper config.  Tap
+    gains may be active even when no model wrapper is required, and downstream
+    nodes must not have to infer safety information from wrapper internals.
+    """
+    if model is original_model:
+        model = model.clone()
+    transformer_options = model.model_options.setdefault("transformer_options", {})
+    transformer_options[FUSION_BUDGET_KEY] = metadata
+    return model
+
+
 def _apply_projector_diff(model, values, strength):
     if float(strength) == 0.0:
         return model
@@ -522,6 +537,7 @@ class DonutKrea2FusionControl:
         )
         output_model = model
         runtime_config = {}
+        tap_gains = _PROFILE_OFF
 
         if tap_method == TAP_METHOD_DONUT:
             tap_gains = _resolve_gains(
@@ -545,9 +561,11 @@ class DonutKrea2FusionControl:
             if not math.isfinite(multiplier):
                 raise ValueError("Tap strength must be finite")
             if tap_profile == "off":
+                tap_gains = _PROFILE_OFF
                 output_conditionings = conditioning_inputs
                 tap_details = f"tap[{tap_method}; off]"
             else:
+                tap_gains = tuple(multiplier * value for value in tap_profile_values)
                 output_conditionings = tuple(
                     None if conditioning is None else _nova452_rebalance_structure(
                         conditioning,
@@ -563,6 +581,7 @@ class DonutKrea2FusionControl:
         else:
             raise ValueError(f"Unknown tap method: {tap_method}")
 
+        projector_gains = _PROFILE_OFF
         if projector_method == PROJECTOR_METHOD_DONUT:
             projector_gains = _resolve_gains(
                 projector_profile,
@@ -604,6 +623,32 @@ class DonutKrea2FusionControl:
 
         if runtime_config:
             output_model = _attach_runtime_wrapper(output_model, runtime_config)
+
+        fusion_budget_active = (
+            not _is_neutral(tap_gains)
+            or not _is_neutral(projector_gains)
+            or (
+                projector_method in (PROJECTOR_METHOD_BYPASS_2, PROJECTOR_METHOD_BYPASS_3)
+                and float(projector_strength) != 0.0
+            )
+            or (fusion_method == FUSION_METHOD_ENHANCER and fusion_strength != 0.0)
+        )
+        if fusion_budget_active:
+            output_model = _attach_fusion_budget(
+                output_model,
+                model,
+                {
+                    "version": 1,
+                    "tap_method": tap_method,
+                    "tap_gains": tuple(float(value) for value in tap_gains),
+                    "tap_normalization": tap_normalization,
+                    "projector_method": projector_method,
+                    "projector_gains": tuple(float(value) for value in projector_gains),
+                    "projector_normalization": projector_normalization,
+                    "fusion_method": fusion_method,
+                    "fusion_strength": float(fusion_strength),
+                },
+            )
 
         diagnostics = (
             f"preset_label={compatibility_preset}; preset_is_ui_only=true\n"

--- a/DonutSafeApplyLoRAStack.py
+++ b/DonutSafeApplyLoRAStack.py
@@ -1,8 +1,9 @@
 """Safe Krea2 LoRA stack application.
 
 Overrides DonutApplyLoRAStack with an opt-in per-block RMS energy limiter for
-Krea2 LoRAs. Safe mode is deliberately conservative and off by default so old
-workflows retain their exact behaviour.
+Krea2 LoRAs and optional fusion-aware budgeting for the 12-column text-fusion
+projector. Safety remains off by default so old workflows retain their exact
+behaviour.
 """
 
 import math
@@ -11,6 +12,7 @@ import re
 import comfy.sd
 import comfy.utils
 import folder_paths
+import torch
 
 from .donut_lora_nodes import (
     _TEXT_MERGE_VECTOR,
@@ -24,6 +26,11 @@ _KREA_BLOCK_RE = re.compile(r"(?<![a-z_])blocks\.(\d+)")
 _KREA_BLOCK_COUNT = 28
 _KREA_VECTOR_SIZE = _KREA_BLOCK_COUNT + 1  # non-block bucket + 28 blocks
 _SAFE_ENERGY_BUDGET = 1.0
+_FUSION_BUDGET_KEY = "donut_krea2_fusion_budget"
+_FUSION_AWARE_MODES = ("Off", "Attenuate only", "Use headroom")
+_KREA_TEXT_RE = re.compile(r"txt(?:fusion|mlp)|text_(?:fusion|mlp)")
+_PROJECTOR_RE = re.compile(r"(?:txtfusion|text_fusion).*projector")
+_PROJECTOR_COLUMN_COUNT = 12
 
 
 def _krea2_block_indices(lora):
@@ -40,6 +47,130 @@ def _is_krea2_lora(lora):
     """Return True when a LoRA contains Krea2-style single-stream blocks."""
     block_nums = _krea2_block_indices(lora)
     return bool(block_nums) and max(block_nums) < _KREA_BLOCK_COUNT
+
+
+def _is_krea2_text_lora(lora):
+    """Return True for Krea2's diffusion-side text-fusion adapter weights."""
+    return any(_KREA_TEXT_RE.search(key.lower()) for key in lora)
+
+
+def _split_projector_text(lora_text):
+    """Separate the 12-column projector adapter from other text-fusion keys."""
+    projector, other = {}, {}
+    for key, value in lora_text.items():
+        (projector if _PROJECTOR_RE.search(key.lower()) else other)[key] = value
+    return projector, other
+
+
+def _read_fusion_budget(model):
+    """Read Fusion Control metadata without depending on its implementation."""
+    model_options = getattr(model, "model_options", None)
+    if not isinstance(model_options, dict):
+        return None
+    transformer_options = model_options.get("transformer_options")
+    if not isinstance(transformer_options, dict):
+        return None
+    metadata = transformer_options.get(_FUSION_BUDGET_KEY)
+    if not isinstance(metadata, dict) or int(metadata.get("version", 0)) != 1:
+        return None
+    gains = metadata.get("projector_gains")
+    if not isinstance(gains, (list, tuple)) or len(gains) != _PROJECTOR_COLUMN_COUNT:
+        return None
+    try:
+        gains = tuple(float(value) for value in gains)
+    except (TypeError, ValueError):
+        return None
+    if not all(math.isfinite(value) for value in gains):
+        return None
+    output = dict(metadata)
+    output["projector_gains"] = gains
+    return output
+
+
+def _nominal_projector_gains(metadata):
+    """Resolve static gains used for scalar-energy accounting.
+
+    tensor_rms adds a prompt-dependent common multiplier at runtime.  Dividing
+    by the profile RMS gives a neutral-energy nominal profile for attenuation,
+    but its unknown runtime multiplier makes automatic headroom boosts unsafe.
+    """
+    gains = tuple(float(value) for value in metadata["projector_gains"])
+    dynamic = metadata.get("projector_normalization") == "tensor_rms"
+    if dynamic:
+        rms = math.sqrt(sum(value * value for value in gains) / len(gains))
+        if rms > 1e-12:
+            gains = tuple(value / rms for value in gains)
+    return gains, dynamic
+
+
+def _projector_column_scales(
+    entries,
+    gains,
+    mode,
+    max_boost,
+    dynamic=False,
+    budget=_SAFE_ENERGY_BUDGET,
+):
+    """Budget projector LoRA scalar energy after Fusion Control's 12 gains."""
+    participants = [
+        idx for idx, entry in enumerate(entries)
+        if entry["is_krea_text"] and entry["projector_text"] and float(entry["cw"]) != 0.0
+    ]
+    if not participants:
+        return (1.0,) * _PROJECTOR_COLUMN_COUNT, None
+
+    energy = math.sqrt(sum(float(entries[idx]["cw"]) ** 2 for idx in participants))
+    allow_boost = mode == "Use headroom" and not dynamic
+    max_boost = max(1.0, float(max_boost))
+    scales = []
+    for gain in gains:
+        effective_energy = abs(float(gain)) * energy
+        if effective_energy <= 1e-12:
+            scale = max_boost if allow_boost else 1.0
+        else:
+            scale = budget / effective_energy
+            scale = min(max_boost if allow_boost else 1.0, scale)
+        scales.append(scale)
+
+    return tuple(scales), {
+        "raw_energy": energy,
+        "dynamic": dynamic,
+        "boosted": any(scale > 1.0 + 1e-12 for scale in scales),
+        "limited": any(scale < 1.0 - 1e-12 for scale in scales),
+    }
+
+
+def _scale_projector_lora_columns(lora, scales):
+    """Scale projector LoRA delta columns without scaling the base projector.
+
+    Standard LoRA/PEFT adapters are adjusted on their input/down matrix. Direct
+    ``.diff`` projector patches are adjusted directly. Unsupported adapter
+    families are returned unchanged so the caller can use a conservative
+    uniform strength fallback.
+    """
+    if len(scales) != _PROJECTOR_COLUMN_COUNT:
+        raise ValueError(f"Expected {_PROJECTOR_COLUMN_COUNT} projector scales")
+
+    adjusted = dict(lora)
+    transformed = False
+    for key, value in lora.items():
+        if not torch.is_tensor(value) or not value.is_floating_point() or value.ndim < 2:
+            continue
+        lower = key.lower()
+        if not _PROJECTOR_RE.search(lower) or value.shape[-1] != _PROJECTOR_COLUMN_COUNT:
+            continue
+
+        is_down = lower.endswith("lora_down.weight") or lower.endswith("lora_a.weight")
+        is_diff = lower.endswith(".diff")
+        is_direct_weight = lower.endswith("projector.weight") and value.shape[-2] == 1
+        if not (is_down or is_diff or is_direct_weight):
+            continue
+
+        scale = torch.tensor(scales, device=value.device, dtype=value.dtype)
+        adjusted[key] = value * scale.reshape(*([1] * (value.ndim - 1)), -1)
+        transformed = True
+
+    return adjusted, transformed
 
 
 def _parse_numeric_vector(vector, required_size=1):
@@ -160,11 +291,16 @@ def _normalise_krea_vectors(entries, budget=_SAFE_ENERGY_BUDGET):
     return adjusted, limited_blocks
 
 
-def _normalise_fused_text_weights(entries, budget=_SAFE_ENERGY_BUDGET):
-    """RMS-limit Krea2 fused-text weights as one shared non-block bucket."""
+def _normalise_fused_text_weights(entries, component=None, budget=_SAFE_ENERGY_BUDGET):
+    """RMS-limit a Krea2 fused-text component as one shared scalar bucket."""
     participants = [
         idx for idx, entry in enumerate(entries)
-        if entry["is_krea"] and entry["fused_text"] and float(entry["cw"]) != 0.0
+        if (
+            entry["is_krea_text"]
+            and entry["fused_text"]
+            and (component is None or bool(entry[component]))
+            and float(entry["cw"]) != 0.0
+        )
     ]
     if not participants:
         return [float(entry["cw"]) for entry in entries], None
@@ -200,6 +336,22 @@ class DonutApplyLoRAStackSafe:
                         "LoRA worth of block energy. Off preserves legacy behaviour."
                     ),
                 }),
+                "fusion_aware": (list(_FUSION_AWARE_MODES), {
+                    "default": "Off",
+                    "tooltip": (
+                        "Requires the model output from Donut Krea2 Fusion Control. "
+                        "Budgets projector LoRA columns against the resolved 12-channel "
+                        "projector gains. Use headroom can boost quiet columns; dynamic "
+                        "tensor_rms profiles are attenuation-only."
+                    ),
+                }),
+                "max_fusion_boost": ("FLOAT", {
+                    "default": 2.0,
+                    "min": 1.0,
+                    "max": 10.0,
+                    "step": 0.05,
+                    "tooltip": "Maximum per-column LoRA boost in Use headroom mode.",
+                }),
             }
         }
 
@@ -208,7 +360,15 @@ class DonutApplyLoRAStackSafe:
     FUNCTION = "apply_stack"
     CATEGORY = "Comfyanonymous/LoRA"
 
-    def apply_stack(self, model, clip, lora_stack=None, safe_stack="Off"):
+    def apply_stack(
+        self,
+        model,
+        clip,
+        lora_stack=None,
+        safe_stack="Off",
+        fusion_aware="Off",
+        max_fusion_boost=2.0,
+    ):
         help_url = (
             "https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes/"
             "wiki/LoRA-Nodes#cr-apply-lora-stack"
@@ -216,6 +376,11 @@ class DonutApplyLoRAStackSafe:
 
         if lora_stack is None or len(lora_stack) == 0:
             return (model, clip, help_url)
+        if fusion_aware not in _FUSION_AWARE_MODES:
+            raise ValueError(f"Unknown fusion-aware safety mode: {fusion_aware}")
+        max_fusion_boost = float(max_fusion_boost)
+        if not math.isfinite(max_fusion_boost) or max_fusion_boost < 1.0:
+            raise ValueError("max_fusion_boost must be finite and at least 1.0")
 
         # Preserve DonutApplyLoRAStack's duplicate semantics before doing any
         # safety calculation, otherwise duplicate entries would consume budget
@@ -258,6 +423,7 @@ class DonutApplyLoRAStackSafe:
             has_real_te = _lora_has_real_text_encoder(lora)
             lora_main, lora_text = _split_fused_text(lora)
             fused_text = bool(lora_text) and not has_real_te
+            projector_text, other_text = _split_projector_text(lora_text)
 
             entries.append({
                 "name": name,
@@ -267,17 +433,30 @@ class DonutApplyLoRAStackSafe:
                 "lora": lora,
                 "lora_main": lora_main,
                 "lora_text": lora_text,
+                "projector_text": projector_text,
+                "other_text": other_text,
+                "has_projector_text": bool(projector_text),
+                "has_other_text": bool(other_text),
                 "fused_text": fused_text,
                 "is_krea": bool(krea_blocks) and max(krea_blocks) < _KREA_BLOCK_COUNT,
+                "is_krea_text": _is_krea2_text_lora(lora),
                 "krea_blocks": krea_blocks,
             })
 
+        fusion_metadata = _read_fusion_budget(model) if fusion_aware != "Off" else None
+        fusion_aware_active = safe_stack == "On" and fusion_metadata is not None and fusion_aware != "Off"
+        if fusion_aware != "Off" and safe_stack != "On":
+            print("[DonutApplyLoRAStack] Fusion-aware safety requires safe_stack=On; using legacy behavior")
+        elif fusion_aware != "Off" and fusion_metadata is None:
+            print(
+                "[DonutApplyLoRAStack] Fusion-aware safety found no Fusion Control metadata; "
+                "connect Donut Krea2 Fusion Control's model output before this node"
+            )
+
         if safe_stack == "On":
             adjusted_vectors, limited_blocks = _normalise_krea_vectors(entries)
-            adjusted_text_weights, text_limit = _normalise_fused_text_weights(entries)
             for idx, entry in enumerate(entries):
                 entry["vector"] = adjusted_vectors[idx]
-                entry["effective_cw"] = adjusted_text_weights[idx]
 
             if limited_blocks:
                 block_labels = ["base" if idx == 0 else str(idx - 1) for idx, _, _ in limited_blocks]
@@ -285,15 +464,84 @@ class DonutApplyLoRAStackSafe:
                     "[DonutApplyLoRAStack] Safe Stack: limited Krea2 block energy "
                     f"in {len(limited_blocks)} bucket(s): {', '.join(block_labels)}"
                 )
-            if text_limit:
-                energy, scale = text_limit
-                print(
-                    "[DonutApplyLoRAStack] Safe Stack: limited Krea2 fused-text "
-                    f"energy {energy:.3f}x -> {_SAFE_ENERGY_BUDGET:.3f}x "
-                    f"(scale {scale:.3f})"
+
+            if fusion_aware_active:
+                other_weights, other_limit = _normalise_fused_text_weights(
+                    entries,
+                    component="has_other_text",
                 )
+                projector_gains, dynamic = _nominal_projector_gains(fusion_metadata)
+                projector_scales, projector_report = _projector_column_scales(
+                    entries,
+                    projector_gains,
+                    fusion_aware,
+                    max_fusion_boost,
+                    dynamic=dynamic,
+                )
+
+                unsupported = []
+                for idx, entry in enumerate(entries):
+                    entry["fusion_split"] = bool(entry["fused_text"] and entry["is_krea_text"])
+                    entry["effective_cw"] = entry["cw"]
+                    entry["effective_other_cw"] = other_weights[idx]
+                    entry["effective_projector_cw"] = entry["cw"]
+                    entry["effective_projector_text"] = entry["projector_text"]
+                    if not (entry["is_krea_text"] and entry["projector_text"]):
+                        continue
+
+                    adjusted_projector, transformed = _scale_projector_lora_columns(
+                        entry["projector_text"],
+                        projector_scales,
+                    )
+                    if transformed:
+                        entry["effective_projector_text"] = adjusted_projector
+                    else:
+                        # A scalar fallback must use the most restrictive column
+                        # scale to keep every projector column within budget.
+                        uniform_scale = min(projector_scales)
+                        entry["effective_projector_cw"] = entry["cw"] * uniform_scale
+                        unsupported.append(entry["name"])
+
+                if other_limit:
+                    energy, scale = other_limit
+                    print(
+                        "[DonutApplyLoRAStack] Safe Stack: limited non-projector "
+                        f"Krea2 fused-text energy {energy:.3f}x -> {_SAFE_ENERGY_BUDGET:.3f}x "
+                        f"(scale {scale:.3f})"
+                    )
+                if projector_report:
+                    print(
+                        "[DonutApplyLoRAStack] Fusion-aware projector budget: "
+                        f"LoRA energy={projector_report['raw_energy']:.3f}x, "
+                        f"column scales={min(projector_scales):.3f}..{max(projector_scales):.3f}, "
+                        f"mode={fusion_aware}"
+                    )
+                    if projector_report["dynamic"] and fusion_aware == "Use headroom":
+                        print(
+                            "[DonutApplyLoRAStack] Fusion-aware projector budget: "
+                            "tensor_rms is prompt-dependent, so automatic boosts were disabled"
+                        )
+                if unsupported:
+                    print(
+                        "[DonutApplyLoRAStack] Fusion-aware projector budget used a "
+                        "conservative scalar fallback for unsupported adapter format(s): "
+                        + ", ".join(unsupported)
+                    )
+            else:
+                adjusted_text_weights, text_limit = _normalise_fused_text_weights(entries)
+                for idx, entry in enumerate(entries):
+                    entry["fusion_split"] = False
+                    entry["effective_cw"] = adjusted_text_weights[idx]
+                if text_limit:
+                    energy, scale = text_limit
+                    print(
+                        "[DonutApplyLoRAStack] Safe Stack: limited Krea2 fused-text "
+                        f"energy {energy:.3f}x -> {_SAFE_ENERGY_BUDGET:.3f}x "
+                        f"(scale {scale:.3f})"
+                    )
         else:
             for entry in entries:
+                entry["fusion_split"] = False
                 entry["effective_cw"] = entry["cw"]
 
         unet, text_enc = model, clip
@@ -301,7 +549,6 @@ class DonutApplyLoRAStackSafe:
 
         for entry in entries:
             mw = entry["mw"]
-            cw = entry["effective_cw"]
             lora = entry["lora"]
             lora_main = entry["lora_main"]
             lora_text = entry["lora_text"]
@@ -326,12 +573,22 @@ class DonutApplyLoRAStackSafe:
 
             # 2) text handling, matching the original DonutApplyLoRAStack.
             if fused_text:
-                if cw != 0.0:
+                text_applications = (
+                    (
+                        (entry["other_text"], entry["effective_other_cw"]),
+                        (entry["effective_projector_text"], entry["effective_projector_cw"]),
+                    )
+                    if entry["fusion_split"]
+                    else ((lora_text, entry["effective_cw"]),)
+                )
+                for text_lora, text_strength in text_applications:
+                    if not text_lora or text_strength == 0.0:
+                        continue
                     unet, _, _ = loader.load_lora_for_models(
                         unet,
                         None,
-                        lora_text,
-                        strength_model=cw,
+                        text_lora,
+                        strength_model=text_strength,
                         strength_clip=0.0,
                         inverse=False,
                         seed=0,
@@ -339,13 +596,13 @@ class DonutApplyLoRAStackSafe:
                         B=1.0,
                         block_vector=_TEXT_MERGE_VECTOR,
                     )
-            elif cw != 0.0:
+            elif entry["effective_cw"] != 0.0:
                 _, text_enc = comfy.sd.load_lora_for_models(
                     unet,
                     text_enc,
                     lora,
                     0.0,
-                    cw,
+                    entry["effective_cw"],
                 )
 
         return (unet, text_enc, help_url)

--- a/DonutSafeApplyLoRAStack.py
+++ b/DonutSafeApplyLoRAStack.py
@@ -1,0 +1,326 @@
+"""Safe Krea2 LoRA stack application.
+
+Overrides DonutApplyLoRAStack with an opt-in per-block RMS energy limiter for
+Krea2 LoRAs. Safe mode is deliberately conservative and off by default so old
+workflows retain their exact behaviour.
+"""
+
+import math
+import re
+
+import comfy.sd
+import comfy.utils
+import folder_paths
+
+from .donut_lora_nodes import (
+    _TEXT_MERGE_VECTOR,
+    _lora_has_real_text_encoder,
+    _split_fused_text,
+)
+from .lora_block_weight import LoraLoaderBlockWeight
+
+
+_KREA_BLOCK_RE = re.compile(r"(?<![a-z_])blocks\.(\d+)")
+_KREA_BLOCK_COUNT = 28
+_KREA_VECTOR_SIZE = _KREA_BLOCK_COUNT + 1  # non-block bucket + 28 blocks
+_SAFE_ENERGY_BUDGET = 1.0
+
+
+def _is_krea2_lora(lora):
+    """Return True when a LoRA contains Krea2-style single-stream blocks."""
+    block_nums = set()
+    for key in lora.keys():
+        match = _KREA_BLOCK_RE.search(key)
+        if match:
+            block_nums.add(int(match.group(1)))
+    return bool(block_nums) and max(block_nums) < _KREA_BLOCK_COUNT
+
+
+def _parse_numeric_vector(vector):
+    """Parse a Krea2 block vector, returning None for symbolic/random vectors."""
+    if not vector:
+        return [1.0] * _KREA_VECTOR_SIZE
+
+    parts = [part.strip() for part in vector.split(",")]
+    if len(parts) != _KREA_VECTOR_SIZE:
+        return None
+
+    values = []
+    try:
+        for part in parts:
+            values.append(float(part))
+    except (TypeError, ValueError):
+        return None
+    return values
+
+
+def _format_vector(values):
+    def fmt(value):
+        if abs(value) < 1e-12:
+            return "0"
+        if abs(value - 1.0) < 1e-12:
+            return "1"
+        return f"{value:.6g}"
+
+    return ",".join(fmt(value) for value in values)
+
+
+def _normalise_krea_vectors(entries, budget=_SAFE_ENERGY_BUDGET):
+    """Cap effective per-block RMS energy while preserving relative strengths.
+
+    Each effective contribution is model_weight * block_weight. If the root
+    sum of squares of all Krea2 contributions in a block exceeds ``budget``,
+    every LoRA touching that block is attenuated by the same factor. Blocks
+    below budget are left byte-for-byte equivalent apart from vector formatting.
+    """
+    vectors = []
+    eligible = []
+
+    for entry in entries:
+        if not entry["is_krea"]:
+            vectors.append(None)
+            eligible.append(False)
+            continue
+
+        parsed = _parse_numeric_vector(entry["vector"])
+        vectors.append(parsed)
+        eligible.append(parsed is not None)
+        if parsed is None:
+            print(
+                f"[DonutApplyLoRAStack] Safe Stack: '{entry['name']}' uses a "
+                "non-numeric or non-Krea2-sized block vector; leaving it unchanged"
+            )
+
+    scales = [[1.0] * _KREA_VECTOR_SIZE for _ in entries]
+    limited_blocks = []
+
+    for block_idx in range(_KREA_VECTOR_SIZE):
+        energy_sq = 0.0
+        participants = []
+        for idx, entry in enumerate(entries):
+            if not eligible[idx]:
+                continue
+            effective = float(entry["mw"]) * vectors[idx][block_idx]
+            if effective == 0.0:
+                continue
+            energy_sq += effective * effective
+            participants.append(idx)
+
+        energy = math.sqrt(energy_sq)
+        if energy > budget and participants:
+            scale = budget / energy
+            limited_blocks.append((block_idx, energy, scale))
+            for idx in participants:
+                scales[idx][block_idx] = scale
+
+    adjusted = []
+    for idx, entry in enumerate(entries):
+        if not eligible[idx]:
+            adjusted.append(entry["vector"])
+            continue
+        adjusted.append(
+            _format_vector([
+                value * scales[idx][block_idx]
+                for block_idx, value in enumerate(vectors[idx])
+            ])
+        )
+
+    return adjusted, limited_blocks
+
+
+def _normalise_fused_text_weights(entries, budget=_SAFE_ENERGY_BUDGET):
+    """RMS-limit Krea2 fused-text weights as one shared non-block bucket."""
+    participants = [
+        idx for idx, entry in enumerate(entries)
+        if entry["is_krea"] and entry["fused_text"] and float(entry["cw"]) != 0.0
+    ]
+    if not participants:
+        return [float(entry["cw"]) for entry in entries], None
+
+    energy = math.sqrt(sum(float(entries[idx]["cw"]) ** 2 for idx in participants))
+    scale = min(1.0, budget / energy) if energy > 0.0 else 1.0
+    weights = [float(entry["cw"]) for entry in entries]
+    if scale < 1.0:
+        for idx in participants:
+            weights[idx] *= scale
+        return weights, (energy, scale)
+    return weights, None
+
+
+class DonutApplyLoRAStackSafe:
+    """Drop-in replacement for DonutApplyLoRAStack with optional Krea2 safety."""
+
+    class_type = "CUSTOM"
+    aux_id = "DonutsDelivery/ComfyUI-DonutNodes"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "model": ("MODEL",),
+                "clip": ("CLIP",),
+                "lora_stack": ("LORA_STACK",),
+                "safe_stack": (["Off", "On"], {
+                    "default": "Off",
+                    "tooltip": (
+                        "Krea2 only. RMS-limits overlapping LoRA strength per block "
+                        "so stacked LoRAs cannot collectively exceed one full-strength "
+                        "LoRA worth of block energy. Off preserves legacy behaviour."
+                    ),
+                }),
+            }
+        }
+
+    RETURN_TYPES = ("MODEL", "CLIP", "STRING")
+    RETURN_NAMES = ("model", "clip", "show_help")
+    FUNCTION = "apply_stack"
+    CATEGORY = "Comfyanonymous/LoRA"
+
+    def apply_stack(self, model, clip, lora_stack=None, safe_stack="Off"):
+        help_url = (
+            "https://github.com/Suzie1/ComfyUI_Comfyroll_CustomNodes/"
+            "wiki/LoRA-Nodes#cr-apply-lora-stack"
+        )
+
+        if lora_stack is None or len(lora_stack) == 0:
+            return (model, clip, help_url)
+
+        # Preserve DonutApplyLoRAStack's duplicate semantics before doing any
+        # safety calculation, otherwise duplicate entries would consume budget
+        # even though the apply pass would skip them.
+        entries = []
+        seen = set()
+        for name, mw, cw, bv in lora_stack:
+            if mw == 0.0 and cw == 0.0:
+                continue
+            if name in seen:
+                print(
+                    f"[DonutApplyLoRAStack] Skipping duplicate LoRA '{name}' "
+                    "(already applied this run)"
+                )
+                continue
+            seen.add(name)
+
+            path = folder_paths.get_full_path("loras", name)
+            lora = comfy.utils.load_torch_file(path, safe_load=True)
+
+            # Match the original apply node's automatic vector behaviour.
+            vector = bv
+            if not vector:
+                block_nums = set()
+                for key in lora.keys():
+                    match = _KREA_BLOCK_RE.search(key)
+                    if match:
+                        block_nums.add(int(match.group(1)))
+                    elif "layers." in key:
+                        layer_match = re.search(r"layers\.(\d+)", key)
+                        if layer_match:
+                            block_nums.add(int(layer_match.group(1)))
+
+                if block_nums:
+                    vector = ",".join(["1"] * (max(block_nums) + 2))
+                else:
+                    vector = ",".join(["1"] * 13)
+
+            has_real_te = _lora_has_real_text_encoder(lora)
+            lora_main, lora_text = _split_fused_text(lora)
+            fused_text = bool(lora_text) and not has_real_te
+
+            entries.append({
+                "name": name,
+                "mw": float(mw),
+                "cw": float(cw),
+                "vector": vector,
+                "lora": lora,
+                "lora_main": lora_main,
+                "lora_text": lora_text,
+                "fused_text": fused_text,
+                "is_krea": _is_krea2_lora(lora),
+            })
+
+        if safe_stack == "On":
+            adjusted_vectors, limited_blocks = _normalise_krea_vectors(entries)
+            adjusted_text_weights, text_limit = _normalise_fused_text_weights(entries)
+            for idx, entry in enumerate(entries):
+                entry["vector"] = adjusted_vectors[idx]
+                entry["effective_cw"] = adjusted_text_weights[idx]
+
+            if limited_blocks:
+                block_labels = ["base" if idx == 0 else str(idx - 1) for idx, _, _ in limited_blocks]
+                print(
+                    "[DonutApplyLoRAStack] Safe Stack: limited Krea2 block energy "
+                    f"in {len(limited_blocks)} bucket(s): {', '.join(block_labels)}"
+                )
+            if text_limit:
+                energy, scale = text_limit
+                print(
+                    "[DonutApplyLoRAStack] Safe Stack: limited Krea2 fused-text "
+                    f"energy {energy:.3f}x -> {_SAFE_ENERGY_BUDGET:.3f}x "
+                    f"(scale {scale:.3f})"
+                )
+        else:
+            for entry in entries:
+                entry["effective_cw"] = entry["cw"]
+
+        unet, text_enc = model, clip
+        loader = LoraLoaderBlockWeight()
+
+        for entry in entries:
+            mw = entry["mw"]
+            cw = entry["effective_cw"]
+            lora = entry["lora"]
+            lora_main = entry["lora_main"]
+            lora_text = entry["lora_text"]
+            fused_text = entry["fused_text"]
+            vector = entry["vector"]
+
+            # 1) block-weighted diffusion-model merge.
+            merge_main = lora_main if fused_text else lora
+            if mw != 0.0 and merge_main:
+                unet, _, _ = loader.load_lora_for_models(
+                    unet,
+                    None,
+                    merge_main,
+                    strength_model=mw,
+                    strength_clip=0.0,
+                    inverse=False,
+                    seed=0,
+                    A=1.0,
+                    B=1.0,
+                    block_vector=vector,
+                )
+
+            # 2) text handling, matching the original DonutApplyLoRAStack.
+            if fused_text:
+                if cw != 0.0:
+                    unet, _, _ = loader.load_lora_for_models(
+                        unet,
+                        None,
+                        lora_text,
+                        strength_model=cw,
+                        strength_clip=0.0,
+                        inverse=False,
+                        seed=0,
+                        A=1.0,
+                        B=1.0,
+                        block_vector=_TEXT_MERGE_VECTOR,
+                    )
+            elif cw != 0.0:
+                _, text_enc = comfy.sd.load_lora_for_models(
+                    unet,
+                    text_enc,
+                    lora,
+                    0.0,
+                    cw,
+                )
+
+        return (unet, text_enc, help_url)
+
+
+NODE_CLASS_MAPPINGS = {
+    "DonutApplyLoRAStack": DonutApplyLoRAStackSafe,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "DonutApplyLoRAStack": "Donut Apply LoRA Stack",
+}

--- a/DonutSafeApplyLoRAStack.py
+++ b/DonutSafeApplyLoRAStack.py
@@ -26,32 +26,52 @@ _KREA_VECTOR_SIZE = _KREA_BLOCK_COUNT + 1  # non-block bucket + 28 blocks
 _SAFE_ENERGY_BUDGET = 1.0
 
 
-def _is_krea2_lora(lora):
-    """Return True when a LoRA contains Krea2-style single-stream blocks."""
+def _krea2_block_indices(lora):
+    """Return the Krea2 single-stream block indices referenced by a LoRA."""
     block_nums = set()
     for key in lora.keys():
         match = _KREA_BLOCK_RE.search(key)
         if match:
             block_nums.add(int(match.group(1)))
+    return block_nums
+
+
+def _is_krea2_lora(lora):
+    """Return True when a LoRA contains Krea2-style single-stream blocks."""
+    block_nums = _krea2_block_indices(lora)
     return bool(block_nums) and max(block_nums) < _KREA_BLOCK_COUNT
 
 
-def _parse_numeric_vector(vector):
-    """Parse a Krea2 block vector, returning None for symbolic/random vectors."""
+def _parse_numeric_vector(vector, required_size=1):
+    """Parse a numeric Krea2 vector into a full safety-analysis vector.
+
+    Donut's normal auto-vector path intentionally sizes a Krea2 vector only up
+    to the highest block actually present in that LoRA. A LoRA that only has
+    blocks 0..15 therefore has a valid 17-value vector (base + 16 blocks), not
+    a 29-value vector. Safe Stack must accept that rather than requiring all 28
+    architectural blocks.
+
+    Returns ``(padded_values, original_size)``. Missing higher Krea2 blocks are
+    zero-filled for the energy calculation because the LoRA has no weights for
+    them. The caller later trims back to ``original_size`` before handing the
+    vector to the normal Donut block loader, preserving its original shape.
+    """
     if not vector:
-        return [1.0] * _KREA_VECTOR_SIZE
+        values = [1.0] * max(1, min(required_size, _KREA_VECTOR_SIZE))
+        return values + [0.0] * (_KREA_VECTOR_SIZE - len(values)), len(values)
 
     parts = [part.strip() for part in vector.split(",")]
-    if len(parts) != _KREA_VECTOR_SIZE:
+    if len(parts) < required_size or len(parts) > _KREA_VECTOR_SIZE:
         return None
 
-    values = []
     try:
-        for part in parts:
-            values.append(float(part))
+        values = [float(part) for part in parts]
     except (TypeError, ValueError):
         return None
-    return values
+
+    original_size = len(values)
+    values.extend([0.0] * (_KREA_VECTOR_SIZE - original_size))
+    return values, original_size
 
 
 def _format_vector(values):
@@ -71,25 +91,37 @@ def _normalise_krea_vectors(entries, budget=_SAFE_ENERGY_BUDGET):
     Each effective contribution is model_weight * block_weight. If the root
     sum of squares of all Krea2 contributions in a block exceeds ``budget``,
     every LoRA touching that block is attenuated by the same factor. Blocks
-    below budget are left byte-for-byte equivalent apart from vector formatting.
+    below budget are left equivalent apart from numeric vector formatting.
     """
     vectors = []
+    original_sizes = []
     eligible = []
 
     for entry in entries:
         if not entry["is_krea"]:
             vectors.append(None)
+            original_sizes.append(0)
             eligible.append(False)
             continue
 
-        parsed = _parse_numeric_vector(entry["vector"])
-        vectors.append(parsed)
-        eligible.append(parsed is not None)
+        block_indices = entry["krea_blocks"]
+        required_size = (max(block_indices) + 2) if block_indices else 1
+        parsed = _parse_numeric_vector(entry["vector"], required_size=required_size)
         if parsed is None:
+            vectors.append(None)
+            original_sizes.append(0)
+            eligible.append(False)
             print(
                 f"[DonutApplyLoRAStack] Safe Stack: '{entry['name']}' uses a "
-                "non-numeric or non-Krea2-sized block vector; leaving it unchanged"
+                "non-numeric vector or one too short for its populated Krea2 "
+                "blocks; leaving it unchanged"
             )
+            continue
+
+        values, original_size = parsed
+        vectors.append(values)
+        original_sizes.append(original_size)
+        eligible.append(True)
 
     scales = [[1.0] * _KREA_VECTOR_SIZE for _ in entries]
     limited_blocks = []
@@ -118,12 +150,12 @@ def _normalise_krea_vectors(entries, budget=_SAFE_ENERGY_BUDGET):
         if not eligible[idx]:
             adjusted.append(entry["vector"])
             continue
-        adjusted.append(
-            _format_vector([
-                value * scales[idx][block_idx]
-                for block_idx, value in enumerate(vectors[idx])
-            ])
-        )
+
+        adjusted_full = [
+            value * scales[idx][block_idx]
+            for block_idx, value in enumerate(vectors[idx])
+        ]
+        adjusted.append(_format_vector(adjusted_full[:original_sizes[idx]]))
 
     return adjusted, limited_blocks
 
@@ -203,6 +235,7 @@ class DonutApplyLoRAStackSafe:
 
             path = folder_paths.get_full_path("loras", name)
             lora = comfy.utils.load_torch_file(path, safe_load=True)
+            krea_blocks = _krea2_block_indices(lora)
 
             # Match the original apply node's automatic vector behaviour.
             vector = bv
@@ -235,7 +268,8 @@ class DonutApplyLoRAStackSafe:
                 "lora_main": lora_main,
                 "lora_text": lora_text,
                 "fused_text": fused_text,
-                "is_krea": _is_krea2_lora(lora),
+                "is_krea": bool(krea_blocks) and max(krea_blocks) < _KREA_BLOCK_COUNT,
+                "krea_blocks": krea_blocks,
             })
 
         if safe_stack == "On":

--- a/README.md
+++ b/README.md
@@ -53,6 +53,29 @@ Install `ComfyUI-DonutLocalAutomation` alongside this package to keep the origin
 | ModelMergeZIT | ZIT model merging |
 | DonutModelSave | Save merged models |
 
+### Fusion-aware Krea2 LoRA safety
+
+The feature branch version of `DonutApplyLoRAStack` can budget Krea2 projector
+LoRAs against the 12 resolved projector-input gains from
+`DonutKrea2FusionControl`.
+
+Connect the model path in this order:
+
+`Checkpoint -> Donut Krea2 Fusion Control -> Donut Apply LoRA Stack -> Sampler`
+
+Then set `safe_stack` to `On` and choose a `fusion_aware` mode:
+
+- `Attenuate only` reduces LoRA projector columns amplified by Fusion Control.
+- `Use headroom` may also boost quieter columns, capped by `max_fusion_boost`.
+- `tensor_rms` projector normalization is prompt-dependent, so it never
+  receives automatic headroom boosts.
+
+The 12 fusion channels are not mapped onto Krea2's 28 DiT blocks. Existing
+per-block Safe Stack behavior remains independent and unchanged. Fusion-aware
+column scaling supports standard LoRA/PEFT projector adapters and direct
+projector `.diff` patches; other adapter formats use a conservative scalar
+fallback.
+
 ## License
 
 See [LICENSE](LICENSE) file.

--- a/__init__.py
+++ b/__init__.py
@@ -15,6 +15,11 @@ from .DonutWidenMerge       import NODE_CLASS_MAPPINGS as m7
 from .donut_lora_nodes      import NODE_CLASS_MAPPINGS        as m_lora
 from .donut_lora_nodes      import NODE_DISPLAY_NAME_MAPPINGS as d_lora
 
+# Safe Krea2 LoRA application overrides only DonutApplyLoRAStack while keeping
+# the existing node id/display name so saved workflows remain compatible.
+from .DonutSafeApplyLoRAStack import NODE_CLASS_MAPPINGS        as m_safe_lora
+from .DonutSafeApplyLoRAStack import NODE_DISPLAY_NAME_MAPPINGS as d_safe_lora
+
 # hot reload functionality
 from .hot_reload            import NODE_CLASS_MAPPINGS        as m_reload
 from .hot_reload            import NODE_DISPLAY_NAME_MAPPINGS as d_reload
@@ -129,6 +134,7 @@ NODE_CLASS_MAPPINGS = {
     **m1, **m2, **m3, **m4, **m5,
     **m6, **m7,
     **m_lora,
+    **m_safe_lora,
     **m_reload,
     # **m_optuna,  # disabled - file not in repo
     **m_teacache,
@@ -161,6 +167,7 @@ NODE_CLASS_MAPPINGS = {
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     **d_lora,
+    **d_safe_lora,
     **d_reload,
     # **d_optuna,  # disabled - file not in repo
     **d_teacache,

--- a/test_krea2_fusion_control.py
+++ b/test_krea2_fusion_control.py
@@ -265,6 +265,16 @@ class ProjectorControlTests(unittest.TestCase):
         after = scaled.square().mean(dim=(1, 2, 3)).sqrt()
         self.assertTrue(torch.allclose(before, after, atol=1e-6, rtol=1e-6))
 
+    def test_resolved_projector_gains_are_published_for_safe_lora_budgeting(self):
+        _, result = self._apply_node(projector_profile="deep_2", projector_normalization="none")
+        patched_model = result[0]
+        metadata = patched_model.model_options["transformer_options"][module.FUSION_BUDGET_KEY]
+
+        self.assertEqual(metadata["version"], 1)
+        self.assertEqual(metadata["projector_gains"], module._PROFILE_DEEP_2)
+        self.assertEqual(metadata["projector_normalization"], "none")
+        self.assertEqual(metadata["tap_gains"], module._PROFILE_OFF)
+
     def test_fully_off_node_does_not_clone_or_validate_conditioning(self):
         model = FakeModel()
         conditioning = [[torch.randn(1, 2, 17), {}]]
@@ -290,6 +300,7 @@ class ProjectorControlTests(unittest.TestCase):
         self.assertIsNone(output_3)
         self.assertIsNone(output_4)
         self.assertEqual(model.clone_count, 0)
+        self.assertNotIn(module.FUSION_BUDGET_KEY, model.model_options.get("transformer_options", {}))
         self.assertIn("; off;", diagnostics)
 
     def test_numbered_conditioning_inputs_route_to_matching_outputs(self):

--- a/test_safe_lora_stack.py
+++ b/test_safe_lora_stack.py
@@ -1,0 +1,277 @@
+import importlib.util
+import math
+import sys
+import types
+import unittest
+from pathlib import Path
+
+import numpy as np
+
+
+ROOT = Path(__file__).resolve().parent
+PACKAGE = "donut_safe_lora_test_package"
+
+
+class _FakeTensor:
+    def __init__(self, value, dtype=None):
+        self.array = np.asarray(value, dtype=dtype or np.float32)
+        self.device = "cpu"
+        self.dtype = self.array.dtype
+
+    @property
+    def ndim(self):
+        return self.array.ndim
+
+    @property
+    def shape(self):
+        return self.array.shape
+
+    def is_floating_point(self):
+        return np.issubdtype(self.array.dtype, np.floating)
+
+    def reshape(self, *shape):
+        return _FakeTensor(self.array.reshape(*shape), dtype=self.dtype)
+
+    def __mul__(self, other):
+        value = other.array if isinstance(other, _FakeTensor) else other
+        return _FakeTensor(self.array * value, dtype=self.dtype)
+
+    def __getitem__(self, item):
+        return _FakeTensor(self.array[item], dtype=self.dtype)
+
+
+fake_torch = types.ModuleType("torch")
+fake_torch.Tensor = _FakeTensor
+fake_torch.tensor = lambda value, device=None, dtype=None: _FakeTensor(value, dtype=dtype)
+fake_torch.ones = lambda *shape: _FakeTensor(np.ones(shape, dtype=np.float32))
+fake_torch.is_tensor = lambda value: isinstance(value, _FakeTensor)
+fake_torch.equal = lambda left, right: np.array_equal(left.array, right.array)
+fake_torch.allclose = lambda left, right: np.allclose(left.array, right.array)
+
+
+def _load_module():
+    package = types.ModuleType(PACKAGE)
+    package.__path__ = [str(ROOT)]
+
+    comfy = types.ModuleType("comfy")
+    comfy_sd = types.ModuleType("comfy.sd")
+    comfy_utils = types.ModuleType("comfy.utils")
+    comfy.sd = comfy_sd
+    comfy.utils = comfy_utils
+
+    folder_paths = types.ModuleType("folder_paths")
+    donut_lora_nodes = types.ModuleType(f"{PACKAGE}.donut_lora_nodes")
+    donut_lora_nodes._TEXT_MERGE_VECTOR = ",".join(["1"] * 60)
+    donut_lora_nodes._lora_has_real_text_encoder = lambda lora: False
+    donut_lora_nodes._split_fused_text = lambda lora: (lora, {})
+
+    lora_block_weight = types.ModuleType(f"{PACKAGE}.lora_block_weight")
+    lora_block_weight.LoraLoaderBlockWeight = object
+
+    injected = {
+        PACKAGE: package,
+        "comfy": comfy,
+        "comfy.sd": comfy_sd,
+        "comfy.utils": comfy_utils,
+        "folder_paths": folder_paths,
+        "torch": fake_torch,
+        f"{PACKAGE}.donut_lora_nodes": donut_lora_nodes,
+        f"{PACKAGE}.lora_block_weight": lora_block_weight,
+    }
+    previous = {name: sys.modules.get(name) for name in injected}
+    sys.modules.update(injected)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            f"{PACKAGE}.DonutSafeApplyLoRAStack",
+            ROOT / "DonutSafeApplyLoRAStack.py",
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, old in previous.items():
+            if old is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = old
+
+
+module = _load_module()
+
+
+def _projector_entry(weight=1.0):
+    return {
+        "cw": weight,
+        "fused_text": True,
+        "is_krea_text": True,
+        "projector_text": {"diffusion_model.txtfusion.projector.diff": fake_torch.ones(1, 12)},
+        "has_projector_text": True,
+        "has_other_text": False,
+    }
+
+
+class FusionMetadataTests(unittest.TestCase):
+    def test_reads_valid_fusion_metadata_from_model_options(self):
+        model = types.SimpleNamespace(model_options={
+            "transformer_options": {
+                module._FUSION_BUDGET_KEY: {
+                    "version": 1,
+                    "projector_gains": [1] * 12,
+                    "projector_normalization": "none",
+                }
+            }
+        })
+
+        metadata = module._read_fusion_budget(model)
+        self.assertEqual(metadata["projector_gains"], (1.0,) * 12)
+
+    def test_rejects_wrong_sized_projector_profile(self):
+        model = types.SimpleNamespace(model_options={
+            "transformer_options": {
+                module._FUSION_BUDGET_KEY: {"version": 1, "projector_gains": [1] * 11}
+            }
+        })
+        self.assertIsNone(module._read_fusion_budget(model))
+
+
+class ProjectorBudgetTests(unittest.TestCase):
+    def test_attenuation_accounts_for_each_projector_gain(self):
+        gains = (2.0, 0.5) + (1.0,) * 10
+        scales, report = module._projector_column_scales(
+            [_projector_entry(), _projector_entry()],
+            gains,
+            "Attenuate only",
+            max_boost=2.0,
+        )
+
+        self.assertAlmostEqual(scales[0], 1.0 / (2.0 * math.sqrt(2.0)))
+        self.assertEqual(scales[1], 1.0)
+        self.assertAlmostEqual(scales[2], 1.0 / math.sqrt(2.0))
+        self.assertTrue(report["limited"])
+        self.assertFalse(report["boosted"])
+
+    def test_headroom_boosts_quiet_columns_up_to_budget(self):
+        gains = (2.0, 0.5) + (1.0,) * 10
+        scales, report = module._projector_column_scales(
+            [_projector_entry(), _projector_entry()],
+            gains,
+            "Use headroom",
+            max_boost=2.0,
+        )
+
+        self.assertAlmostEqual(scales[1], math.sqrt(2.0))
+        self.assertTrue(report["boosted"])
+
+    def test_dynamic_tensor_rms_metadata_disables_headroom_boosts(self):
+        scales, report = module._projector_column_scales(
+            [_projector_entry(weight=0.25)],
+            (0.5,) * 12,
+            "Use headroom",
+            max_boost=4.0,
+            dynamic=True,
+        )
+        self.assertEqual(scales, (1.0,) * 12)
+        self.assertTrue(report["dynamic"])
+        self.assertFalse(report["boosted"])
+
+    def test_tensor_rms_profile_is_nominally_rms_normalized(self):
+        gains, dynamic = module._nominal_projector_gains({
+            "projector_gains": (1.0,) * 10 + (2.0, 2.0),
+            "projector_normalization": "tensor_rms",
+        })
+        rms = math.sqrt(sum(value * value for value in gains) / len(gains))
+        self.assertAlmostEqual(rms, 1.0)
+        self.assertTrue(dynamic)
+
+
+class ProjectorTensorScalingTests(unittest.TestCase):
+    def test_standard_lora_down_matrix_is_scaled_by_input_column(self):
+        down_key = "diffusion_model.txtfusion.projector.lora_down.weight"
+        up_key = "diffusion_model.txtfusion.projector.lora_up.weight"
+        original = {
+            down_key: fake_torch.ones(2, 12),
+            up_key: fake_torch.ones(1, 2),
+        }
+        scales = tuple(float(index + 1) for index in range(12))
+
+        adjusted, transformed = module._scale_projector_lora_columns(original, scales)
+
+        self.assertTrue(transformed)
+        self.assertTrue(fake_torch.equal(adjusted[down_key][0], fake_torch.tensor(scales)))
+        self.assertTrue(fake_torch.equal(adjusted[up_key], original[up_key]))
+        self.assertTrue(fake_torch.equal(original[down_key], fake_torch.ones(2, 12)))
+
+    def test_direct_projector_diff_is_scaled_by_column(self):
+        key = "diffusion_model.txtfusion.projector.diff"
+        scales = tuple(0.1 * (index + 1) for index in range(12))
+        adjusted, transformed = module._scale_projector_lora_columns(
+            {key: fake_torch.ones(1, 12)},
+            scales,
+        )
+        self.assertTrue(transformed)
+        self.assertTrue(fake_torch.allclose(adjusted[key][0], fake_torch.tensor(scales)))
+
+
+class SafetyCompatibilityTests(unittest.TestCase):
+    def test_projector_only_krea_lora_participates_in_text_budget(self):
+        weights, limited = module._normalise_fused_text_weights(
+            [_projector_entry(), _projector_entry()]
+        )
+        expected = 1.0 / math.sqrt(2.0)
+        self.assertAlmostEqual(weights[0], expected)
+        self.assertAlmostEqual(weights[1], expected)
+        self.assertIsNotNone(limited)
+
+    def test_new_controls_default_to_legacy_off(self):
+        required = module.DonutApplyLoRAStackSafe.INPUT_TYPES()["required"]
+        self.assertEqual(required["fusion_aware"][1]["default"], "Off")
+        self.assertEqual(required["max_fusion_boost"][1]["default"], 2.0)
+
+    def test_apply_splits_and_column_scales_projector_lora(self):
+        down_key = "diffusion_model.txtfusion.projector.lora_down.weight"
+        up_key = "diffusion_model.txtfusion.projector.lora_up.weight"
+        loaded_lora = {
+            down_key: fake_torch.ones(2, 12),
+            up_key: fake_torch.ones(1, 2),
+        }
+        calls = []
+
+        class Loader:
+            def load_lora_for_models(self, model, clip, lora, **kwargs):
+                calls.append((lora, kwargs["strength_model"]))
+                return model, clip, kwargs["block_vector"]
+
+        module.LoraLoaderBlockWeight = Loader
+        module.folder_paths.get_full_path = lambda category, name: f"/{name}"
+        module.comfy.utils.load_torch_file = lambda path, safe_load=True: loaded_lora
+        module._lora_has_real_text_encoder = lambda lora: False
+        module._split_fused_text = lambda lora: ({}, dict(lora))
+
+        model = types.SimpleNamespace(model_options={
+            "transformer_options": {
+                module._FUSION_BUDGET_KEY: {
+                    "version": 1,
+                    "projector_gains": (2.0, 0.5) + (1.0,) * 10,
+                    "projector_normalization": "none",
+                }
+            }
+        })
+
+        module.DonutApplyLoRAStackSafe().apply_stack(
+            model,
+            object(),
+            [("projector.safetensors", 0.0, 1.0, "")],
+            safe_stack="On",
+            fusion_aware="Use headroom",
+            max_fusion_boost=2.0,
+        )
+
+        self.assertEqual(len(calls), 1)
+        applied_lora, applied_strength = calls[0]
+        self.assertEqual(applied_strength, 1.0)
+        expected = (0.5, 2.0) + (1.0,) * 10
+        self.assertTrue(fake_torch.allclose(applied_lora[down_key][0], fake_torch.tensor(expected)))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds fusion-aware LoRA budgeting between Krea2 Fusion Control and Donut Safe Apply LoRA Stack.

- Publishes resolved Krea2 text-fusion gains as model metadata.
- Adds Off, Attenuate only, and Use headroom modes.
- Budgets LoRA projector columns against their individual fusion weights.
- Preserves the existing independent 28-block safety limit.
- Adds focused unit coverage and README usage notes.

Validation:
- `python -m py_compile DonutSafeApplyLoRAStack.py DonutKrea2FusionControl.py test_safe_lora_stack.py`
- `python -m unittest -v test_safe_lora_stack.py` (11 tests passed)
- `git diff --check`