### PR TITLE
Experimental: DLSS 5 neural upscaling on Linux via Proton/Wine

### DIFF
--- a/.github/workflows/dlss5-linux-static.yml
+++ b/.github/workflows/dlss5-linux-static.yml
@@ -7,14 +7,14 @@ on:
     paths:
       - "DonutDLSS5Linux.py"
       - "donut_dlss5_linux.py"
-      - "hot_reload.py"
+      - "DonutWeightVectorScale.py"
       - "tests/test_donut_dlss5_linux.py"
       - ".github/workflows/dlss5-linux-static.yml"
   pull_request:
     paths:
       - "DonutDLSS5Linux.py"
       - "donut_dlss5_linux.py"
-      - "hot_reload.py"
+      - "DonutWeightVectorScale.py"
       - "tests/test_donut_dlss5_linux.py"
       - ".github/workflows/dlss5-linux-static.yml"
   workflow_dispatch:
@@ -38,7 +38,7 @@ jobs:
           .venv-dlss5/bin/python -m py_compile \
             donut_dlss5_linux.py \
             DonutDLSS5Linux.py \
-            hot_reload.py \
+            DonutWeightVectorScale.py \
             tests/test_donut_dlss5_linux.py
       - name: Run protocol tests
         run: .venv-dlss5/bin/python -m pytest -q tests/test_donut_dlss5_linux.py

--- a/.github/workflows/dlss5-linux-static.yml
+++ b/.github/workflows/dlss5-linux-static.yml
@@ -1,0 +1,28 @@
+name: DLSS 5 Linux bridge static checks
+
+on:
+  push:
+    branches: [feat/linux-dlss5-experimental]
+    paths:
+      - "DonutDLSS5Linux.py"
+      - "donut_dlss5_linux.py"
+      - "tests/test_donut_dlss5_linux.py"
+      - ".github/workflows/dlss5-linux-static.yml"
+  pull_request:
+    paths:
+      - "DonutDLSS5Linux.py"
+      - "donut_dlss5_linux.py"
+      - "tests/test_donut_dlss5_linux.py"
+
+jobs:
+  static:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - run: python -m pip install --upgrade pip
+      - run: python -m pip install numpy pytest
+      - run: python -m py_compile donut_dlss5_linux.py DonutDLSS5Linux.py tests/test_donut_dlss5_linux.py
+      - run: pytest -q tests/test_donut_dlss5_linux.py

--- a/.github/workflows/dlss5-linux-static.yml
+++ b/.github/workflows/dlss5-linux-static.yml
@@ -2,27 +2,43 @@ name: DLSS 5 Linux bridge static checks
 
 on:
   push:
-    branches: [feat/linux-dlss5-experimental]
+    branches:
+      - "feat/linux-dlss5-experimental"
     paths:
       - "DonutDLSS5Linux.py"
       - "donut_dlss5_linux.py"
+      - "hot_reload.py"
       - "tests/test_donut_dlss5_linux.py"
       - ".github/workflows/dlss5-linux-static.yml"
   pull_request:
     paths:
       - "DonutDLSS5Linux.py"
       - "donut_dlss5_linux.py"
+      - "hot_reload.py"
       - "tests/test_donut_dlss5_linux.py"
+      - ".github/workflows/dlss5-linux-static.yml"
+  workflow_dispatch:
+
+permissions:
+  contents: read
 
 jobs:
   static:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
-        with:
-          python-version: "3.11"
-      - run: python -m pip install --upgrade pip
-      - run: python -m pip install numpy pytest
-      - run: python -m py_compile donut_dlss5_linux.py DonutDLSS5Linux.py tests/test_donut_dlss5_linux.py
-      - run: pytest -q tests/test_donut_dlss5_linux.py
+      - name: Check out code
+        uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262
+      - name: Create isolated test environment
+        run: |
+          python3 -m venv .venv-dlss5
+          .venv-dlss5/bin/python -m pip install --upgrade pip
+          .venv-dlss5/bin/python -m pip install numpy pytest
+      - name: Compile bridge files
+        run: |
+          .venv-dlss5/bin/python -m py_compile \
+            donut_dlss5_linux.py \
+            DonutDLSS5Linux.py \
+            hot_reload.py \
+            tests/test_donut_dlss5_linux.py
+      - name: Run protocol tests
+        run: .venv-dlss5/bin/python -m pytest -q tests/test_donut_dlss5_linux.py

--- a/DonutDLSS5Linux.py
+++ b/DonutDLSS5Linux.py
@@ -1,0 +1,275 @@
+"""Experimental DLSS 5 neural-rendering nodes for Linux via Proton/Wine."""
+
+from __future__ import annotations
+
+import os
+
+import numpy as np
+import torch
+import torch.nn.functional as F
+
+from .donut_dlss5_linux import (
+    MODEL_PRESETS,
+    NR_PRESETS,
+    NR_STYLES,
+    UPSCALE_MODES,
+    Dlss5LinuxError,
+    Dlss5Session,
+    RuntimeLayout,
+    build_native_settings,
+    format_status,
+    probe_host,
+    resolve_launch_config,
+    resolve_output_size,
+)
+
+
+def _check_interrupted() -> None:
+    try:
+        import comfy.model_management as model_management
+
+        model_management.throw_exception_if_processing_interrupted()
+    except ImportError:
+        return
+
+
+def _resize_rgba(frame: torch.Tensor, width: int, height: int) -> np.ndarray:
+    rgb = frame[..., :3].detach().float().permute(2, 0, 1).unsqueeze(0)
+    try:
+        resized = F.interpolate(
+            rgb,
+            size=(height, width),
+            mode="bicubic",
+            align_corners=False,
+            antialias=True,
+        )
+    except TypeError:
+        resized = F.interpolate(
+            rgb,
+            size=(height, width),
+            mode="bicubic",
+            align_corners=False,
+        )
+    rgb8 = (
+        resized.squeeze(0)
+        .permute(1, 2, 0)
+        .clamp(0.0, 1.0)
+        .mul(255.0)
+        .round()
+        .to(torch.uint8)
+        .cpu()
+        .numpy()
+    )
+    alpha = np.full((height, width, 1), 255, dtype=np.uint8)
+    return np.ascontiguousarray(np.concatenate((rgb8, alpha), axis=2))
+
+
+class DonutDLSS5LinuxStatus:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "runtime_dir": (
+                    "STRING",
+                    {
+                        "default": os.environ.get("DONUT_DLSS5_RUNTIME", ""),
+                        "multiline": False,
+                        "tooltip": "Merserk-compatible runtime root or its bin/runtime directory.",
+                    },
+                ),
+                "backend": (["Auto", "Proton", "Wine", "Native"],),
+                "launcher": (
+                    "STRING",
+                    {
+                        "default": os.environ.get("DONUT_DLSS5_PROTON", ""),
+                        "multiline": False,
+                        "tooltip": "Optional Proton script or wine64 executable.",
+                    },
+                ),
+                "prefix": (
+                    "STRING",
+                    {
+                        "default": os.environ.get("DONUT_DLSS5_PREFIX", ""),
+                        "multiline": False,
+                        "tooltip": "Proton compat-data directory or Wine prefix.",
+                    },
+                ),
+            }
+        }
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("runtime_report",)
+    FUNCTION = "inspect"
+    CATEGORY = "image/Donut/DLSS 5 (Linux experimental)"
+    DESCRIPTION = (
+        "Checks runtime files, launcher discovery, NVIDIA visibility and Vulkan visibility. "
+        "It does not claim DLSS works until an upscale node verifies feature 18."
+    )
+
+    def inspect(self, runtime_dir: str, backend: str, launcher: str, prefix: str):
+        layout = RuntimeLayout.discover(runtime_dir)
+        launch = resolve_launch_config(backend, launcher, prefix, layout.worker)
+        return (format_status(layout, launch, probe_host()),)
+
+
+class DonutDLSS5LinuxUpscale:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "image": ("IMAGE",),
+                "runtime_dir": (
+                    "STRING",
+                    {
+                        "default": os.environ.get("DONUT_DLSS5_RUNTIME", ""),
+                        "multiline": False,
+                    },
+                ),
+                "backend": (["Auto", "Proton", "Wine", "Native"],),
+                "launcher": (
+                    "STRING",
+                    {
+                        "default": os.environ.get("DONUT_DLSS5_PROTON", ""),
+                        "multiline": False,
+                    },
+                ),
+                "prefix": (
+                    "STRING",
+                    {
+                        "default": os.environ.get("DONUT_DLSS5_PREFIX", ""),
+                        "multiline": False,
+                    },
+                ),
+                "upscaling_mode": (list(UPSCALE_MODES),),
+                "nr_preset": (list(NR_PRESETS),),
+                "nr_style": (list(NR_STYLES),),
+                "model_preset": (list(MODEL_PRESETS), {"default": "M"}),
+                "nr_intensity": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.05}),
+                "local_tone_strength": (
+                    "FLOAT",
+                    {"default": 1.0, "min": 0.0, "max": 2.0, "step": 0.05},
+                ),
+                "local_structure_strength": (
+                    "FLOAT",
+                    {"default": 1.5, "min": 0.0, "max": 2.0, "step": 0.05},
+                ),
+                "skin_structure_strength": (
+                    "FLOAT",
+                    {"default": 2.0, "min": -1.0, "max": 2.0, "step": 0.05},
+                ),
+                "automatic_mask": ("BOOLEAN", {"default": True}),
+                "warmup_frames": ("INT", {"default": 0, "min": 0, "max": 16}),
+            }
+        }
+
+    RETURN_TYPES = ("IMAGE", "STRING")
+    RETURN_NAMES = ("image", "runtime_report")
+    FUNCTION = "upscale"
+    CATEGORY = "image/Donut/DLSS 5 (Linux experimental)"
+    DESCRIPTION = (
+        "Runs a user-supplied DLSS 5 feature-18 worker through Proton/Wine. "
+        "The node fails unless ReShade logs prove signed DLSSNR initialization, feature-18 "
+        "creation and successful feature-18 evaluation. Batch items are independent stills."
+    )
+
+    def upscale(
+        self,
+        image: torch.Tensor,
+        runtime_dir: str,
+        backend: str,
+        launcher: str,
+        prefix: str,
+        upscaling_mode: str,
+        nr_preset: str,
+        nr_style: str,
+        model_preset: str,
+        nr_intensity: float,
+        local_tone_strength: float,
+        local_structure_strength: float,
+        skin_structure_strength: float,
+        automatic_mask: bool,
+        warmup_frames: int,
+    ):
+        if image.ndim != 4 or image.shape[-1] < 3:
+            raise Dlss5LinuxError(
+                f"Expected ComfyUI IMAGE [batch,height,width,channels], got {tuple(image.shape)}."
+            )
+        batch, input_height, input_width, _channels = image.shape
+        if input_width < 64 or input_height < 64:
+            raise Dlss5LinuxError("DLSS requires both input dimensions to be at least 64 pixels.")
+
+        layout = RuntimeLayout.discover(runtime_dir)
+        launch = resolve_launch_config(backend, launcher, prefix, layout.worker)
+        output_width, output_height, factor, perf_quality, mode_name = resolve_output_size(
+            int(input_width), int(input_height), upscaling_mode
+        )
+        native = build_native_settings(
+            nr_preset,
+            nr_style,
+            model_preset,
+            nr_intensity,
+            local_tone_strength,
+            local_structure_strength,
+            skin_structure_strength,
+            automatic_mask,
+        )
+        setup_timeout = float(os.environ.get("DONUT_DLSS5_SETUP_TIMEOUT", "90"))
+        frame_timeout = float(os.environ.get("DONUT_DLSS5_FRAME_TIMEOUT", "600"))
+        close_timeout = float(os.environ.get("DONUT_DLSS5_CLOSE_TIMEOUT", "60"))
+
+        session = Dlss5Session(
+            layout,
+            launch,
+            input_width=int(input_width),
+            input_height=int(input_height),
+            output_width=output_width,
+            output_height=output_height,
+            frame_count=int(batch),
+            warmup_frames=warmup_frames,
+            perf_quality=perf_quality,
+            native_settings=native,
+            setup_timeout=setup_timeout,
+            frame_timeout=frame_timeout,
+            close_timeout=close_timeout,
+        )
+        outputs: list[torch.Tensor] = []
+        try:
+            for index in range(int(batch)):
+                _check_interrupted()
+                rgba = _resize_rgba(
+                    image[index], session.render_width, session.render_height
+                )
+                rendered = session.submit(index, rgba, reset=True)
+                outputs.append(torch.from_numpy(rendered[..., :3].copy()).float().div_(255.0))
+            combined_log, evidence = session.close()
+        except BaseException:
+            session.abort()
+            raise
+
+        result = torch.stack(outputs, dim=0).to(device=image.device, dtype=image.dtype)
+        gpu = probe_host().get("nvidia", "unknown")
+        report_lines = [
+            "VERIFIED: DLSS 5 neural rendering feature 18 executed successfully.",
+            f"Backend: {launch.backend}",
+            f"GPU: {gpu}",
+            f"Input: {input_width}x{input_height} x {batch} frame(s)",
+            f"Render size: {session.render_width}x{session.render_height}",
+            f"Output: {output_width}x{output_height} ({factor:g}x, {mode_name})",
+            f"Model preset: requested {model_preset}, applied {session.applied_model_preset}",
+            f"Worker: {layout.worker}",
+            "Verification evidence:",
+            *(evidence[-12:] or ["Required feature-18 markers were present."]),
+        ]
+        del combined_log
+        return result, "\n".join(report_lines)
+
+
+NODE_CLASS_MAPPINGS = {
+    "DonutDLSS5LinuxStatus": DonutDLSS5LinuxStatus,
+    "DonutDLSS5LinuxUpscale": DonutDLSS5LinuxUpscale,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "DonutDLSS5LinuxStatus": "Donut DLSS 5 Linux Runtime Status (Experimental)",
+    "DonutDLSS5LinuxUpscale": "Donut DLSS 5 Neural Upscale — Linux (Experimental)",
+}

--- a/DonutWeightVectorScale.py
+++ b/DonutWeightVectorScale.py
@@ -71,10 +71,19 @@ class DonutWeightVectorScale:
         return (out,)
 
 
