### PR TITLE
Accept legacy detail_clip in Krea2 Fusion Control

### DIFF
--- a/DonutKrea2FusionControl.py
+++ b/DonutKrea2FusionControl.py
@@ -526,7 +526,12 @@ class DonutKrea2FusionControl:
         projector_method=PROJECTOR_METHOD_DONUT,
         fusion_method=FUSION_METHOD_STANDARD,
         fusion_strength=1.0,
+        detail_clip=None,
     ):
+        # Older saved workflows/subgraphs may still submit this removed input.
+        # It never participates in the current fusion path, but accepting it
+        # keeps those workflows executable after updating the node pack.
+        del detail_clip
         if compatibility_preset not in COMPATIBILITY_PRESETS:
             raise ValueError(f"Unknown compatibility preset label: {compatibility_preset}")
         conditioning_inputs = (

--- a/test_krea2_fusion_control.py
+++ b/test_krea2_fusion_control.py
@@ -203,7 +203,7 @@ class ConditioningControlTests(unittest.TestCase):
 
 
 class ProjectorControlTests(unittest.TestCase):
-    def _apply_node(self, projector_profile="deep_2", projector_normalization="none"):
+    def _apply_node(self, projector_profile="deep_2", projector_normalization="none", **legacy_inputs):
         model = FakeModel()
         conditioning = [[torch.randn(1, 2, module.KREA2_CONDITIONING_DIM), {}]]
         node = module.DonutKrea2FusionControl()
@@ -220,7 +220,19 @@ class ProjectorControlTests(unittest.TestCase):
             projector_normalization=projector_normalization,
             per_layer_weights=",".join(["1"] * 12),
             projector_layer_weights=module._format_profile_string(module._PROFILE_DEEP_2),
+            **legacy_inputs,
         )
+
+    def test_legacy_detail_clip_keyword_is_accepted_but_not_exposed(self):
+        original_model, result = self._apply_node(
+            projector_profile="off",
+            detail_clip=object(),
+        )
+
+        self.assertIs(result[0], original_model)
+        schema = module.DonutKrea2FusionControl.INPUT_TYPES()
+        self.assertNotIn("detail_clip", schema["required"])
+        self.assertNotIn("detail_clip", schema["optional"])
 
     def test_deep_two_wrapper_exactly_doubles_two_live_projector_inputs(self):
         original_model, result = self._apply_node()


### PR DESCRIPTION
Fixes saved workflows/subgraphs that still submit the removed `detail_clip` keyword to `DonutKrea2FusionControl.apply()`.

The compatibility parameter is accepted and ignored because it is not part of the current fusion path. It remains absent from the node UI schema, so new workflows are unaffected.

Validation:
- Python compilation passed.
- Added a regression assertion covering the legacy keyword and current schema.
- The full focused runtime test module could not run in the validation environment because PyTorch is unavailable.