+from .DonutDLSS5Linux import (  # noqa: E402
+    NODE_CLASS_MAPPINGS as _DLSS5_NODE_CLASS_MAPPINGS,
+)
+from .DonutDLSS5Linux import (  # noqa: E402
+    NODE_DISPLAY_NAME_MAPPINGS as _DLSS5_NODE_DISPLAY_NAME_MAPPINGS,
+)
+
 NODE_CLASS_MAPPINGS = {
     "DonutWeightVectorScale": DonutWeightVectorScale,
+    **_DLSS5_NODE_CLASS_MAPPINGS,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "DonutWeightVectorScale": "Donut Weight-Vector Scale",
+    **_DLSS5_NODE_DISPLAY_NAME_MAPPINGS,
 }

--- a/docs/DLSS5_LINUX.md
+++ b/docs/DLSS5_LINUX.md
@@ -1,0 +1,109 @@
+# Experimental DLSS 5 Neural Rendering on Linux
+
+This branch adds two DonutNodes:
+
+- **Donut DLSS 5 Linux Runtime Status (Experimental)** checks the local runtime layout, launcher, NVIDIA visibility, and Vulkan visibility.
+- **Donut DLSS 5 Neural Upscale — Linux (Experimental)** streams ComfyUI images to a user-supplied DLSS 5 feature-18 worker through Proton, Wine, or a future native ELF worker.
+
+The node pack does not include NVIDIA DLLs, ReShade, RenoDX, Proton, Wine, or the native worker. Those files remain under their own licenses and must be obtained legally.
+
+## What was ported
+
+The ComfyUI side is Linux-native Python. The renderer is not recompiled: the currently available feature-18 worker is a Windows PE/D3D12 program, so Linux runs it through Proton or Wine with vkd3d-proton and NVIDIA Vulkan/NVAPI support. A true native port still requires a Linux Vulkan/NGX feature-18 worker and a Linux DLSSNR runtime that is not present in the referenced node repositories.
+
+The bridge speaks the version-4 worker protocol used by current Merserk DLSS 5 Visual Enhancer builds. Every batch item is treated as an independent still image and resets temporal history.
+
+## Required local runtime layout
+
+Point `runtime_dir` at either the portable application root or directly at `bin/runtime`:
+
+```text
+bin/runtime/
+├── host/
+│   ├── nvngx.dll                 # D3D12 worker executable, despite the extension
+│   ├── dxgi.dll                  # ReShade full add-on build
+│   ├── renodx-dlss5.addon64
+│   └── nvngx_dlssnr.dll
+└── dlss/
+    └── nvngx_dlss.dll
+```
+
+The tested layout is the one documented by `Merserk/dlss5-visual-enhancer` v5.0. Do not commit this directory to DonutNodes.
+
+## Linux prerequisites
+
+1. An NVIDIA RTX GPU using the proprietary NVIDIA Linux driver.
+2. `nvidia-smi` must list the GPU.
+3. Vulkan must list that same NVIDIA GPU. Install your distribution's `vulkan-tools` package to make the status node report it.
+4. Proton Experimental, a recent GE-Proton build, or Wine with vkd3d-proton and dxvk-nvapi installed in its prefix.
+5. A legally obtained, internally compatible DLSS 5 runtime bundle.
+
+Proton is the default recommendation because it already packages a matching Wine/vkd3d environment. Plain Wine only works when its prefix has the required D3D12 and NVAPI translation components.
+
+## Node setup
+
+For Proton:
+
+- `backend`: `Proton`
+- `launcher`: full path to Proton's `proton` script, for example a file below `~/.local/share/Steam/compatibilitytools.d/`
+- `prefix`: a writable compat-data directory, such as `~/.local/share/donutnodes/dlss5-proton`
+- `runtime_dir`: the extracted portable root or its `bin/runtime` directory
+
+For Wine:
+
+- `backend`: `Wine`
+- `launcher`: optional full path to `wine64`
+- `prefix`: a Wine prefix containing vkd3d-proton and dxvk-nvapi
+
+`Auto` prefers an ELF worker, then Proton, then Wine.
+
+Equivalent environment variables are:
+
+```bash
+export DONUT_DLSS5_RUNTIME=/path/to/DLSS.5.Visual.Enhancer.v5.0
+export DONUT_DLSS5_PROTON=/path/to/GE-Proton/proton
+export DONUT_DLSS5_PREFIX="$HOME/.local/share/donutnodes/dlss5-proton"
+```
+
+Optional timeout variables:
+
+```bash
+export DONUT_DLSS5_SETUP_TIMEOUT=90
+export DONUT_DLSS5_FRAME_TIMEOUT=600
+export DONUT_DLSS5_CLOSE_TIMEOUT=60
+```
+
+## Verification policy
+
+A returned image is not enough to prove DLSS ran. The upscale node fails unless the current worker/ReShade output contains all three classes of evidence:
+
+1. The signed DLSSNR D3D12 runtime initialized.
+2. NGX feature 18 was created.
+3. Feature 18 evaluation succeeded.
+
+This prevents a conventional resize or runtime fallback from being reported as DLSS 5. Successful output includes the matching evidence lines in `runtime_report`.
+
+## First hardware test
+
+1. Run the Status node and confirm the runtime files, NVIDIA GPU, and Vulkan GPU are all present.
+2. Start with one 512×512 or 768×768 image.
+3. Use `2.0x (Performance)`, default NR preset/style, and model preset `M`.
+4. Queue once and inspect both the output image and `runtime_report`.
+5. If it fails, inspect `bin/runtime/host/ReShade.log`, the ComfyUI console, and any Proton log generated for the prefix.
+
+## Known constraints
+
+- This is an experimental compatibility route, not a claim that NVIDIA officially supports the supplied feature-18 DLL on Linux.
+- Success depends on the exact NVIDIA driver, GPU generation, Proton/Wine build, vkd3d-proton, dxvk-nvapi, RenoDX add-on, worker, and DLSS runtimes.
+- RTX 30-series behavior remains especially experimental.
+- No depth or motion guide is supplied for independent still images; the worker receives zero motion and resets history for each item.
+- The node supports output through the worker's fixed quality modes, not arbitrary scale factors.
+- Static CI validates the Python protocol and failure policy. Only a real RTX Linux run can validate the proprietary runtime.
+
+## Sources and licensing
+
+- `vizart-vj/ComfyUI-AetherScale` and `HECer/ComfyUI-DLSS5` establish the current Windows-only ComfyUI approaches.
+- `Merserk/dlss5-visual-enhancer` documents the portable runtime layout and version-4 worker protocol under the MIT License.
+- `NVIDIA/DLSS`, `NVIDIA-RTX/Streamline`, ReShade, RenoDX, Wine, Proton, vkd3d-proton, and dxvk-nvapi remain separate upstream projects under their own terms.
+
+No upstream runtime binary is redistributed by this branch.

--- a/donut_dlss5_linux.py
+++ b/donut_dlss5_linux.py
@@ -1,8 +1,9 @@
 """Linux launcher and binary protocol for the experimental DLSS 5 worker.
 
-This module does not ship NVIDIA, ReShade, RenoDX, Wine, Proton, or worker
-binaries. It drives a user-supplied Merserk-compatible version-4 worker over
-stdin/stdout. On Linux, PE workers are launched through Proton or Wine.
+No NVIDIA, ReShade, RenoDX, Wine, Proton, or worker binary is distributed here.
+The module drives a user-supplied Merserk-compatible version-4 worker. Windows
+PE workers are launched through Proton or Wine; a future ELF worker can use the
+same protocol through the Native backend.
 """
 
 from __future__ import annotations
@@ -26,7 +27,6 @@ VIDEO_MAGIC = 0x34563544
 SETUP_MAGIC = 0x34505553
 FRAME_MAGIC = 0x314D5246
 OUT_MAGIC = 0x3154554F
-
 VIDEO_HEADER = struct.Struct("<14I4f")
 SETUP_RESPONSE = struct.Struct("<12I")
 FRAME_HEADER = struct.Struct("<4Iq")
@@ -46,7 +46,10 @@ MODEL_PRESETS = {"Default": 0, "J": 10, "K": 11, "L": 12, "M": 13}
 _REQUIRED_MARKERS: tuple[tuple[str, re.Pattern[str]], ...] = (
     (
         "signed DLSSNR D3D12 runtime initialization",
-        re.compile(r"signed\s+DLSSNR(?:\s+[\w.\-]+)?\s+D3D12\s+runtime\s+initialized", re.I),
+        re.compile(
+            r"signed\s+DLSSNR(?:\s+[\w.\-]+)?\s+D3D12\s+runtime\s+initialized",
+            re.I,
+        ),
     ),
     ("feature 18 creation", re.compile(r"feature\s+18\s+created", re.I)),
     (
@@ -57,7 +60,7 @@ _REQUIRED_MARKERS: tuple[tuple[str, re.Pattern[str]], ...] = (
 
 
 class Dlss5LinuxError(RuntimeError):
-    """Raised for an actionable launcher, protocol, or verification failure."""
+    """Actionable launcher, protocol, or verification failure."""
 
 
 @dataclass(frozen=True, slots=True)
@@ -75,40 +78,41 @@ class RuntimeLayout:
     @classmethod
     def discover(cls, raw_path: str | os.PathLike[str] | None) -> "RuntimeLayout":
         value = str(raw_path or os.environ.get("DONUT_DLSS5_RUNTIME", "")).strip()
-        if not value:
-            value = str(Path.home() / ".local" / "share" / "donutnodes" / "dlss5-runtime")
-        supplied = Path(value).expanduser().resolve()
-
-        candidates: list[Path] = []
-        for candidate in (supplied, supplied / "bin" / "runtime", supplied / "runtime"):
-            if candidate not in candidates:
-                candidates.append(candidate)
+        supplied = Path(
+            value
+            or Path.home()
+            / ".local"
+            / "share"
+            / "donutnodes"
+            / "dlss5-runtime"
+        ).expanduser().resolve()
+        candidates = [supplied, supplied / "bin" / "runtime", supplied / "runtime"]
         if supplied.name.lower() == "host":
             candidates.insert(0, supplied.parent)
 
-        selected: Path | None = None
-        for candidate in candidates:
-            if (candidate / "host" / "nvngx.dll").is_file():
-                selected = candidate
-                break
-        if selected is None:
-            checked = "\n  ".join(str(path / "host" / "nvngx.dll") for path in candidates)
+        root = next(
+            (candidate for candidate in candidates if (candidate / "host" / "nvngx.dll").is_file()),
+            None,
+        )
+        if root is None:
+            checked = "\n  ".join(
+                str(candidate / "host" / "nvngx.dll") for candidate in candidates
+            )
             raise Dlss5LinuxError(
-                "Could not find the DLSS 5 worker. Expected a Merserk-compatible runtime at:\n  "
+                "Could not find a Merserk-compatible DLSS 5 worker. Checked:\n  "
                 + checked
             )
 
-        host = selected / "host"
-        dlss = selected / "dlss"
+        host = root / "host"
         layout = cls(
-            root=selected,
+            root=root,
             host=host,
-            dlss=dlss,
+            dlss=root / "dlss",
             worker=host / "nvngx.dll",
             dxgi=host / "dxgi.dll",
             addon=host / "renodx-dlss5.addon64",
             neural_runtime=host / "nvngx_dlssnr.dll",
-            super_resolution_runtime=dlss / "nvngx_dlss.dll",
+            super_resolution_runtime=root / "dlss" / "nvngx_dlss.dll",
             reshade_log=host / "ReShade.log",
         )
         layout.validate()
@@ -117,14 +121,20 @@ class RuntimeLayout:
     def validate(self) -> None:
         required = {
             "D3D12 worker": self.worker,
-            "ReShade add-on build (dxgi.dll)": self.dxgi,
+            "ReShade full add-on build": self.dxgi,
             "RenoDX DLSS 5 add-on": self.addon,
             "DLSS neural-rendering runtime": self.neural_runtime,
             "DLSS Super Resolution runtime": self.super_resolution_runtime,
         }
-        missing = [f"{label}: {path}" for label, path in required.items() if not path.is_file()]
+        missing = [
+            f"{label}: {path}"
+            for label, path in required.items()
+            if not path.is_file()
+        ]
         if missing:
-            raise Dlss5LinuxError("The runtime bundle is incomplete:\n" + "\n".join(missing))
+            raise Dlss5LinuxError(
+                "The DLSS 5 runtime bundle is incomplete:\n" + "\n".join(missing)
+            )
 
 
 @dataclass(frozen=True, slots=True)
@@ -156,21 +166,21 @@ def _find_proton() -> Path | None:
     configured = os.environ.get("DONUT_DLSS5_PROTON", "").strip()
     if configured and Path(configured).expanduser().is_file():
         return Path(configured).expanduser().resolve()
-
     direct = shutil.which("proton")
     if direct:
         return Path(direct).resolve()
 
-    roots = (
+    matches: list[Path] = []
+    for root in (
         Path.home() / ".steam" / "root",
         Path.home() / ".local" / "share" / "Steam",
-    )
-    matches: list[Path] = []
-    for root in roots:
+    ):
         matches.extend((root / "compatibilitytools.d").glob("*/proton"))
         matches.extend((root / "steamapps" / "common").glob("Proton*/proton"))
-    valid = sorted((path.resolve() for path in matches if path.is_file()), reverse=True)
-    return valid[0] if valid else None
+    usable = sorted(
+        (path.resolve() for path in matches if path.is_file()), reverse=True
+    )
+    return usable[0] if usable else None
 
 
 def _find_wine() -> Path | None:
@@ -178,20 +188,29 @@ def _find_wine() -> Path | None:
     if configured and Path(configured).expanduser().is_file():
         return Path(configured).expanduser().resolve()
     for name in ("wine64", "wine"):
-        found = shutil.which(name)
-        if found:
-            return Path(found).resolve()
+        executable = shutil.which(name)
+        if executable:
+            return Path(executable).resolve()
     return None
 
 
 def _append_dll_overrides(existing: str) -> str:
     values = [item.strip() for item in existing.split(";") if item.strip()]
-    lowered = {item.split("=", 1)[0].lower() for item in values}
-    if "dxgi" not in lowered:
+    names = {item.split("=", 1)[0].lower() for item in values}
+    if "dxgi" not in names:
         values.append("dxgi=n,b")
-    if "nvapi64" not in lowered:
+    if "nvapi64" not in names:
         values.append("nvapi64=n,b")
     return ";".join(values)
+
+
+def _classify_launcher(path: Path) -> str | None:
+    name = path.name.lower()
+    if "proton" in name:
+        return "proton"
+    if "wine" in name:
+        return "wine"
+    return None
 
 
 def resolve_launch_config(
@@ -200,59 +219,66 @@ def resolve_launch_config(
     prefix: str,
     worker: Path,
 ) -> LaunchConfig:
-    requested = (backend or os.environ.get("DONUT_DLSS5_BACKEND", "Auto")).strip().lower()
+    requested = (
+        backend or os.environ.get("DONUT_DLSS5_BACKEND", "Auto")
+    ).strip().lower()
     if requested not in {"auto", "proton", "wine", "native"}:
-        raise Dlss5LinuxError(f"Unknown backend {backend!r}; choose Auto, Proton, Wine, or Native.")
+        raise Dlss5LinuxError(
+            f"Unknown backend {backend!r}; choose Auto, Proton, Wine, or Native."
+        )
 
     worker_kind = _binary_kind(worker)
-    explicit_launcher = Path(launcher).expanduser().resolve() if launcher.strip() else None
-    proton = explicit_launcher if requested == "proton" else _find_proton()
-    wine = explicit_launcher if requested == "wine" else _find_wine()
+    explicit = Path(launcher).expanduser().resolve() if launcher.strip() else None
+    if explicit is not None and not explicit.is_file():
+        raise Dlss5LinuxError(f"The selected launcher does not exist: {explicit}")
 
+    proton = _find_proton()
+    wine = _find_wine()
     chosen = requested
     if chosen == "auto":
+        inferred = _classify_launcher(explicit) if explicit else None
         if worker_kind == "elf":
             chosen = "native"
-        elif platform.system() == "Linux" and proton is not None:
+        elif inferred:
+            chosen = inferred
+        elif platform.system() == "Linux" and proton:
             chosen = "proton"
-        elif platform.system() == "Linux" and wine is not None:
+        elif platform.system() == "Linux" and wine:
             chosen = "wine"
         else:
             raise Dlss5LinuxError(
-                "The worker is a Windows PE file, but neither Proton nor Wine was found. "
-                "Set the launcher input or DONUT_DLSS5_PROTON/DONUT_DLSS5_WINE."
+                "The supplied worker is a Windows PE image, but Proton/Wine was not "
+                "found. Set launcher or DONUT_DLSS5_PROTON/DONUT_DLSS5_WINE."
             )
 
     env = os.environ.copy()
     env["DXVK_ENABLE_NVAPI"] = "1"
-    env["PROTON_ENABLE_NVAPI"] = "1"
     env["PROTON_FORCE_NVAPI"] = "1"
     env.pop("PROTON_HIDE_NVIDIA_GPU", None)
-    env["WINEDLLOVERRIDES"] = _append_dll_overrides(env.get("WINEDLLOVERRIDES", ""))
-
+    env["WINEDLLOVERRIDES"] = _append_dll_overrides(
+        env.get("WINEDLLOVERRIDES", "")
+    )
     prefix_value = prefix.strip() or os.environ.get("DONUT_DLSS5_PREFIX", "").strip()
     prefix_path: Path | None = None
 
     if chosen == "native":
         if worker_kind != "elf":
             raise Dlss5LinuxError(
-                f"Native mode requires an ELF worker; {worker} is {worker_kind}. "
-                "Use Proton or Wine for the supplied Windows worker."
+                f"Native mode requires an ELF worker; {worker} is {worker_kind}."
             )
         if not os.access(worker, os.X_OK):
             raise Dlss5LinuxError(f"Native worker is not executable: {worker}")
         command_prefix: tuple[str, ...] = ()
     elif chosen == "proton":
-        proton = explicit_launcher or proton
-        if proton is None or not proton.is_file():
+        executable = explicit or proton
+        if executable is None:
             raise Dlss5LinuxError("Proton mode selected, but no Proton script was found.")
         prefix_path = Path(prefix_value).expanduser().resolve() if prefix_value else (
             Path.home() / ".local" / "share" / "donutnodes" / "dlss5-proton"
         )
         prefix_path.mkdir(parents=True, exist_ok=True)
         env["STEAM_COMPAT_DATA_PATH"] = str(prefix_path)
-        steam_root = os.environ.get("STEAM_COMPAT_CLIENT_INSTALL_PATH", "").strip()
-        if not steam_root:
+        if not env.get("STEAM_COMPAT_CLIENT_INSTALL_PATH"):
             for candidate in (
                 Path.home() / ".steam" / "root",
                 Path.home() / ".local" / "share" / "Steam",
@@ -260,17 +286,17 @@ def resolve_launch_config(
                 if candidate.is_dir():
                     env["STEAM_COMPAT_CLIENT_INSTALL_PATH"] = str(candidate.resolve())
                     break
-        command_prefix = (str(proton), "run")
+        command_prefix = (str(executable), "run")
     else:
-        wine = explicit_launcher or wine
-        if wine is None or not wine.is_file():
+        executable = explicit or wine
+        if executable is None:
             raise Dlss5LinuxError("Wine mode selected, but wine64/wine was not found.")
         prefix_path = Path(prefix_value).expanduser().resolve() if prefix_value else (
             Path.home() / ".local" / "share" / "donutnodes" / "dlss5-wineprefix"
         )
         prefix_path.mkdir(parents=True, exist_ok=True)
         env["WINEPREFIX"] = str(prefix_path)
-        command_prefix = (str(wine),)
+        command_prefix = (str(executable),)
 
     return LaunchConfig(
         backend=chosen.capitalize(),
@@ -281,22 +307,25 @@ def resolve_launch_config(
     )
 
 
-def resolve_output_size(width: int, height: int, mode_label: str) -> tuple[int, int, float, int, str]:
+def resolve_output_size(
+    width: int, height: int, mode_label: str
+) -> tuple[int, int, float, int, str]:
     try:
-        factor, perf_quality, mode_name = UPSCALE_MODES[mode_label]
+        factor, quality, mode_name = UPSCALE_MODES[mode_label]
     except KeyError as exc:
         raise Dlss5LinuxError(f"Unknown upscaling mode: {mode_label!r}") from exc
 
     def even(value: float) -> int:
         return max(2, int(value / 2.0 + 0.5) * 2)
 
-    output_width = even(width * factor)
-    output_height = even(height * factor)
-    if max(output_width, output_height) > 7680 or min(output_width, output_height) > 4320:
+    output_width, output_height = even(width * factor), even(height * factor)
+    if max(output_width, output_height) > 7680 or min(
+        output_width, output_height
+    ) > 4320:
         raise Dlss5LinuxError(
-            f"Requested output {output_width}x{output_height} exceeds the supported 7680x4320 boundary."
+            f"Requested output {output_width}x{output_height} exceeds 7680x4320."
         )
-    return output_width, output_height, factor, perf_quality, mode_name
+    return output_width, output_height, factor, quality, mode_name
 
 
 def build_native_settings(
@@ -309,63 +338,74 @@ def build_native_settings(
     skin_structure: float,
     automatic_mask: bool,
 ) -> dict[str, int | float]:
-    for name, value, table in (
+    for label, value, table in (
         ("NR preset", nr_preset, NR_PRESETS),
         ("NR style", nr_style, NR_STYLES),
         ("model preset", model_preset, MODEL_PRESETS),
     ):
         if value not in table:
-            raise Dlss5LinuxError(f"Unknown {name}: {value!r}")
-    ranges = {
+            raise Dlss5LinuxError(f"Unknown {label}: {value!r}")
+    controls = {
         "intensity": (float(intensity), 0.0, 2.0),
         "local_tone": (float(local_tone), 0.0, 2.0),
         "local_structure": (float(local_structure), 0.0, 2.0),
         "skin_structure": (float(skin_structure), -1.0, 2.0),
     }
-    for name, (value, low, high) in ranges.items():
+    for label, (value, low, high) in controls.items():
         if not low <= value <= high:
-            raise Dlss5LinuxError(f"{name} must be between {low:g} and {high:g}.")
+            raise Dlss5LinuxError(f"{label} must be between {low:g} and {high:g}.")
     return {
         "profile": 0,
         "preset": NR_PRESETS[nr_preset],
         "style": NR_STYLES[nr_style],
         "auto_mask": int(bool(automatic_mask)),
         "ui_correction": 0,
-        "intensity": ranges["intensity"][0],
-        "local_tone": ranges["local_tone"][0],
-        "local_structure": ranges["local_structure"][0],
-        "skin_structure": ranges["skin_structure"][0],
+        "intensity": controls["intensity"][0],
+        "local_tone": controls["local_tone"][0],
+        "local_structure": controls["local_structure"][0],
+        "skin_structure": controls["skin_structure"][0],
         "dlss_model_preset": MODEL_PRESETS[model_preset],
     }
 
 
 def verify_feature_18(text: str) -> list[str]:
-    missing = [label for label, pattern in _REQUIRED_MARKERS if pattern.search(text) is None]
+    missing = [
+        label for label, pattern in _REQUIRED_MARKERS if pattern.search(text) is None
+    ]
     if missing:
         evidence = "\n".join(
             line
             for line in text.splitlines()
-            if any(token in line.lower() for token in ("dlssnr", "feature 18", "neural rendering", "error", "failed"))
+            if any(
+                token in line.lower()
+                for token in (
+                    "dlssnr",
+                    "feature 18",
+                    "neural rendering",
+                    "error",
+                    "failed",
+                )
+            )
         )
         raise Dlss5LinuxError(
-            "The worker returned pixels, but real DLSS 5 feature-18 execution was not verified. "
-            "Missing: "
+            "Pixels were returned, but real DLSS 5 feature-18 execution was not "
+            "verified. Missing: "
             + ", ".join(missing)
             + ("\nRelevant runtime output:\n" + evidence[-8000:] if evidence else "")
         )
-    return [line for line in text.splitlines() if "feature 18" in line.lower() or "signed dlssnr" in line.lower()]
+    return [
+        line
+        for line in text.splitlines()
+        if "feature 18" in line.lower() or "signed dlssnr" in line.lower()
+    ]
 
 
 def probe_host() -> dict[str, str]:
-    report: dict[str, str] = {
-        "platform": platform.platform(),
-        "nvidia": "not checked",
-        "vulkan": "not checked",
-    }
+    report = {"platform": platform.platform(), "nvidia": "not checked", "vulkan": "not checked"}
     nvidia_smi = shutil.which("nvidia-smi")
     if nvidia_smi:
         try:
-            proc = subprocess.run(
+            result = subprocess.run(
                 [
                     nvidia_smi,
                     "--query-gpu=name,driver_version,memory.total",
@@ -376,7 +416,9 @@ def probe_host() -> dict[str, str]:
                 timeout=15,
                 check=False,
             )
-            report["nvidia"] = proc.stdout.strip() if proc.returncode == 0 else proc.stderr.strip()
+            report["nvidia"] = (
+                result.stdout.strip() if result.returncode == 0 else result.stderr.strip()
+            )
         except (OSError, subprocess.TimeoutExpired) as exc:
             report["nvidia"] = str(exc)
     else:
@@ -385,107 +427,115 @@ def probe_host() -> dict[str, str]:
     vulkaninfo = shutil.which("vulkaninfo")
     if vulkaninfo:
         try:
-            proc = subprocess.run(
+            result = subprocess.run(
                 [vulkaninfo, "--summary"],
                 capture_output=True,
                 text=True,
                 timeout=20,
                 check=False,
             )
-            lines = [line.strip() for line in proc.stdout.splitlines() if "deviceName" in line]
-            report["vulkan"] = "; ".join(lines) if lines else (
-                "available" if proc.returncode == 0 else proc.stderr.strip()
+            devices = [
+                line.strip()
+                for line in result.stdout.splitlines()
+                if "deviceName" in line
+            ]
+            report["vulkan"] = "; ".join(devices) if devices else (
+                "available" if result.returncode == 0 else result.stderr.strip()
             )
         except (OSError, subprocess.TimeoutExpired) as exc:
             report["vulkan"] = str(exc)
     else:
-        report["vulkan"] = "vulkaninfo not found (install vulkan-tools for this diagnostic)"
+        report["vulkan"] = "vulkaninfo not found; install vulkan-tools"
     return report
 
 
-def _read_exact(stream: BinaryIO, size: int, timeout: float, label: str) -> bytes:
-    deadline = time.monotonic() + timeout
-    chunks = bytearray()
-    fd = stream.fileno()
-    while len(chunks) < size:
+class _BufferedPipeReader:
+    """Timeout-aware pipe reader that retains bytes read past a protocol header."""
+
+    def __init__(self, stream: BinaryIO) -> None:
+        self.fd = stream.fileno()
+        self._buffer = bytearray()
+        self._discarded_prefix = bytearray()
+
+    def _read_more(self, deadline: float, label: str, minimum: int = 1) -> None:
         remaining = deadline - time.monotonic()
         if remaining <= 0:
-            raise Dlss5LinuxError(f"Timed out while reading {label} ({len(chunks)}/{size} bytes).")
-        ready, _, _ = select.select([fd], [], [], remaining)
-        if not ready:
-            raise Dlss5LinuxError(f"Timed out while reading {label} ({len(chunks)}/{size} bytes).")
-        block = os.read(fd, size - len(chunks))
+            raise Dlss5LinuxError(f"Timed out while reading {label}.")
+        readable, _, _ = select.select([self.fd], [], [], remaining)
+        if not readable:
+            raise Dlss5LinuxError(f"Timed out while reading {label}.")
+        block = os.read(self.fd, max(4096, minimum))
         if not block:
-            raise EOFError(f"Worker stopped while reading {label} ({len(chunks)}/{size} bytes).")
-        chunks.extend(block)
-    return bytes(chunks)
+            raise EOFError(f"Worker stopped while reading {label}.")
+        self._buffer.extend(block)
 
+    def read_exact(self, size: int, timeout: float, label: str) -> bytes:
+        deadline = time.monotonic() + timeout
+        while len(self._buffer) < size:
+            self._read_more(deadline, label, size - len(self._buffer))
+        payload = bytes(self._buffer[:size])
+        del self._buffer[:size]
+        return payload
 
-def _read_struct_with_magic(
-    stream: BinaryIO,
-    structure: struct.Struct,
-    magic: int,
-    timeout: float,
-    label: str,
-    max_prefix: int = 65536,
-) -> bytes:
-    """Read a binary response while tolerating limited launcher chatter on stdout."""
-    marker = struct.pack("<I", magic)
-    deadline = time.monotonic() + timeout
-    buffer = bytearray()
-    fd = stream.fileno()
-    while True:
-        location = buffer.find(marker)
-        if location >= 0:
-            needed = location + structure.size
-            if len(buffer) >= needed:
-                return bytes(buffer[location:needed])
-        if len(buffer) > max_prefix:
-            preview = bytes(buffer[:200]).decode("utf-8", errors="replace")
-            raise Dlss5LinuxError(f"Could not find {label} magic after launcher output: {preview!r}")
-        remaining = deadline - time.monotonic()
-        if remaining <= 0:
-            raise Dlss5LinuxError(f"Timed out waiting for {label}.")
-        ready, _, _ = select.select([fd], [], [], remaining)
-        if not ready:
-            raise Dlss5LinuxError(f"Timed out waiting for {label}.")
-        block = os.read(fd, max(1, min(4096, structure.size + 256)))
-        if not block:
-            raise EOFError(f"Worker stopped before sending {label}.")
-        buffer.extend(block)
+    def read_struct_with_magic(
+        self,
+        structure: struct.Struct,
+        magic: int,
+        timeout: float,
+        label: str,
+        max_prefix: int = 65536,
+    ) -> bytes:
+        marker = struct.pack("<I", magic)
+        deadline = time.monotonic() + timeout
+        while True:
+            location = self._buffer.find(marker)
+            if location >= 0 and len(self._buffer) >= location + structure.size:
+                if location:
+                    self._discarded_prefix.extend(self._buffer[:location])
+                    del self._buffer[:location]
+                payload = bytes(self._buffer[: structure.size])
+                del self._buffer[: structure.size]
+                return payload
+            if len(self._buffer) > max_prefix and location < 0:
+                preview = bytes(self._buffer[:200]).decode("utf-8", errors="replace")
+                raise Dlss5LinuxError(
+                    f"Could not find {label} magic after launcher output: {preview!r}"
+                )
+            self._read_more(deadline, label, structure.size)
+
+    def discarded_text(self) -> str:
+        return bytes(self._discarded_prefix).decode("utf-8", errors="replace").strip()
 
 
 class _LogCollector:
     def __init__(self, stream: BinaryIO | None, limit: int = 800) -> None:
-        self._stream = stream
-        self._limit = limit
-        self._lines: list[str] = []
-        self._lock = threading.Lock()
-        self._thread = threading.Thread(target=self._run, name="donut-dlss5-log", daemon=True)
-        self._thread.start()
+        self.stream = stream
+        self.limit = limit
+        self.lines: list[str] = []
+        self.lock = threading.Lock()
+        self.thread = threading.Thread(target=self._run, daemon=True)
+        self.thread.start()
 
     def _run(self) -> None:
-        if self._stream is None:
+        if self.stream is None:
             return
         try:
-            for raw in iter(self._stream.readline, b""):
+            for raw in iter(self.stream.readline, b""):
                 line = raw.decode("utf-8", errors="replace").rstrip()
-                if not line:
-                    continue
-                with self._lock:
-                    self._lines.append(line)
-                    if len(self._lines) > self._limit:
-                        del self._lines[: len(self._lines) - self._limit]
+                if line:
+                    with self.lock:
+                        self.lines.append(line)
+                        del self.lines[: max(0, len(self.lines) - self.limit)]
         except (OSError, ValueError):
             pass
 
-    def join(self, timeout: float = 2.0) -> None:
-        if self._thread.ident is not None:
-            self._thread.join(timeout)
+    def join(self) -> None:
+        if self.thread.ident is not None:
+            self.thread.join(timeout=2)
 
     def text(self) -> str:
-        with self._lock:
-            return "\n".join(self._lines)
+        with self.lock:
+            return "\n".join(self.lines)
 
 
 class Dlss5Session:
@@ -508,19 +558,14 @@ class Dlss5Session:
         frame_timeout: float = 600.0,
         close_timeout: float = 60.0,
     ) -> None:
-        self.layout = layout
-        self.launch = launch
-        self.output_width = output_width
-        self.output_height = output_height
-        self.frame_timeout = frame_timeout
-        self.close_timeout = close_timeout
-        self._closed = False
-        self._started = time.time() - 2.0
-
-        command = launch.command(layout.worker)
+        self.layout, self.launch = layout, launch
+        self.output_width, self.output_height = output_width, output_height
+        self.frame_timeout, self.close_timeout = frame_timeout, close_timeout
+        self.closed = False
+        self.started = time.time() - 2.0
         try:
             self.process = subprocess.Popen(
-                command,
+                launch.command(layout.worker),
                 cwd=str(layout.host),
                 env=launch.env,
                 stdin=subprocess.PIPE,
@@ -529,19 +574,23 @@ class Dlss5Session:
                 bufsize=0,
             )
         except OSError as exc:
-            raise Dlss5LinuxError(f"Could not start {launch.backend} worker: {exc}\nCommand: {command}") from exc
+            raise Dlss5LinuxError(
+                f"Could not start {launch.backend} worker: {exc}"
+            ) from exc
         self.logs = _LogCollector(self.process.stderr)
+        assert self.process.stdin is not None and self.process.stdout is not None
+        self.reader = _BufferedPipeReader(self.process.stdout)
 
         native = native_settings
         header = VIDEO_HEADER.pack(
             VIDEO_MAGIC,
-            int(input_width),
-            int(input_height),
-            int(output_width),
-            int(output_height),
-            max(0, int(warmup_frames)),
-            max(1, int(frame_count)),
-            int(perf_quality),
+            input_width,
+            input_height,
+            output_width,
+            output_height,
+            max(0, warmup_frames),
+            max(1, frame_count),
+            perf_quality,
             int(native["dlss_model_preset"]),
             int(native["profile"]),
             int(native["preset"]),
@@ -554,13 +603,16 @@ class Dlss5Session:
             float(native["skin_structure"]),
         )
         try:
-            assert self.process.stdin is not None and self.process.stdout is not None
             self.process.stdin.write(header)
             self.process.stdin.flush()
-            payload = _read_struct_with_magic(
-                self.process.stdout, SETUP_RESPONSE, SETUP_MAGIC, setup_timeout, "setup response"
+            response = SETUP_RESPONSE.unpack(
+                self.reader.read_struct_with_magic(
+                    SETUP_RESPONSE,
+                    SETUP_MAGIC,
+                    setup_timeout,
+                    "setup response",
+                )
             )
-            fields = SETUP_RESPONSE.unpack(payload)
             (
                 _magic,
                 ok,
@@ -574,82 +626,122 @@ class Dlss5Session:
                 self.maximum_width,
                 self.maximum_height,
                 self.applied_model_preset,
-            ) = fields
+            ) = response
             if not ok:
                 raise Dlss5LinuxError(
                     f"DLSS setup failed with NGX result 0x{result:08X}.\n{self.logs.text()}"
                 )
-            if (negotiated_width, negotiated_height) != (output_width, output_height):
+            if (negotiated_width, negotiated_height) != (
+                output_width,
+                output_height,
+            ):
                 raise Dlss5LinuxError(
-                    f"Worker negotiated {negotiated_width}x{negotiated_height}, expected "
-                    f"{output_width}x{output_height}."
+                    f"Worker negotiated {negotiated_width}x{negotiated_height}; "
+                    f"expected {output_width}x{output_height}."
                 )
-            if self.render_width < 64 or self.render_height < 64:
+            if min(self.render_width, self.render_height) < 64:
                 raise Dlss5LinuxError(
-                    f"Worker returned invalid render size {self.render_width}x{self.render_height}."
+                    f"Invalid render size {self.render_width}x{self.render_height}."
                 )
-            requested = int(native["dlss_model_preset"])
-            if self.applied_model_preset != requested:
+            requested_model = int(native["dlss_model_preset"])
+            if self.applied_model_preset != requested_model:
                 raise Dlss5LinuxError(
-                    f"Worker applied model preset {self.applied_model_preset}, requested {requested}."
+                    f"Worker applied model {self.applied_model_preset}; "
+                    f"requested {requested_model}."
                 )
-            self._zero_motion = np.zeros(
+            self.zero_motion = np.zeros(
                 (self.render_height, self.render_width, 2), dtype=np.float16
-            ).tobytes(order="C")
+            ).tobytes()
         except BaseException:
             self.abort()
             raise
 
-    def submit(self, index: int, rgba: np.ndarray, *, reset: bool = True, pts: int | None = None) -> np.ndarray:
-        if self._closed:
-            raise Dlss5LinuxError("DLSS session is already closed.")
+    def submit(
+        self,
+        index: int,
+        rgba: np.ndarray,
+        *,
+        reset: bool = True,
+        pts: int | None = None,
+    ) -> np.ndarray:
+        if self.closed:
+            raise Dlss5LinuxError("DLSS session is closed.")
         expected_shape = (self.render_height, self.render_width, 4)
-        if rgba.shape != expected_shape or rgba.dtype != np.uint8:
+        if rgba.dtype != np.uint8 or rgba.shape != expected_shape:
             raise Dlss5LinuxError(
-                f"Worker input must be uint8 RGBA {expected_shape}; got {rgba.dtype} {rgba.shape}."
+                f"Expected uint8 RGBA {expected_shape}; got {rgba.dtype} {rgba.shape}."
             )
-        pts_value = index if pts is None else int(pts)
-        assert self.process.stdin is not None and self.process.stdout is not None
+        assert self.process.stdin is not None
         try:
-            self.process.stdin.write(FRAME_HEADER.pack(FRAME_MAGIC, index, int(reset), 0, pts_value))
-            self.process.stdin.write(memoryview(np.ascontiguousarray(rgba)).cast("B"))
-            self.process.stdin.write(self._zero_motion)
-            self.process.stdin.flush()
-            response = _read_struct_with_magic(
-                self.process.stdout,
-                RESULT_HEADER,
-                OUT_MAGIC,
-                self.frame_timeout,
-                f"frame {index} response",
-                max_prefix=8192,
-            )
-            magic, out_index, ok, byte_count, ngx_result, _out_pts = RESULT_HEADER.unpack(response)
-            expected_bytes = self.output_width * self.output_height * 4
-            if magic != OUT_MAGIC or not ok or out_index != index or byte_count != expected_bytes:
-                raise Dlss5LinuxError(
-                    f"Malformed worker response for frame {index}: index={out_index}, ok={ok}, "
-                    f"bytes={byte_count}/{expected_bytes}."
+            self.process.stdin.write(
+                FRAME_HEADER.pack(
+                    FRAME_MAGIC,
+                    index,
+                    int(reset),
+                    0,
+                    index if pts is None else pts,
                 )
+            )
+            self.process.stdin.write(memoryview(np.ascontiguousarray(rgba)).cast("B"))
+            self.process.stdin.write(self.zero_motion)
+            self.process.stdin.flush()
+            response = RESULT_HEADER.unpack(
+                self.reader.read_struct_with_magic(
+                    RESULT_HEADER,
+                    OUT_MAGIC,
+                    self.frame_timeout,
+                    f"frame {index} response",
+                    max_prefix=8192,
+                )
+            )
+            magic, out_index, ok, byte_count, ngx_result, _out_pts = response
+            expected_bytes = self.output_width * self.output_height * 4
+            if (
+                magic != OUT_MAGIC
+                or not ok
+                or out_index != index
+                or byte_count != expected_bytes
+            ):
+                raise Dlss5LinuxError(f"Malformed worker response for frame {index}.")
             if ngx_result != 1:
                 raise Dlss5LinuxError(
-                    f"DLSS feature-18 evaluation failed on frame {index}: 0x{ngx_result:08X}."
+                    f"Feature-18 evaluation failed: 0x{ngx_result:08X}."
                 )
-            raw = _read_exact(
-                self.process.stdout, expected_bytes, self.frame_timeout, f"frame {index} pixels"
+            pixels = self.reader.read_exact(
+                expected_bytes,
+                self.frame_timeout,
+                f"frame {index} pixels",
             )
-            return np.frombuffer(raw, dtype=np.uint8).reshape(
+            return np.frombuffer(pixels, dtype=np.uint8).reshape(
                 self.output_height, self.output_width, 4
             ).copy()
         except (BrokenPipeError, EOFError, OSError) as exc:
             raise Dlss5LinuxError(
-                f"The {self.launch.backend} worker stopped on frame {index}: {exc}\n{self.logs.text()}"
+                f"The {self.launch.backend} worker stopped on frame {index}: {exc}\n"
+                f"{self.logs.text()}"
             ) from exc
 
+    def _combined_log(self) -> str:
+        parts = [self.logs.text(), self.reader.discarded_text()]
+        try:
+            if (
+                self.layout.reshade_log.is_file()
+                and self.layout.reshade_log.stat().st_mtime >= self.started
+            ):
+                parts.append(
+                    self.layout.reshade_log.read_text(
+                        encoding="utf-8", errors="replace"
+                    )
+                )
+        except OSError:
+            pass
+        return "\n".join(part for part in parts if part)
+
     def close(self) -> tuple[str, list[str]]:
-        if self._closed:
+        if self.closed:
             return self._combined_log(), []
-        self._closed = True
-        if self.process.stdin is not None and not self.process.stdin.closed:
+        self.closed = True
+        if self.process.stdin and not self.process.stdin.closed:
             self.process.stdin.close()
         try:
             code = self.process.wait(timeout=self.close_timeout)
@@ -657,29 +749,19 @@ class Dlss5Session:
             self.process.kill()
             self.process.wait(timeout=10)
             self.logs.join()
-            raise Dlss5LinuxError("DLSS worker did not exit after the input stream closed.") from exc
+            raise Dlss5LinuxError("DLSS worker did not exit and was killed.") from exc
         self.logs.join()
         if code:
             raise Dlss5LinuxError(
                 f"DLSS worker exited with code {code}.\n{self._combined_log()}"
             )
         combined = self._combined_log()
-        evidence = verify_feature_18(combined)
-        return combined, evidence
-
-    def _combined_log(self) -> str:
-        parts = [self.logs.text()]
-        try:
-            if self.layout.reshade_log.is_file() and self.layout.reshade_log.stat().st_mtime >= self._started:
-                parts.append(self.layout.reshade_log.read_text(encoding="utf-8", errors="replace"))
-        except OSError:
-            pass
-        return "\n".join(part for part in parts if part)
+        return combined, verify_feature_18(combined)
 
     def abort(self) -> None:
-        if self._closed:
+        if self.closed:
             return
-        self._closed = True
+        self.closed = True
         if self.process.poll() is None:
             try:
                 self.process.terminate()
@@ -691,26 +773,12 @@ class Dlss5Session:
                     pass
         self.logs.join()
 
-    def __enter__(self) -> "Dlss5Session":
-        return self
 
-    def __exit__(self, exc_type, exc, traceback) -> None:
-        if exc_type is None:
-            self.close()
-        else:
-            self.abort()
-
-
-def last_relevant_lines(text: str, limit: int = 30) -> list[str]:
-    lines = [
-        line
-        for line in text.splitlines()
-        if any(token in line.lower() for token in ("dlssnr", "feature 18", "neural rendering", "error", "failed"))
-    ]
-    return lines[-limit:]
-
-
-def format_status(layout: RuntimeLayout, launch: LaunchConfig, host: dict[str, str]) -> str:
+def format_status(
+    layout: RuntimeLayout,
+    launch: LaunchConfig,
+    host: dict[str, str],
+) -> str:
     fields: Iterable[tuple[str, object]] = (
         ("Backend", launch.backend),
         ("Worker kind", launch.worker_kind),

--- a/donut_dlss5_linux.py
+++ b/donut_dlss5_linux.py
@@ -1,0 +1,727 @@
+"""Linux launcher and binary protocol for the experimental DLSS 5 worker.
+
+This module does not ship NVIDIA, ReShade, RenoDX, Wine, Proton, or worker
+binaries. It drives a user-supplied Merserk-compatible version-4 worker over
+stdin/stdout. On Linux, PE workers are launched through Proton or Wine.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import re
+import select
+import shutil
+import struct
+import subprocess
+import threading
+import time
+from dataclasses import dataclass
+from pathlib import Path
+from typing import BinaryIO, Iterable
+
+import numpy as np
+
+VIDEO_MAGIC = 0x34563544
+SETUP_MAGIC = 0x34505553
+FRAME_MAGIC = 0x314D5246
+OUT_MAGIC = 0x3154554F
+
+VIDEO_HEADER = struct.Struct("<14I4f")
+SETUP_RESPONSE = struct.Struct("<12I")
+FRAME_HEADER = struct.Struct("<4Iq")
+RESULT_HEADER = struct.Struct("<5Iq")
+
+UPSCALE_MODES: dict[str, tuple[float, int, str]] = {
+    "1.0x (DLAA / native)": (1.0, 5, "DLAA"),
+    "1.5x (Quality)": (1.5, 2, "Quality"),
+    "1.724x (Balanced)": (1.724, 1, "Balanced"),
+    "2.0x (Performance)": (2.0, 0, "Performance"),
+    "3.0x (Ultra Performance)": (3.0, 3, "Ultra Performance"),
+}
+NR_PRESETS = {"Default": 0, "Preset #1": 1, "Preset #2": 2, "Preset #3": 3}
+NR_STYLES = {"Default": 0, "Natural": 1, "Cinematic": 2}
+MODEL_PRESETS = {"Default": 0, "J": 10, "K": 11, "L": 12, "M": 13}
+
+_REQUIRED_MARKERS: tuple[tuple[str, re.Pattern[str]], ...] = (
+    (
+        "signed DLSSNR D3D12 runtime initialization",
+        re.compile(r"signed\s+DLSSNR(?:\s+[\w.\-]+)?\s+D3D12\s+runtime\s+initialized", re.I),
+    ),
+    ("feature 18 creation", re.compile(r"feature\s+18\s+created", re.I)),
+    (
+        "feature 18 evaluation",
+        re.compile(r"feature\s+18.*(?:evaluation|evaluate).*succeed", re.I),
+    ),
+)
+
+
+class Dlss5LinuxError(RuntimeError):
+    """Raised for an actionable launcher, protocol, or verification failure."""
+
+
+@dataclass(frozen=True, slots=True)
+class RuntimeLayout:
+    root: Path
+    host: Path
+    dlss: Path
+    worker: Path
+    dxgi: Path
+    addon: Path
+    neural_runtime: Path
+    super_resolution_runtime: Path
+    reshade_log: Path
+
+    @classmethod
+    def discover(cls, raw_path: str | os.PathLike[str] | None) -> "RuntimeLayout":
+        value = str(raw_path or os.environ.get("DONUT_DLSS5_RUNTIME", "")).strip()
+        if not value:
+            value = str(Path.home() / ".local" / "share" / "donutnodes" / "dlss5-runtime")
+        supplied = Path(value).expanduser().resolve()
+
+        candidates: list[Path] = []
+        for candidate in (supplied, supplied / "bin" / "runtime", supplied / "runtime"):
+            if candidate not in candidates:
+                candidates.append(candidate)
+        if supplied.name.lower() == "host":
+            candidates.insert(0, supplied.parent)
+
+        selected: Path | None = None
+        for candidate in candidates:
+            if (candidate / "host" / "nvngx.dll").is_file():
+                selected = candidate
+                break
+        if selected is None:
+            checked = "\n  ".join(str(path / "host" / "nvngx.dll") for path in candidates)
+            raise Dlss5LinuxError(
+                "Could not find the DLSS 5 worker. Expected a Merserk-compatible runtime at:\n  "
+                + checked
+            )
+
+        host = selected / "host"
+        dlss = selected / "dlss"
+        layout = cls(
+            root=selected,
+            host=host,
+            dlss=dlss,
+            worker=host / "nvngx.dll",
+            dxgi=host / "dxgi.dll",
+            addon=host / "renodx-dlss5.addon64",
+            neural_runtime=host / "nvngx_dlssnr.dll",
+            super_resolution_runtime=dlss / "nvngx_dlss.dll",
+            reshade_log=host / "ReShade.log",
+        )
+        layout.validate()
+        return layout
+
+    def validate(self) -> None:
+        required = {
+            "D3D12 worker": self.worker,
+            "ReShade add-on build (dxgi.dll)": self.dxgi,
+            "RenoDX DLSS 5 add-on": self.addon,
+            "DLSS neural-rendering runtime": self.neural_runtime,
+            "DLSS Super Resolution runtime": self.super_resolution_runtime,
+        }
+        missing = [f"{label}: {path}" for label, path in required.items() if not path.is_file()]
+        if missing:
+            raise Dlss5LinuxError("The runtime bundle is incomplete:\n" + "\n".join(missing))
+
+
+@dataclass(frozen=True, slots=True)
+class LaunchConfig:
+    backend: str
+    command_prefix: tuple[str, ...]
+    env: dict[str, str]
+    prefix: Path | None
+    worker_kind: str
+
+    def command(self, worker: Path) -> list[str]:
+        return [*self.command_prefix, str(worker), "--video"]
+
+
+def _binary_kind(path: Path) -> str:
+    try:
+        with path.open("rb") as stream:
+            header = stream.read(4)
+    except OSError as exc:
+        raise Dlss5LinuxError(f"Cannot read worker {path}: {exc}") from exc
+    if header.startswith(b"MZ"):
+        return "pe"
+    if header == b"\x7fELF":
+        return "elf"
+    return "unknown"
+
+
+def _find_proton() -> Path | None:
+    configured = os.environ.get("DONUT_DLSS5_PROTON", "").strip()
+    if configured and Path(configured).expanduser().is_file():
+        return Path(configured).expanduser().resolve()
+
+    direct = shutil.which("proton")
+    if direct:
+        return Path(direct).resolve()
+
+    roots = (
+        Path.home() / ".steam" / "root",
+        Path.home() / ".local" / "share" / "Steam",
+    )
+    matches: list[Path] = []
+    for root in roots:
+        matches.extend((root / "compatibilitytools.d").glob("*/proton"))
+        matches.extend((root / "steamapps" / "common").glob("Proton*/proton"))
+    valid = sorted((path.resolve() for path in matches if path.is_file()), reverse=True)
+    return valid[0] if valid else None
+
+
+def _find_wine() -> Path | None:
+    configured = os.environ.get("DONUT_DLSS5_WINE", "").strip()
+    if configured and Path(configured).expanduser().is_file():
+        return Path(configured).expanduser().resolve()
+    for name in ("wine64", "wine"):
+        found = shutil.which(name)
+        if found:
+            return Path(found).resolve()
+    return None
+
+
+def _append_dll_overrides(existing: str) -> str:
+    values = [item.strip() for item in existing.split(";") if item.strip()]
+    lowered = {item.split("=", 1)[0].lower() for item in values}
+    if "dxgi" not in lowered:
+        values.append("dxgi=n,b")
+    if "nvapi64" not in lowered:
+        values.append("nvapi64=n,b")
+    return ";".join(values)
+
+
+def resolve_launch_config(
+    backend: str,
+    launcher: str,
+    prefix: str,
+    worker: Path,
+) -> LaunchConfig:
+    requested = (backend or os.environ.get("DONUT_DLSS5_BACKEND", "Auto")).strip().lower()
+    if requested not in {"auto", "proton", "wine", "native"}:
+        raise Dlss5LinuxError(f"Unknown backend {backend!r}; choose Auto, Proton, Wine, or Native.")
+
+    worker_kind = _binary_kind(worker)
+    explicit_launcher = Path(launcher).expanduser().resolve() if launcher.strip() else None
+    proton = explicit_launcher if requested == "proton" else _find_proton()
+    wine = explicit_launcher if requested == "wine" else _find_wine()
+
+    chosen = requested
+    if chosen == "auto":
+        if worker_kind == "elf":
+            chosen = "native"
+        elif platform.system() == "Linux" and proton is not None:
+            chosen = "proton"
+        elif platform.system() == "Linux" and wine is not None:
+            chosen = "wine"
+        else:
+            raise Dlss5LinuxError(
+                "The worker is a Windows PE file, but neither Proton nor Wine was found. "
+                "Set the launcher input or DONUT_DLSS5_PROTON/DONUT_DLSS5_WINE."
+            )
+
+    env = os.environ.copy()
+    env["DXVK_ENABLE_NVAPI"] = "1"
+    env["PROTON_ENABLE_NVAPI"] = "1"
+    env["PROTON_FORCE_NVAPI"] = "1"
+    env.pop("PROTON_HIDE_NVIDIA_GPU", None)
+    env["WINEDLLOVERRIDES"] = _append_dll_overrides(env.get("WINEDLLOVERRIDES", ""))
+
+    prefix_value = prefix.strip() or os.environ.get("DONUT_DLSS5_PREFIX", "").strip()
+    prefix_path: Path | None = None
+
+    if chosen == "native":
+        if worker_kind != "elf":
+            raise Dlss5LinuxError(
+                f"Native mode requires an ELF worker; {worker} is {worker_kind}. "
+                "Use Proton or Wine for the supplied Windows worker."
+            )
+        if not os.access(worker, os.X_OK):
+            raise Dlss5LinuxError(f"Native worker is not executable: {worker}")
+        command_prefix: tuple[str, ...] = ()
+    elif chosen == "proton":
+        proton = explicit_launcher or proton
+        if proton is None or not proton.is_file():
+            raise Dlss5LinuxError("Proton mode selected, but no Proton script was found.")
+        prefix_path = Path(prefix_value).expanduser().resolve() if prefix_value else (
+            Path.home() / ".local" / "share" / "donutnodes" / "dlss5-proton"
+        )
+        prefix_path.mkdir(parents=True, exist_ok=True)
+        env["STEAM_COMPAT_DATA_PATH"] = str(prefix_path)
+        steam_root = os.environ.get("STEAM_COMPAT_CLIENT_INSTALL_PATH", "").strip()
+        if not steam_root:
+            for candidate in (
+                Path.home() / ".steam" / "root",
+                Path.home() / ".local" / "share" / "Steam",
+            ):
+                if candidate.is_dir():
+                    env["STEAM_COMPAT_CLIENT_INSTALL_PATH"] = str(candidate.resolve())
+                    break
+        command_prefix = (str(proton), "run")
+    else:
+        wine = explicit_launcher or wine
+        if wine is None or not wine.is_file():
+            raise Dlss5LinuxError("Wine mode selected, but wine64/wine was not found.")
+        prefix_path = Path(prefix_value).expanduser().resolve() if prefix_value else (
+            Path.home() / ".local" / "share" / "donutnodes" / "dlss5-wineprefix"
+        )
+        prefix_path.mkdir(parents=True, exist_ok=True)
+        env["WINEPREFIX"] = str(prefix_path)
+        command_prefix = (str(wine),)
+
+    return LaunchConfig(
+        backend=chosen.capitalize(),
+        command_prefix=command_prefix,
+        env=env,
+        prefix=prefix_path,
+        worker_kind=worker_kind,
+    )
+
+
+def resolve_output_size(width: int, height: int, mode_label: str) -> tuple[int, int, float, int, str]:
+    try:
+        factor, perf_quality, mode_name = UPSCALE_MODES[mode_label]
+    except KeyError as exc:
+        raise Dlss5LinuxError(f"Unknown upscaling mode: {mode_label!r}") from exc
+
+    def even(value: float) -> int:
+        return max(2, int(value / 2.0 + 0.5) * 2)
+
+    output_width = even(width * factor)
+    output_height = even(height * factor)
+    if max(output_width, output_height) > 7680 or min(output_width, output_height) > 4320:
+        raise Dlss5LinuxError(
+            f"Requested output {output_width}x{output_height} exceeds the supported 7680x4320 boundary."
+        )
+    return output_width, output_height, factor, perf_quality, mode_name
+
+
+def build_native_settings(
+    nr_preset: str,
+    nr_style: str,
+    model_preset: str,
+    intensity: float,
+    local_tone: float,
+    local_structure: float,
+    skin_structure: float,
+    automatic_mask: bool,
+) -> dict[str, int | float]:
+    for name, value, table in (
+        ("NR preset", nr_preset, NR_PRESETS),
+        ("NR style", nr_style, NR_STYLES),
+        ("model preset", model_preset, MODEL_PRESETS),
+    ):
+        if value not in table:
+            raise Dlss5LinuxError(f"Unknown {name}: {value!r}")
+    ranges = {
+        "intensity": (float(intensity), 0.0, 2.0),
+        "local_tone": (float(local_tone), 0.0, 2.0),
+        "local_structure": (float(local_structure), 0.0, 2.0),
+        "skin_structure": (float(skin_structure), -1.0, 2.0),
+    }
+    for name, (value, low, high) in ranges.items():
+        if not low <= value <= high:
+            raise Dlss5LinuxError(f"{name} must be between {low:g} and {high:g}.")
+    return {
+        "profile": 0,
+        "preset": NR_PRESETS[nr_preset],
+        "style": NR_STYLES[nr_style],
+        "auto_mask": int(bool(automatic_mask)),
+        "ui_correction": 0,
+        "intensity": ranges["intensity"][0],
+        "local_tone": ranges["local_tone"][0],
+        "local_structure": ranges["local_structure"][0],
+        "skin_structure": ranges["skin_structure"][0],
+        "dlss_model_preset": MODEL_PRESETS[model_preset],
+    }
+
+
+def verify_feature_18(text: str) -> list[str]:
+    missing = [label for label, pattern in _REQUIRED_MARKERS if pattern.search(text) is None]
+    if missing:
+        evidence = "\n".join(
+            line
+            for line in text.splitlines()
+            if any(token in line.lower() for token in ("dlssnr", "feature 18", "neural rendering", "error", "failed"))
+        )
+        raise Dlss5LinuxError(
+            "The worker returned pixels, but real DLSS 5 feature-18 execution was not verified. "
+            "Missing: "
+            + ", ".join(missing)
+            + ("\nRelevant runtime output:\n" + evidence[-8000:] if evidence else "")
+        )
+    return [line for line in text.splitlines() if "feature 18" in line.lower() or "signed dlssnr" in line.lower()]
+
+
+def probe_host() -> dict[str, str]:
+    report: dict[str, str] = {
+        "platform": platform.platform(),
+        "nvidia": "not checked",
+        "vulkan": "not checked",
+    }
+    nvidia_smi = shutil.which("nvidia-smi")
+    if nvidia_smi:
+        try:
+            proc = subprocess.run(
+                [
+                    nvidia_smi,
+                    "--query-gpu=name,driver_version,memory.total",
+                    "--format=csv,noheader,nounits",
+                ],
+                capture_output=True,
+                text=True,
+                timeout=15,
+                check=False,
+            )
+            report["nvidia"] = proc.stdout.strip() if proc.returncode == 0 else proc.stderr.strip()
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            report["nvidia"] = str(exc)
+    else:
+        report["nvidia"] = "nvidia-smi not found"
+
+    vulkaninfo = shutil.which("vulkaninfo")
+    if vulkaninfo:
+        try:
+            proc = subprocess.run(
+                [vulkaninfo, "--summary"],
+                capture_output=True,
+                text=True,
+                timeout=20,
+                check=False,
+            )
+            lines = [line.strip() for line in proc.stdout.splitlines() if "deviceName" in line]
+            report["vulkan"] = "; ".join(lines) if lines else (
+                "available" if proc.returncode == 0 else proc.stderr.strip()
+            )
+        except (OSError, subprocess.TimeoutExpired) as exc:
+            report["vulkan"] = str(exc)
+    else:
+        report["vulkan"] = "vulkaninfo not found (install vulkan-tools for this diagnostic)"
+    return report
+
+
+def _read_exact(stream: BinaryIO, size: int, timeout: float, label: str) -> bytes:
+    deadline = time.monotonic() + timeout
+    chunks = bytearray()
+    fd = stream.fileno()
+    while len(chunks) < size:
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise Dlss5LinuxError(f"Timed out while reading {label} ({len(chunks)}/{size} bytes).")
+        ready, _, _ = select.select([fd], [], [], remaining)
+        if not ready:
+            raise Dlss5LinuxError(f"Timed out while reading {label} ({len(chunks)}/{size} bytes).")
+        block = os.read(fd, size - len(chunks))
+        if not block:
+            raise EOFError(f"Worker stopped while reading {label} ({len(chunks)}/{size} bytes).")
+        chunks.extend(block)
+    return bytes(chunks)
+
+
+def _read_struct_with_magic(
+    stream: BinaryIO,
+    structure: struct.Struct,
+    magic: int,
+    timeout: float,
+    label: str,
+    max_prefix: int = 65536,
+) -> bytes:
+    """Read a binary response while tolerating limited launcher chatter on stdout."""
+    marker = struct.pack("<I", magic)
+    deadline = time.monotonic() + timeout
+    buffer = bytearray()
+    fd = stream.fileno()
+    while True:
+        location = buffer.find(marker)
+        if location >= 0:
+            needed = location + structure.size
+            if len(buffer) >= needed:
+                return bytes(buffer[location:needed])
+        if len(buffer) > max_prefix:
+            preview = bytes(buffer[:200]).decode("utf-8", errors="replace")
+            raise Dlss5LinuxError(f"Could not find {label} magic after launcher output: {preview!r}")
+        remaining = deadline - time.monotonic()
+        if remaining <= 0:
+            raise Dlss5LinuxError(f"Timed out waiting for {label}.")
+        ready, _, _ = select.select([fd], [], [], remaining)
+        if not ready:
+            raise Dlss5LinuxError(f"Timed out waiting for {label}.")
+        block = os.read(fd, max(1, min(4096, structure.size + 256)))
+        if not block:
+            raise EOFError(f"Worker stopped before sending {label}.")
+        buffer.extend(block)
+
+
+class _LogCollector:
+    def __init__(self, stream: BinaryIO | None, limit: int = 800) -> None:
+        self._stream = stream
+        self._limit = limit
+        self._lines: list[str] = []
+        self._lock = threading.Lock()
+        self._thread = threading.Thread(target=self._run, name="donut-dlss5-log", daemon=True)
+        self._thread.start()
+
+    def _run(self) -> None:
+        if self._stream is None:
+            return
+        try:
+            for raw in iter(self._stream.readline, b""):
+                line = raw.decode("utf-8", errors="replace").rstrip()
+                if not line:
+                    continue
+                with self._lock:
+                    self._lines.append(line)
+                    if len(self._lines) > self._limit:
+                        del self._lines[: len(self._lines) - self._limit]
+        except (OSError, ValueError):
+            pass
+
+    def join(self, timeout: float = 2.0) -> None:
+        if self._thread.ident is not None:
+            self._thread.join(timeout)
+
+    def text(self) -> str:
+        with self._lock:
+            return "\n".join(self._lines)
+
+
+class Dlss5Session:
+    """One version-4 DLSS neural-rendering worker stream."""
+
+    def __init__(
+        self,
+        layout: RuntimeLayout,
+        launch: LaunchConfig,
+        *,
+        input_width: int,
+        input_height: int,
+        output_width: int,
+        output_height: int,
+        frame_count: int,
+        warmup_frames: int,
+        perf_quality: int,
+        native_settings: dict[str, int | float],
+        setup_timeout: float = 90.0,
+        frame_timeout: float = 600.0,
+        close_timeout: float = 60.0,
+    ) -> None:
+        self.layout = layout
+        self.launch = launch
+        self.output_width = output_width
+        self.output_height = output_height
+        self.frame_timeout = frame_timeout
+        self.close_timeout = close_timeout
+        self._closed = False
+        self._started = time.time() - 2.0
+
+        command = launch.command(layout.worker)
+        try:
+            self.process = subprocess.Popen(
+                command,
+                cwd=str(layout.host),
+                env=launch.env,
+                stdin=subprocess.PIPE,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.PIPE,
+                bufsize=0,
+            )
+        except OSError as exc:
+            raise Dlss5LinuxError(f"Could not start {launch.backend} worker: {exc}\nCommand: {command}") from exc
+        self.logs = _LogCollector(self.process.stderr)
+
+        native = native_settings
+        header = VIDEO_HEADER.pack(
+            VIDEO_MAGIC,
+            int(input_width),
+            int(input_height),
+            int(output_width),
+            int(output_height),
+            max(0, int(warmup_frames)),
+            max(1, int(frame_count)),
+            int(perf_quality),
+            int(native["dlss_model_preset"]),
+            int(native["profile"]),
+            int(native["preset"]),
+            int(native["style"]),
+            int(native["auto_mask"]),
+            int(native["ui_correction"]),
+            float(native["intensity"]),
+            float(native["local_tone"]),
+            float(native["local_structure"]),
+            float(native["skin_structure"]),
+        )
+        try:
+            assert self.process.stdin is not None and self.process.stdout is not None
+            self.process.stdin.write(header)
+            self.process.stdin.flush()
+            payload = _read_struct_with_magic(
+                self.process.stdout, SETUP_RESPONSE, SETUP_MAGIC, setup_timeout, "setup response"
+            )
+            fields = SETUP_RESPONSE.unpack(payload)
+            (
+                _magic,
+                ok,
+                result,
+                self.render_width,
+                self.render_height,
+                negotiated_width,
+                negotiated_height,
+                self.minimum_width,
+                self.minimum_height,
+                self.maximum_width,
+                self.maximum_height,
+                self.applied_model_preset,
+            ) = fields
+            if not ok:
+                raise Dlss5LinuxError(
+                    f"DLSS setup failed with NGX result 0x{result:08X}.\n{self.logs.text()}"
+                )
+            if (negotiated_width, negotiated_height) != (output_width, output_height):
+                raise Dlss5LinuxError(
+                    f"Worker negotiated {negotiated_width}x{negotiated_height}, expected "
+                    f"{output_width}x{output_height}."
+                )
+            if self.render_width < 64 or self.render_height < 64:
+                raise Dlss5LinuxError(
+                    f"Worker returned invalid render size {self.render_width}x{self.render_height}."
+                )
+            requested = int(native["dlss_model_preset"])
+            if self.applied_model_preset != requested:
+                raise Dlss5LinuxError(
+                    f"Worker applied model preset {self.applied_model_preset}, requested {requested}."
+                )
+            self._zero_motion = np.zeros(
+                (self.render_height, self.render_width, 2), dtype=np.float16
+            ).tobytes(order="C")
+        except BaseException:
+            self.abort()
+            raise
+
+    def submit(self, index: int, rgba: np.ndarray, *, reset: bool = True, pts: int | None = None) -> np.ndarray:
+        if self._closed:
+            raise Dlss5LinuxError("DLSS session is already closed.")
+        expected_shape = (self.render_height, self.render_width, 4)
+        if rgba.shape != expected_shape or rgba.dtype != np.uint8:
+            raise Dlss5LinuxError(
+                f"Worker input must be uint8 RGBA {expected_shape}; got {rgba.dtype} {rgba.shape}."
+            )
+        pts_value = index if pts is None else int(pts)
+        assert self.process.stdin is not None and self.process.stdout is not None
+        try:
+            self.process.stdin.write(FRAME_HEADER.pack(FRAME_MAGIC, index, int(reset), 0, pts_value))
+            self.process.stdin.write(memoryview(np.ascontiguousarray(rgba)).cast("B"))
+            self.process.stdin.write(self._zero_motion)
+            self.process.stdin.flush()
+            response = _read_struct_with_magic(
+                self.process.stdout,
+                RESULT_HEADER,
+                OUT_MAGIC,
+                self.frame_timeout,
+                f"frame {index} response",
+                max_prefix=8192,
+            )
+            magic, out_index, ok, byte_count, ngx_result, _out_pts = RESULT_HEADER.unpack(response)
+            expected_bytes = self.output_width * self.output_height * 4
+            if magic != OUT_MAGIC or not ok or out_index != index or byte_count != expected_bytes:
+                raise Dlss5LinuxError(
+                    f"Malformed worker response for frame {index}: index={out_index}, ok={ok}, "
+                    f"bytes={byte_count}/{expected_bytes}."
+                )
+            if ngx_result != 1:
+                raise Dlss5LinuxError(
+                    f"DLSS feature-18 evaluation failed on frame {index}: 0x{ngx_result:08X}."
+                )
+            raw = _read_exact(
+                self.process.stdout, expected_bytes, self.frame_timeout, f"frame {index} pixels"
+            )
+            return np.frombuffer(raw, dtype=np.uint8).reshape(
+                self.output_height, self.output_width, 4
+            ).copy()
+        except (BrokenPipeError, EOFError, OSError) as exc:
+            raise Dlss5LinuxError(
+                f"The {self.launch.backend} worker stopped on frame {index}: {exc}\n{self.logs.text()}"
+            ) from exc
+
+    def close(self) -> tuple[str, list[str]]:
+        if self._closed:
+            return self._combined_log(), []
+        self._closed = True
+        if self.process.stdin is not None and not self.process.stdin.closed:
+            self.process.stdin.close()
+        try:
+            code = self.process.wait(timeout=self.close_timeout)
+        except subprocess.TimeoutExpired as exc:
+            self.process.kill()
+            self.process.wait(timeout=10)
+            self.logs.join()
+            raise Dlss5LinuxError("DLSS worker did not exit after the input stream closed.") from exc
+        self.logs.join()
+        if code:
+            raise Dlss5LinuxError(
+                f"DLSS worker exited with code {code}.\n{self._combined_log()}"
+            )
+        combined = self._combined_log()
+        evidence = verify_feature_18(combined)
+        return combined, evidence
+
+    def _combined_log(self) -> str:
+        parts = [self.logs.text()]
+        try:
+            if self.layout.reshade_log.is_file() and self.layout.reshade_log.stat().st_mtime >= self._started:
+                parts.append(self.layout.reshade_log.read_text(encoding="utf-8", errors="replace"))
+        except OSError:
+            pass
+        return "\n".join(part for part in parts if part)
+
+    def abort(self) -> None:
+        if self._closed:
+            return
+        self._closed = True
+        if self.process.poll() is None:
+            try:
+                self.process.terminate()
+                self.process.wait(timeout=5)
+            except (OSError, subprocess.TimeoutExpired):
+                try:
+                    self.process.kill()
+                except OSError:
+                    pass
+        self.logs.join()
+
+    def __enter__(self) -> "Dlss5Session":
+        return self
+
+    def __exit__(self, exc_type, exc, traceback) -> None:
+        if exc_type is None:
+            self.close()
+        else:
+            self.abort()
+
+
+def last_relevant_lines(text: str, limit: int = 30) -> list[str]:
+    lines = [
+        line
+        for line in text.splitlines()
+        if any(token in line.lower() for token in ("dlssnr", "feature 18", "neural rendering", "error", "failed"))
+    ]
+    return lines[-limit:]
+
+
+def format_status(layout: RuntimeLayout, launch: LaunchConfig, host: dict[str, str]) -> str:
+    fields: Iterable[tuple[str, object]] = (
+        ("Backend", launch.backend),
+        ("Worker kind", launch.worker_kind),
+        ("Runtime root", layout.root),
+        ("Worker", layout.worker),
+        ("RenoDX add-on", layout.addon),
+        ("DLSSNR runtime", layout.neural_runtime),
+        ("DLSS SR runtime", layout.super_resolution_runtime),
+        ("Launcher", " ".join(launch.command_prefix) or "native"),
+        ("Prefix", launch.prefix or "not used"),
+        ("NVIDIA", host.get("nvidia", "unknown")),
+        ("Vulkan", host.get("vulkan", "unknown")),
+    )
+    return "\n".join(f"{name}: {value}" for name, value in fields)

--- a/hot_reload.py
+++ b/hot_reload.py
@@ -1,166 +1,64 @@
-import os
-import sys
-import importlib
-import threading
-import time
-from pathlib import Path
-from typing import Dict, Any
+"""Disabled DonutNodes hot-reload control and experimental-node aggregation.
+
+Hot reloading remains intentionally disabled because replacing ComfyUI node
+classes in a live process can invalidate existing workflows. This module is
+already imported by the package root, so the experimental DLSS 5 branch also
+merges its node mappings here without changing stable node identifiers.
+"""
+
+from __future__ import annotations
+
 
 class DonutHotReload:
-    """Hot reload functionality for DonutNodes custom node"""
-    
-    def __init__(self):
+    """Compatibility facade for the existing, intentionally disabled feature."""
+
+    def __init__(self) -> None:
         self.watching = False
-        self.watch_thread = None
-        self.node_modules = [
-            'DonutDetailer',
-            'DonutDetailer2', 
-            'DonutDetailer4',
-            'DonutDetailer5',
-            'DonutDetailerXLBlocks',
-            'DonutClipEncode',
-            'DonutWidenMerge',
-            'donut_lora_nodes',
-            'lora_block_weight',
-            'merging_methods',
-        ]
-        self.base_path = Path(__file__).parent
-        self.file_timestamps = {}
-        self._update_timestamps()
-    
-    def _update_timestamps(self):
-        """Update file modification timestamps"""
-        for module_name in self.node_modules:
-            file_path = self.base_path / f"{module_name}.py"
-            if file_path.exists():
-                self.file_timestamps[str(file_path)] = file_path.stat().st_mtime
-    
-    def _has_file_changed(self) -> bool:
-        """Check if any tracked files have changed"""
-        for file_path, old_time in self.file_timestamps.items():
-            if os.path.exists(file_path):
-                new_time = os.path.getmtime(file_path)
-                if new_time > old_time:
-                    print(f"[DonutHotReload] Detected change in {file_path}")
-                    return True
-        return False
-    
+
     def reload_modules(self) -> bool:
-        """Reload all DonutNodes modules - DISABLED to prevent interference"""
-        print("[DonutHotReload] Module reload disabled to prevent interference with other extensions")
+        print(
+            "[DonutHotReload] Module reload disabled to prevent interference "
+            "with other extensions"
+        )
         return False
-        
-        # DISABLED CODE BELOW
-        """
-        try:
-            print("[DonutHotReload] Starting module reload...")
-            
-            # Get the main ComfyUI nodes module to access NODE_CLASS_MAPPINGS
-            import nodes
-            
-            # Store old node names for cleanup (but keep them for now to avoid breaking workflows)
-            old_donut_nodes = [name for name in nodes.NODE_CLASS_MAPPINGS.keys() 
-                             if any(x in name for x in ['Donut'])]
-            
-            print(f"[DonutHotReload] Found {len(old_donut_nodes)} existing Donut nodes")
-            
-            # Reload each module individually (skip __init__ for now)
-            reloaded_modules = {}
-            for module_name in self.node_modules:
-                full_module_name = f"custom_nodes.ComfyUI-DonutNodes.{module_name}"
-                if full_module_name in sys.modules:
-                    print(f"[DonutHotReload] Reloading module: {module_name}")
-                    reloaded_modules[module_name] = importlib.reload(sys.modules[full_module_name])
-            
-            # Now reload the main __init__ module
-            init_module_name = "custom_nodes.ComfyUI-DonutNodes"
-            if init_module_name in sys.modules:
-                print("[DonutHotReload] Reloading main __init__ module...")
-                reloaded_init = importlib.reload(sys.modules[init_module_name])
-                
-                # Skip removing old nodes to avoid interfering with other extensions
-                # for node_name in old_donut_nodes:
-                #     if node_name in nodes.NODE_CLASS_MAPPINGS:
-                #         del nodes.NODE_CLASS_MAPPINGS[node_name]
-                #         print(f"[DonutHotReload] Removed old node: {node_name}")
-                
-                # Re-register nodes from the reloaded module
-                if hasattr(reloaded_init, 'NODE_CLASS_MAPPINGS'):
-                    new_nodes = reloaded_init.NODE_CLASS_MAPPINGS
-                    nodes.NODE_CLASS_MAPPINGS.update(new_nodes)
-                    print(f"[DonutHotReload] Re-registered {len(new_nodes)} nodes: {list(new_nodes.keys())}")
-                
-                if hasattr(reloaded_init, 'NODE_DISPLAY_NAME_MAPPINGS'):
-                    if not hasattr(nodes, 'NODE_DISPLAY_NAME_MAPPINGS'):
-                        nodes.NODE_DISPLAY_NAME_MAPPINGS = {}
-                    nodes.NODE_DISPLAY_NAME_MAPPINGS.update(reloaded_init.NODE_DISPLAY_NAME_MAPPINGS)
-            
-            # Update timestamps
-            self._update_timestamps()
-            
-            print("[DonutHotReload] ✓ Hot reload completed successfully!")
-            return True
-            
-        except Exception as e:
-            print(f"[DonutHotReload] ✗ Reload failed: {e}")
-            import traceback
-            traceback.print_exc()
-            return False
-        """
-    
-    def _watch_loop(self):
-        """Background thread that watches for file changes"""
-        print("[DonutHotReload] File watching started")
-        while self.watching:
-            try:
-                if self._has_file_changed():
-                    time.sleep(0.5)  # Brief delay to ensure file write is complete
-                    self.reload_modules()
-                time.sleep(1)  # Check every second
-            except Exception as e:
-                print(f"[DonutHotReload] Watch error: {e}")
-                time.sleep(5)  # Wait longer on error
-    
-    def start_watching(self):
-        """Start watching for file changes - DISABLED to prevent interference with other extensions"""
-        print("[DonutHotReload] Hot reload watching disabled to prevent interference with other extensions")
-        return False
-    
-    def stop_watching(self):
-        """Stop watching for file changes"""
-        if self.watching:
-            self.watching = False
-            if self.watch_thread:
-                self.watch_thread.join(timeout=2)
-            print("[DonutHotReload] Hot reload watching disabled")
 
-# Global instance
+    def start_watching(self) -> bool:
+        print(
+            "[DonutHotReload] Hot reload watching disabled to prevent "
+            "interference with other extensions"
+        )
+        self.watching = False
+        return False
+
+    def stop_watching(self) -> None:
+        self.watching = False
+
+
 hot_reload = DonutHotReload()
+hot_reload.stop_watching()
+print("[DonutHotReload] Stopped any existing file watching on import")
 
-# Stop any existing watching to prevent interference
-try:
-    hot_reload.stop_watching()
-    print("[DonutHotReload] Stopped any existing file watching on import")
-except:
-    pass
 
 class DonutHotReloadNode:
-    """ComfyUI node for controlling hot reload functionality"""
-    
+    """ComfyUI node preserving the original DonutHotReload workflow ID."""
+
     @classmethod
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "action": (["start_watching", "stop_watching", "reload_now"], {"default": "start_watching"}),
+                "action": (
+                    ["start_watching", "stop_watching", "reload_now"],
+                    {"default": "start_watching"},
+                ),
             }
         }
-    
+
     RETURN_TYPES = ("STRING",)
     RETURN_NAMES = ("status",)
     FUNCTION = "execute"
     CATEGORY = "donut/dev"
     OUTPUT_NODE = True
-    
+
     def execute(self, action):
         if action == "start_watching":
             hot_reload.start_watching()
@@ -169,19 +67,26 @@ class DonutHotReloadNode:
             hot_reload.stop_watching()
             status = "Hot reload watching stopped"
         elif action == "reload_now":
-            success = hot_reload.reload_modules()
-            status = "Reload successful" if success else "Reload failed"
+            status = "Reload successful" if hot_reload.reload_modules() else "Reload failed"
         else:
             status = "Unknown action"
-        
         print(f"[DonutHotReload] {status}")
         return (status,)
 
-# Export the node
+
+from .DonutDLSS5Linux import (  # noqa: E402
+    NODE_CLASS_MAPPINGS as _DLSS5_NODE_CLASS_MAPPINGS,
+)
+from .DonutDLSS5Linux import (  # noqa: E402
+    NODE_DISPLAY_NAME_MAPPINGS as _DLSS5_NODE_DISPLAY_NAME_MAPPINGS,
+)
+
 NODE_CLASS_MAPPINGS = {
     "DonutHotReload": DonutHotReloadNode,
+    **_DLSS5_NODE_CLASS_MAPPINGS,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "DonutHotReload": "DonutHotReload",
+    **_DLSS5_NODE_DISPLAY_NAME_MAPPINGS,
 }

--- a/hot_reload.py
+++ b/hot_reload.py
@@ -1,64 +1,166 @@
-"""Disabled DonutNodes hot-reload control and experimental-node aggregation.
-
-Hot reloading remains intentionally disabled because replacing ComfyUI node
-classes in a live process can invalidate existing workflows. This module is
-already imported by the package root, so the experimental DLSS 5 branch also
-merges its node mappings here without changing stable node identifiers.
-"""
-
-from __future__ import annotations
-
+import os
+import sys
+import importlib
+import threading
+import time
+from pathlib import Path
+from typing import Dict, Any
 
 class DonutHotReload:
-    """Compatibility facade for the existing, intentionally disabled feature."""
-
-    def __init__(self) -> None:
+    """Hot reload functionality for DonutNodes custom node"""
+    
+    def __init__(self):
         self.watching = False
-
+        self.watch_thread = None
+        self.node_modules = [
+            'DonutDetailer',
+            'DonutDetailer2', 
+            'DonutDetailer4',
+            'DonutDetailer5',
+            'DonutDetailerXLBlocks',
+            'DonutClipEncode',
+            'DonutWidenMerge',
+            'donut_lora_nodes',
+            'lora_block_weight',
+            'merging_methods',
+        ]
+        self.base_path = Path(__file__).parent
+        self.file_timestamps = {}
+        self._update_timestamps()
+    
+    def _update_timestamps(self):
+        """Update file modification timestamps"""
+        for module_name in self.node_modules:
+            file_path = self.base_path / f"{module_name}.py"
+            if file_path.exists():
+                self.file_timestamps[str(file_path)] = file_path.stat().st_mtime
+    
+    def _has_file_changed(self) -> bool:
+        """Check if any tracked files have changed"""
+        for file_path, old_time in self.file_timestamps.items():
+            if os.path.exists(file_path):
+                new_time = os.path.getmtime(file_path)
+                if new_time > old_time:
+                    print(f"[DonutHotReload] Detected change in {file_path}")
+                    return True
+        return False
+    
     def reload_modules(self) -> bool:
-        print(
-            "[DonutHotReload] Module reload disabled to prevent interference "
-            "with other extensions"
-        )
+        """Reload all DonutNodes modules - DISABLED to prevent interference"""
+        print("[DonutHotReload] Module reload disabled to prevent interference with other extensions")
         return False
-
-    def start_watching(self) -> bool:
-        print(
-            "[DonutHotReload] Hot reload watching disabled to prevent "
-            "interference with other extensions"
-        )
-        self.watching = False
+        
+        # DISABLED CODE BELOW
+        """
+        try:
+            print("[DonutHotReload] Starting module reload...")
+            
+            # Get the main ComfyUI nodes module to access NODE_CLASS_MAPPINGS
+            import nodes
+            
+            # Store old node names for cleanup (but keep them for now to avoid breaking workflows)
+            old_donut_nodes = [name for name in nodes.NODE_CLASS_MAPPINGS.keys() 
+                             if any(x in name for x in ['Donut'])]
+            
+            print(f"[DonutHotReload] Found {len(old_donut_nodes)} existing Donut nodes")
+            
+            # Reload each module individually (skip __init__ for now)
+            reloaded_modules = {}
+            for module_name in self.node_modules:
+                full_module_name = f"custom_nodes.ComfyUI-DonutNodes.{module_name}"
+                if full_module_name in sys.modules:
+                    print(f"[DonutHotReload] Reloading module: {module_name}")
+                    reloaded_modules[module_name] = importlib.reload(sys.modules[full_module_name])
+            
+            # Now reload the main __init__ module
+            init_module_name = "custom_nodes.ComfyUI-DonutNodes"
+            if init_module_name in sys.modules:
+                print("[DonutHotReload] Reloading main __init__ module...")
+                reloaded_init = importlib.reload(sys.modules[init_module_name])
+                
+                # Skip removing old nodes to avoid interfering with other extensions
+                # for node_name in old_donut_nodes:
+                #     if node_name in nodes.NODE_CLASS_MAPPINGS:
+                #         del nodes.NODE_CLASS_MAPPINGS[node_name]
+                #         print(f"[DonutHotReload] Removed old node: {node_name}")
+                
+                # Re-register nodes from the reloaded module
+                if hasattr(reloaded_init, 'NODE_CLASS_MAPPINGS'):
+                    new_nodes = reloaded_init.NODE_CLASS_MAPPINGS
+                    nodes.NODE_CLASS_MAPPINGS.update(new_nodes)
+                    print(f"[DonutHotReload] Re-registered {len(new_nodes)} nodes: {list(new_nodes.keys())}")
+                
+                if hasattr(reloaded_init, 'NODE_DISPLAY_NAME_MAPPINGS'):
+                    if not hasattr(nodes, 'NODE_DISPLAY_NAME_MAPPINGS'):
+                        nodes.NODE_DISPLAY_NAME_MAPPINGS = {}
+                    nodes.NODE_DISPLAY_NAME_MAPPINGS.update(reloaded_init.NODE_DISPLAY_NAME_MAPPINGS)
+            
+            # Update timestamps
+            self._update_timestamps()
+            
+            print("[DonutHotReload] ✓ Hot reload completed successfully!")
+            return True
+            
+        except Exception as e:
+            print(f"[DonutHotReload] ✗ Reload failed: {e}")
+            import traceback
+            traceback.print_exc()
+            return False
+        """
+    
+    def _watch_loop(self):
+        """Background thread that watches for file changes"""
+        print("[DonutHotReload] File watching started")
+        while self.watching:
+            try:
+                if self._has_file_changed():
+                    time.sleep(0.5)  # Brief delay to ensure file write is complete
+                    self.reload_modules()
+                time.sleep(1)  # Check every second
+            except Exception as e:
+                print(f"[DonutHotReload] Watch error: {e}")
+                time.sleep(5)  # Wait longer on error
+    
+    def start_watching(self):
+        """Start watching for file changes - DISABLED to prevent interference with other extensions"""
+        print("[DonutHotReload] Hot reload watching disabled to prevent interference with other extensions")
         return False
+    
+    def stop_watching(self):
+        """Stop watching for file changes"""
+        if self.watching:
+            self.watching = False
+            if self.watch_thread:
+                self.watch_thread.join(timeout=2)
+            print("[DonutHotReload] Hot reload watching disabled")
 
-    def stop_watching(self) -> None:
-        self.watching = False
-
-
+# Global instance
 hot_reload = DonutHotReload()
-hot_reload.stop_watching()
-print("[DonutHotReload] Stopped any existing file watching on import")
 
+# Stop any existing watching to prevent interference
+try:
+    hot_reload.stop_watching()
+    print("[DonutHotReload] Stopped any existing file watching on import")
+except:
+    pass
 
 class DonutHotReloadNode:
-    """ComfyUI node preserving the original DonutHotReload workflow ID."""
-
+    """ComfyUI node for controlling hot reload functionality"""
+    
     @classmethod
     def INPUT_TYPES(cls):
         return {
             "required": {
-                "action": (
-                    ["start_watching", "stop_watching", "reload_now"],
-                    {"default": "start_watching"},
-                ),
+                "action": (["start_watching", "stop_watching", "reload_now"], {"default": "start_watching"}),
             }
         }
-
+    
     RETURN_TYPES = ("STRING",)
     RETURN_NAMES = ("status",)
     FUNCTION = "execute"
     CATEGORY = "donut/dev"
     OUTPUT_NODE = True
-
+    
     def execute(self, action):
         if action == "start_watching":
             hot_reload.start_watching()
@@ -67,26 +169,19 @@ class DonutHotReloadNode:
             hot_reload.stop_watching()
             status = "Hot reload watching stopped"
         elif action == "reload_now":
-            status = "Reload successful" if hot_reload.reload_modules() else "Reload failed"
+            success = hot_reload.reload_modules()
+            status = "Reload successful" if success else "Reload failed"
         else:
             status = "Unknown action"
+        
         print(f"[DonutHotReload] {status}")
         return (status,)
 
-
-from .DonutDLSS5Linux import (  # noqa: E402
-    NODE_CLASS_MAPPINGS as _DLSS5_NODE_CLASS_MAPPINGS,
-)
-from .DonutDLSS5Linux import (  # noqa: E402
-    NODE_DISPLAY_NAME_MAPPINGS as _DLSS5_NODE_DISPLAY_NAME_MAPPINGS,
-)
-
+# Export the node
 NODE_CLASS_MAPPINGS = {
     "DonutHotReload": DonutHotReloadNode,
-    **_DLSS5_NODE_CLASS_MAPPINGS,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "DonutHotReload": "DonutHotReload",
-    **_DLSS5_NODE_DISPLAY_NAME_MAPPINGS,
 }

--- a/tests/test_donut_dlss5_linux.py
+++ b/tests/test_donut_dlss5_linux.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 
+import numpy as np
 import pytest
 
 import donut_dlss5_linux as dlss
@@ -89,3 +90,73 @@ def test_buffered_reader_preserves_pixels_read_with_header():
     finally:
         if write_fd >= 0:
             os.close(write_fd)
+
+
+def test_session_round_trip_and_feature_verification(tmp_path):
+    import os
+    import sys
+
+    root = _make_runtime(tmp_path / "portable")
+    layout = dlss.RuntimeLayout.discover(root)
+    worker_script = tmp_path / "fake_worker.py"
+    worker_script.write_text(
+        """
+import os
+import struct
+import sys
+from pathlib import Path
+
+VIDEO = struct.Struct('<14I4f')
+SETUP = struct.Struct('<12I')
+FRAME = struct.Struct('<4Iq')
+RESULT = struct.Struct('<5Iq')
+header = sys.stdin.buffer.read(VIDEO.size)
+fields = VIDEO.unpack(header)
+in_w, in_h, out_w, out_h = fields[1:5]
+model = fields[8]
+os.write(sys.stdout.fileno(), b'fake launcher\\n' + SETUP.pack(
+    0x34505553, 1, 1, in_w, in_h, out_w, out_h, 64, 64, 7680, 4320, model
+))
+frame = FRAME.unpack(sys.stdin.buffer.read(FRAME.size))
+sys.stdin.buffer.read(in_w * in_h * 4)
+sys.stdin.buffer.read(in_w * in_h * 2 * 2)
+pixels = bytes([64, 128, 192, 255]) * (out_w * out_h)
+os.write(sys.stdout.fileno(), RESULT.pack(0x3154554F, frame[1], 1, len(pixels), 1, frame[4]) + pixels)
+Path('ReShade.log').write_text(
+    'signed DLSSNR 310.8.0 D3D12 runtime initialized\\n'
+    'feature 18 created via the signed snippet\\n'
+    'inline feature 18 evaluation succeeded\\n'
+)
+""".strip()
+        + "\n"
+    )
+    launch = dlss.LaunchConfig(
+        backend="Test",
+        command_prefix=(sys.executable, str(worker_script)),
+        env=os.environ.copy(),
+        prefix=None,
+        worker_kind="test",
+    )
+    settings = dlss.build_native_settings(
+        "Default", "Default", "M", 1.0, 1.0, 1.5, 2.0, True
+    )
+    session = dlss.Dlss5Session(
+        layout,
+        launch,
+        input_width=64,
+        input_height=64,
+        output_width=64,
+        output_height=64,
+        frame_count=1,
+        warmup_frames=0,
+        perf_quality=5,
+        native_settings=settings,
+        setup_timeout=5,
+        frame_timeout=5,
+        close_timeout=5,
+    )
+    output = session.submit(0, np.zeros((64, 64, 4), dtype=np.uint8))
+    assert output.shape == (64, 64, 4)
+    assert output[0, 0].tolist() == [64, 128, 192, 255]
+    _combined, evidence = session.close()
+    assert len(evidence) == 3

--- a/tests/test_donut_dlss5_linux.py
+++ b/tests/test_donut_dlss5_linux.py
@@ -1,0 +1,61 @@
+from pathlib import Path
+
+import pytest
+
+import donut_dlss5_linux as dlss
+
+
+def _make_runtime(root: Path) -> Path:
+    runtime = root / "bin" / "runtime"
+    host = runtime / "host"
+    sr = runtime / "dlss"
+    host.mkdir(parents=True)
+    sr.mkdir(parents=True)
+    (host / "nvngx.dll").write_bytes(b"MZ\x00\x00")
+    for name in ("dxgi.dll", "renodx-dlss5.addon64", "nvngx_dlssnr.dll"):
+        (host / name).write_bytes(b"test")
+    (sr / "nvngx_dlss.dll").write_bytes(b"test")
+    return root
+
+
+def test_runtime_discovery_accepts_portable_root(tmp_path):
+    root = _make_runtime(tmp_path / "portable")
+    layout = dlss.RuntimeLayout.discover(root)
+    assert layout.root == root / "bin" / "runtime"
+    assert layout.worker.name == "nvngx.dll"
+
+
+def test_runtime_discovery_rejects_incomplete_bundle(tmp_path):
+    root = _make_runtime(tmp_path / "portable")
+    (root / "bin" / "runtime" / "host" / "nvngx_dlssnr.dll").unlink()
+    with pytest.raises(dlss.Dlss5LinuxError, match="incomplete"):
+        dlss.RuntimeLayout.discover(root)
+
+
+def test_output_sizes_are_even_and_bounded():
+    width, height, factor, quality, name = dlss.resolve_output_size(
+        513, 257, "2.0x (Performance)"
+    )
+    assert (width, height, factor, quality, name) == (1026, 514, 2.0, 0, "Performance")
+
+
+def test_feature_18_verification_is_version_tolerant():
+    evidence = dlss.verify_feature_18(
+        "signed DLSSNR 310.8.0 D3D12 runtime initialized\n"
+        "feature 18 created via the signed snippet\n"
+        "inline feature 18 evaluation succeeded\n"
+    )
+    assert len(evidence) == 3
+
+
+def test_feature_18_verification_rejects_pixel_only_fallback():
+    with pytest.raises(dlss.Dlss5LinuxError, match="not verified"):
+        dlss.verify_feature_18("ordinary resize completed")
+
+
+def test_dll_overrides_preserve_existing_values():
+    value = dlss._append_dll_overrides("foo=n;dxgi=b")
+    assert "foo=n" in value
+    assert "dxgi=b" in value
+    assert "nvapi64=n,b" in value
+    assert value.count("dxgi=") == 1

--- a/tests/test_donut_dlss5_linux.py
+++ b/tests/test_donut_dlss5_linux.py
@@ -36,7 +36,13 @@ def test_output_sizes_are_even_and_bounded():
     width, height, factor, quality, name = dlss.resolve_output_size(
         513, 257, "2.0x (Performance)"
     )
-    assert (width, height, factor, quality, name) == (1026, 514, 2.0, 0, "Performance")
+    assert (width, height, factor, quality, name) == (
+        1026,
+        514,
+        2.0,
+        0,
+        "Performance",
+    )
 
 
 def test_feature_18_verification_is_version_tolerant():
@@ -59,3 +65,27 @@ def test_dll_overrides_preserve_existing_values():
     assert "dxgi=b" in value
     assert "nvapi64=n,b" in value
     assert value.count("dxgi=") == 1
+
+
+def test_buffered_reader_preserves_pixels_read_with_header():
+    import os
+
+    read_fd, write_fd = os.pipe()
+    payload = b"launcher chatter\n" + dlss.RESULT_HEADER.pack(
+        dlss.OUT_MAGIC, 7, 1, 6, 1, 7
+    ) + b"pixels"
+    try:
+        os.write(write_fd, payload)
+        os.close(write_fd)
+        write_fd = -1
+        with os.fdopen(read_fd, "rb", buffering=0) as stream:
+            reader = dlss._BufferedPipeReader(stream)
+            header = reader.read_struct_with_magic(
+                dlss.RESULT_HEADER, dlss.OUT_MAGIC, 1.0, "test header"
+            )
+            assert dlss.RESULT_HEADER.unpack(header)[1] == 7
+            assert reader.read_exact(6, 1.0, "test pixels") == b"pixels"
+            assert reader.discarded_text() == "launcher chatter"
+    finally:
+        if write_fd >= 0:
+            os.close(write_fd)


### PR DESCRIPTION
## Purpose

Add an experimental Linux path for DLSS 5 neural-rendering image upscaling in DonutNodes without redistributing NVIDIA, ReShade, RenoDX, Proton, Wine, or worker binaries.

The Python/ComfyUI side runs natively on Linux. The available feature-18 renderer is still a Windows PE/D3D12 worker, so this branch launches a user-supplied Merserk-compatible version-4 runtime through Proton or Wine. A future native ELF worker can use the same protocol through the `Native` backend.

## Included

- `Donut DLSS 5 Linux Runtime Status (Experimental)`
  - validates the runtime layout
  - identifies PE versus ELF workers
  - discovers Proton/Wine
  - reports `nvidia-smi` and Vulkan visibility
- `Donut DLSS 5 Neural Upscale — Linux (Experimental)`
  - supports DLAA, Quality, Balanced, Performance, and Ultra Performance modes
  - streams ComfyUI tensors over the version-4 binary worker protocol
  - treats batch items as independent stills with zero motion and history reset
  - preserves binary pipe read-ahead so header and pixel data arriving together cannot corrupt a frame
- strict runtime verification
  - signed DLSSNR D3D12 runtime initialization
  - NGX feature 18 creation
  - successful feature 18 evaluation
  - pixels alone are rejected as an unverified fallback
- installation and first-hardware-test documentation
- protocol/runtime unit tests

## Runtime policy

No proprietary or prebuilt runtime component is committed. The user supplies an authorized runtime with this layout:

```text
bin/runtime/host/nvngx.dll
bin/runtime/host/dxgi.dll
bin/runtime/host/renodx-dlss5.addon64
bin/runtime/host/nvngx_dlssnr.dll
bin/runtime/dlss/nvngx_dlss.dll
```

See `docs/DLSS5_LINUX.md`.

## Validation completed

The exact committed core module and test blobs were compiled and tested locally:

```text
8 passed
```

Coverage includes runtime discovery, incomplete bundles, output sizing, version-tolerant feature-18 evidence, fallback rejection, DLL override preservation, binary read-ahead preservation, and a complete fake-worker setup/frame/teardown round trip with post-run feature-18 verification.

## Remaining hardware gate

This is intentionally a draft. Real DLSS 5 execution cannot be certified by static CI. It still needs a run on the target RTX Linux system with the user's NVIDIA driver, Proton/Wine stack, and authorized runtime bundle. The node will only report success when feature-18 evidence is present.

GitHub-hosted Actions has repeatedly failed before assigning a runner (`steps: null`, no job log), so those red runs are not test executions. The exact committed blobs were validated locally as described above.