### PR TITLE
Add experimental bypass mode to Krea2 model merging

### DIFF
--- a/DonutModelMergeKrea2.py
+++ b/DonutModelMergeKrea2.py
@@ -1,0 +1,463 @@
+"""Krea2 model merge with an optional quantized-weight bypass path.
+
+The regular mode mirrors ComfyUI's built-in ``ModelMergeKrea2`` node.  The
+experimental mode keeps eligible linear layers from model1 and model2 intact
+and blends their forward outputs instead of materialising merged quantized
+weights.  Small/unsupported parameters continue to use ComfyUI's normal patch
+path, so the node is intentionally a hybrid rather than an all-or-nothing
+runtime replacement.
+"""
+
+from __future__ import annotations
+
+import math
+import uuid
+import weakref
+from typing import Any
+
+import torch
+
+try:
+    import comfy.weight_adapter as comfy_weight_adapter
+except ImportError:  # Older ComfyUI versions keep the regular merge available.
+    comfy_weight_adapter = None
+
+try:
+    from comfy.patcher_extension import PatcherInjection
+except ImportError:  # Older ComfyUI versions keep the regular merge available.
+    PatcherInjection = None
+
+
+_EXECUTION_MODES = ("Comfy patches", "Experimental bypass")
+_DIFFUSION_PREFIX = "diffusion_model."
+_INJECTION_KEY = "donut_krea2_model_merge_bypass"
+_SOURCE_MODELS_KEY = "donut_krea2_model_merge_sources"
+_CACHE_ATTACHMENT_PREFIX = "donut_krea2_model_merge_identity:"
+_WEIGHT_ADAPTER_BASE = getattr(comfy_weight_adapter, "WeightAdapterBase", None)
+_BYPASS_MANAGER = getattr(comfy_weight_adapter, "BypassInjectionManager", None)
+
+
+def _module_for_path(model_root: Any, module_path: str):
+    """Resolve a dotted module path, including numeric ModuleList indices."""
+    module = model_root
+    try:
+        for part in module_path.split("."):
+            module = module[int(part)] if part.isdigit() else getattr(module, part)
+    except (AttributeError, IndexError, KeyError, TypeError):
+        return None
+    return module
+
+
+def _module_for_weight_key(model_root: Any, key: str):
+    if not isinstance(key, str) or not key.endswith(".weight"):
+        return None
+    return _module_for_path(model_root, key[:-7])
+
+
+def _is_supported_linear(module: Any) -> bool:
+    """Match the conservative linear-layer subset used by Donut bypass nodes."""
+    if module is None:
+        return False
+    if isinstance(module, torch.nn.Linear):
+        return True
+
+    module_type = type(module)
+    return (
+        module_type.__module__ == "comfy.ops"
+        and module_type.__name__ == "Linear"
+        and callable(getattr(module, "_forward", None))
+    )
+
+
+def _linear_compatibility_error(base_module: Any, source_module: Any):
+    if not _is_supported_linear(base_module):
+        return "model1 target is not a supported linear layer"
+    if not _is_supported_linear(source_module):
+        return "model2 target is not a supported linear layer"
+    if base_module is source_module:
+        return "model1 and model2 resolve to the same layer object"
+
+    for attribute in ("in_features", "out_features"):
+        base_value = getattr(base_module, attribute, None)
+        source_value = getattr(source_module, attribute, None)
+        if (
+            base_value is not None
+            and source_value is not None
+            and int(base_value) != int(source_value)
+        ):
+            return f"linear {attribute} differs between the two models"
+    return None
+
+
+def _direct_module_state_keys(keys, module_path: str):
+    """Return state keys owned directly by a module, not by its children.
+
+    Quantized Comfy linear layers can own buffers such as ``weight_scale``,
+    ``input_scale`` and ``pre_quant_scale`` in addition to weight/bias.  When a
+    layer is bypassed, all of those direct keys must remain with their original
+    model so each full module forward uses internally consistent metadata.
+    """
+    prefix = f"{module_path}."
+    direct = set()
+    for key in keys:
+        if not isinstance(key, str) or not key.startswith(prefix):
+            continue
+        suffix = key[len(prefix):]
+        if suffix and "." not in suffix:
+            direct.add(key)
+    return direct
+
+
+def _ratio_for_key(key: str, ratios: dict[str, float]) -> float:
+    """Resolve the longest Krea2 component-prefix match, like core ComfyUI."""
+    default_ratio = float(ratios.get("first.", next(iter(ratios.values()), 1.0)))
+    ratio = default_ratio
+    key_without_prefix = (
+        key[len(_DIFFUSION_PREFIX):]
+        if key.startswith(_DIFFUSION_PREFIX)
+        else key
+    )
+
+    longest = -1
+    for prefix, value in ratios.items():
+        if key_without_prefix.startswith(prefix) and len(prefix) > longest:
+            ratio = float(value)
+            longest = len(prefix)
+
+    if not math.isfinite(ratio):
+        raise ValueError(f"Non-finite merge ratio for {key}: {ratio}")
+    return ratio
+
+
+def _has_runtime_injections(model) -> bool:
+    if bool(getattr(model, "is_injected", False)):
+        return True
+    injections = getattr(model, "injections", {})
+    if isinstance(injections, dict):
+        return any(bool(value) for value in injections.values())
+    return bool(injections)
+
+
+def _bypass_prerequisite_error(model1, model2):
+    if _WEIGHT_ADAPTER_BASE is None or _BYPASS_MANAGER is None or PatcherInjection is None:
+        return "this ComfyUI build does not expose weight-adapter bypass support"
+    required_methods = (
+        "clone",
+        "get_key_patches",
+        "set_injections",
+        "set_additional_models",
+        "get_additional_models_with_key",
+        "set_attachments",
+    )
+    for label, model in (("model1", model1), ("model2", model2)):
+        missing = [name for name in required_methods if not callable(getattr(model, name, None))]
+        if missing:
+            return f"{label} patcher lacks required methods: {', '.join(missing)}"
+
+    if getattr(model1, "model", None) is getattr(model2, "model", None):
+        return "model1 and model2 share the same underlying model"
+    is_clone = getattr(model1, "is_clone", None)
+    if callable(is_clone) and is_clone(model2):
+        return "model1 and model2 are patcher clones of the same model"
+    if _has_runtime_injections(model1) or _has_runtime_injections(model2):
+        return "one of the input models already has runtime injections"
+
+    device1 = getattr(model1, "load_device", None)
+    device2 = getattr(model2, "load_device", None)
+    if device1 is not None and device2 is not None and device1 != device2:
+        return "model1 and model2 use different load devices"
+    return None
+
+
+if _WEIGHT_ADAPTER_BASE is not None:
+    class _ModelBlendBypassAdapter(_WEIGHT_ADAPTER_BASE):
+        """Blend two complete linear forwards without rebuilding either weight."""
+
+        name = "donut_model_merge"
+
+        def __init__(self, source_patcher, module_path: str, model1_ratio: float):
+            self.source_patcher = source_patcher
+            self.module_path = module_path
+            self.model1_ratio = float(model1_ratio)
+            self.loaded_keys = set()
+            # BypassForwardHook moves adapter weights to the compute device.  This
+            # adapter owns none; the source patcher manages its model's weights.
+            self.weights = ()
+            self._source_module = None
+
+        def _get_source_module(self):
+            # Resolve lazily: additional models may apply object patches after the
+            # output model's injection is installed but before the first forward.
+            if self._source_module is None:
+                source_root = getattr(self.source_patcher, "model", None)
+                source_module = _module_for_path(source_root, self.module_path)
+                if not _is_supported_linear(source_module):
+                    raise RuntimeError(
+                        "Donut Krea2 merge bypass could not resolve a supported "
+                        f"model2 linear layer at '{self.module_path}'"
+                    )
+                self._source_module = source_module
+            return self._source_module
+
+        def bypass_forward(self, original_forward, x, *args, **kwargs):
+            ratio = self.model1_ratio
+            if ratio >= 1.0:
+                return original_forward(x, *args, **kwargs)
+
+            source_out = self._get_source_module()(x, *args, **kwargs)
+            if ratio <= 0.0:
+                return source_out
+
+            base_out = original_forward(x, *args, **kwargs)
+            if not torch.is_tensor(base_out) or not torch.is_tensor(source_out):
+                raise TypeError(
+                    "Donut Krea2 merge bypass expected tensor outputs from both "
+                    f"linear layers at '{self.module_path}'"
+                )
+            if base_out.shape != source_out.shape:
+                raise RuntimeError(
+                    "Donut Krea2 merge bypass received different output shapes at "
+                    f"'{self.module_path}': {tuple(base_out.shape)} vs "
+                    f"{tuple(source_out.shape)}"
+                )
+            if source_out.device != base_out.device or source_out.dtype != base_out.dtype:
+                source_out = source_out.to(device=base_out.device, dtype=base_out.dtype)
+            return base_out * ratio + source_out * (1.0 - ratio)
+else:
+    class _ModelBlendBypassAdapter:  # pyright: ignore[reportRedeclaration]
+        def __init__(self, *args, **kwargs):
+            raise RuntimeError("Experimental bypass requires comfy.weight_adapter")
+
+
+def _make_dynamic_bypass_injection(plans):
+    """Build a clone-safe injection that resolves the paired model at load time."""
+    if PatcherInjection is None or _BYPASS_MANAGER is None:
+        raise RuntimeError("Experimental bypass is unavailable")
+
+    plans = tuple(plans)
+    active_injections = weakref.WeakKeyDictionary()
+
+    def inject(model_patcher):
+        if model_patcher in active_injections:
+            return
+
+        source_models = model_patcher.get_additional_models_with_key(_SOURCE_MODELS_KEY)
+        if len(source_models) != 1:
+            raise RuntimeError(
+                "Donut Krea2 merge bypass expected exactly one paired model2 "
+                f"source, found {len(source_models)}"
+            )
+        source_patcher = source_models[0]
+
+        manager = _BYPASS_MANAGER()
+        for module_path, weight_key, ratio in plans:
+            base_module = _module_for_path(model_patcher.model, module_path)
+            source_module = _module_for_path(source_patcher.model, module_path)
+            reason = _linear_compatibility_error(base_module, source_module)
+            if reason is not None:
+                raise RuntimeError(
+                    f"Donut Krea2 merge bypass target '{module_path}' changed "
+                    f"after node execution: {reason}"
+                )
+            adapter = _ModelBlendBypassAdapter(source_patcher, module_path, ratio)
+            manager.add_adapter(weight_key, adapter, strength=1.0)
+
+        inner_injections = manager.create_injections(model_patcher.model)
+        hook_count = manager.get_hook_count()
+        if hook_count != len(plans):
+            raise RuntimeError(
+                "Donut Krea2 merge bypass could not create every planned hook "
+                f"({hook_count}/{len(plans)})"
+            )
+
+        injected = []
+        try:
+            for inner in inner_injections:
+                injected.append(inner)
+                inner.inject(model_patcher)
+        except Exception:
+            for inner in reversed(injected):
+                inner.eject(model_patcher)
+            raise
+        active_injections[model_patcher] = tuple(inner_injections)
+
+    def eject(model_patcher):
+        inner_injections = active_injections.pop(model_patcher, ())
+        for inner in reversed(inner_injections):
+            inner.eject(model_patcher)
+
+    return PatcherInjection(inject=inject, eject=eject)
+
+
+def _regular_merge(model1, model2, ratios):
+    """Mirror ComfyUI's ModelMergeBlocks patch orientation exactly."""
+    merged = model1.clone()
+    patches = model2.get_key_patches(_DIFFUSION_PREFIX)
+    for key, patch in patches.items():
+        ratio = _ratio_for_key(key, ratios)
+        merged.add_patches({key: patch}, 1.0 - ratio, ratio)
+    return merged
+
+
+def _build_bypass_plans(base_model, source_model, patch_keys, ratios):
+    plans = []
+    bypassed_keys = set()
+    seen_paths = set()
+
+    for key in patch_keys:
+        if not isinstance(key, str) or not key.endswith(".weight"):
+            continue
+        module_path = key[:-7]
+        if module_path in seen_paths:
+            continue
+        seen_paths.add(module_path)
+
+        ratio = _ratio_for_key(key, ratios)
+        if ratio >= 1.0:
+            continue
+
+        base_module = _module_for_weight_key(base_model.model, key)
+        source_module = _module_for_weight_key(source_model.model, key)
+        if _linear_compatibility_error(base_module, source_module) is not None:
+            continue
+
+        direct_keys = _direct_module_state_keys(patch_keys, module_path)
+        if key not in direct_keys:
+            continue
+
+        plans.append((module_path, key, ratio))
+        bypassed_keys.update(direct_keys)
+
+    return plans, bypassed_keys
+
+
+class DonutModelMergeKrea2:
+    """ComfyUI ModelMergeKrea2 plus an opt-in forward-time merge bypass."""
+
+    class_type = "CUSTOM"
+    aux_id = "DonutsDelivery/ComfyUI-DonutNodes"
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        required = {
+            "model1": ("MODEL",),
+            "model2": ("MODEL",),
+        }
+        argument = ("FLOAT", {
+            "default": 1.0,
+            "min": 0.0,
+            "max": 1.0,
+            "step": 0.01,
+            "tooltip": "1.0 keeps model1; 0.0 uses model2 for this Krea2 component.",
+        })
+
+        required["first."] = argument
+        required["tmlp."] = argument
+        required["txtmlp."] = argument
+        required["tproj."] = argument
+
+        for index in range(2):
+            required[f"txtfusion.layerwise_blocks.{index}."] = argument
+        required["txtfusion.projector."] = argument
+        for index in range(2):
+            required[f"txtfusion.refiner_blocks.{index}."] = argument
+        for index in range(28):
+            required[f"blocks.{index}."] = argument
+        required["last."] = argument
+
+        return {
+            "required": required,
+            "optional": {
+                "execution_mode": (list(_EXECUTION_MODES), {
+                    "default": "Comfy patches",
+                    "tooltip": (
+                        "Experimental bypass keeps eligible model1/model2 linear "
+                        "weights intact and blends their forward outputs, avoiding "
+                        "rebuilt merged quantized weights. Unsupported tensors use "
+                        "Comfy patches. Partial ratios run both linear layers and the "
+                        "runtime result is not materialized when saving a checkpoint."
+                    ),
+                }),
+            },
+        }
+
+    RETURN_TYPES = ("MODEL",)
+    FUNCTION = "merge"
+    CATEGORY = "model/merging/model specific"
+    DESCRIPTION = (
+        "Krea2 component merge with the same controls as ComfyUI's built-in node. "
+        "Experimental bypass is intended for inference with quantized models; use "
+        "Comfy patches when the merged weights must be saved."
+    )
+
+    def merge(self, model1, model2, execution_mode="Comfy patches", **ratios):
+        if execution_mode not in _EXECUTION_MODES:
+            raise ValueError(f"Unknown Krea2 merge execution mode: {execution_mode}")
+        if execution_mode == "Comfy patches":
+            return (_regular_merge(model1, model2, ratios),)
+
+        prerequisite_error = _bypass_prerequisite_error(model1, model2)
+        if prerequisite_error is not None:
+            print(
+                "[DonutModelMergeKrea2] Experimental bypass used the regular "
+                f"compatibility path: {prerequisite_error}"
+            )
+            return (_regular_merge(model1, model2, ratios),)
+
+        merged = model1.clone()
+        source = model2.clone()
+        patches = model2.get_key_patches(_DIFFUSION_PREFIX)
+        plans, bypassed_keys = _build_bypass_plans(
+            merged,
+            source,
+            tuple(patches.keys()),
+            ratios,
+        )
+
+        if not plans:
+            print(
+                "[DonutModelMergeKrea2] Experimental bypass found no compatible "
+                "linear targets; using Comfy patches"
+            )
+            return (_regular_merge(model1, model2, ratios),)
+
+        regular_count = 0
+        for key, patch in patches.items():
+            if key in bypassed_keys:
+                continue
+            ratio = _ratio_for_key(key, ratios)
+            if ratio >= 1.0:
+                continue
+            merged.add_patches({key: patch}, 1.0 - ratio, ratio)
+            regular_count += 1
+
+        merged.set_additional_models(_SOURCE_MODELS_KEY, [source])
+        merged.set_injections(
+            _INJECTION_KEY,
+            [_make_dynamic_bypass_injection(plans)],
+        )
+        # ModelPatcher treats two patchless models with the same injection and
+        # attachment *keys* as equivalent; it does not compare injection payloads.
+        # A clone-stable, per-result attachment key prevents different ratio sets
+        # from sharing a loaded-model cache entry. The UUID also distinguishes
+        # results that retain one or more regular patches.
+        identity_key = f"{_CACHE_ATTACHMENT_PREFIX}{uuid.uuid4().hex}"
+        merged.set_attachments(identity_key, tuple(plans))
+        if hasattr(merged, "patches_uuid"):
+            merged.patches_uuid = uuid.uuid4()
+
+        print(
+            "[DonutModelMergeKrea2] Experimental bypass attached "
+            f"{len(plans)} model-blend forward hook(s); kept {regular_count} "
+            "state key(s) on Comfy's regular patch path"
+        )
+        return (merged,)
+
+
+NODE_CLASS_MAPPINGS = {
+    "DonutModelMergeKrea2": DonutModelMergeKrea2,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "DonutModelMergeKrea2": "Donut Model Merge Krea2",
+}

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ Custom nodes for ComfyUI focused on LoRA management, model merging, and image en
 ## Features
 
 - **Block-weighted LoRA stacking** with per-block strength control, CivitAI integration, and an experimental quantized-model bypass mode
+- **Krea2 component model merging** with regular patches or an experimental quantized forward bypass
 - **Donut Detailers** for per-block model tuning and face/object enhancement
 - **TeaCache acceleration** for faster SDXL inference
 - **Tiled upscaling** with seamless blending
@@ -51,6 +52,7 @@ Install `ComfyUI-DonutLocalAutomation` alongside this package to keep the origin
 | DonutKSamplerCFG | CFG sampling with curve control |
 | DonutSpectralNoiseSharpener | Reference-based spectral sharpening |
 | ModelMergeZIT | ZIT model merging |
+| DonutModelMergeKrea2 | Krea2 component merging with optional quantized forward bypass |
 | DonutModelSave | Save merged models |
 
 ### Experimental quantized LoRA bypass
@@ -72,6 +74,30 @@ ComfyUI's regular patch path. Models with pre-existing runtime injections and
 LoRAs without supported forward adapters use the regular compatibility path
 instead of failing. Existing workflows default to `Comfy patches` and retain
 their previous behavior.
+
+### Experimental Krea2 model-merge bypass
+
+`DonutModelMergeKrea2` mirrors the component controls and ratio direction of
+ComfyUI's built-in `ModelMergeKrea2`: `1.0` keeps `model1`, while `0.0` uses
+`model2`. Its optional `execution_mode` also defaults to `Comfy patches`.
+
+In `Experimental bypass`, eligible linear layers keep both models' quantized
+weights intact and evaluate:
+
+`ratio * model1_layer(x) + (1 - ratio) * model2_layer(x)`
+
+Direct state owned by those linear layers—including bias and quantization
+metadata—stays with its original model. Normalization, modulation, and other
+unsupported tensors still use ComfyUI's regular merge patches. A ratio of
+`0.0` runs only the `model2` layer, `1.0` runs only `model1`, and a partial
+ratio runs both linear layers, trading more inference compute and model memory
+for avoiding rebuilt merged quantized weights.
+
+The bypass is an inference-time result and is not materialized by checkpoint
+saving. Select `Comfy patches` before `DonutModelSave` or another checkpoint
+save node. Inputs that share the same underlying model, use different load
+devices, or already contain runtime injections automatically use the regular
+compatibility path instead of failing.
 
 ### Fusion-aware Krea2 LoRA safety
 

--- a/__init__.py
+++ b/__init__.py
@@ -64,6 +64,10 @@ from .DonutDetailerZIT import NODE_DISPLAY_NAME_MAPPINGS as d_zit_detailer
 from .ModelMergeZIT import NODE_CLASS_MAPPINGS        as m_merge_zit
 from .ModelMergeZIT import NODE_DISPLAY_NAME_MAPPINGS as d_merge_zit
 
+# Krea2 Model Merge with optional quantized forward bypass
+from .DonutModelMergeKrea2 import NODE_CLASS_MAPPINGS        as m_merge_krea2
+from .DonutModelMergeKrea2 import NODE_DISPLAY_NAME_MAPPINGS as d_merge_krea2
+
 # ZIT Model Merge Blocks (individual layer control)
 from .ModelMergeZITBlocks import NODE_CLASS_MAPPINGS        as m_merge_zit_blocks
 from .ModelMergeZITBlocks import NODE_DISPLAY_NAME_MAPPINGS as d_merge_zit_blocks
@@ -146,6 +150,7 @@ NODE_CLASS_MAPPINGS = {
     **m_tiled_upscale,
     **m_zit_detailer,
     **m_merge_zit,
+    **m_merge_krea2,
     **m_merge_zit_blocks,
     **m_model_save,
     **m_face_detailer,
@@ -179,6 +184,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     **d_tiled_upscale,
     **d_zit_detailer,
     **d_merge_zit,
+    **d_merge_krea2,
     **d_merge_zit_blocks,
     **d_model_save,
     **d_face_detailer,

--- a/test_model_merge_krea2.py
+++ b/test_model_merge_krea2.py
@@ -1,0 +1,360 @@
+import importlib.util
+import sys
+import types
+import unittest
+import uuid
+from pathlib import Path
+
+import torch
+
+
+ROOT = Path(__file__).resolve().parent
+MODULE_PATH = ROOT / 'DonutModelMergeKrea2.py'
+
+
+class PatcherInjection:
+    def __init__(self, inject, eject):
+        self.inject = inject
+        self.eject = eject
+
+
+class WeightAdapterBase:
+    def h(self, x, base_out):
+        return torch.zeros_like(base_out)
+
+    def g(self, value):
+        return value
+
+    def bypass_forward(self, original_forward, x, *args, **kwargs):
+        base_out = original_forward(x, *args, **kwargs)
+        return self.g(base_out + self.h(x, base_out))
+
+
+class BypassInjectionManager:
+    def __init__(self):
+        self.adapters = {}
+        self.hooks = []
+
+    def add_adapter(self, key, adapter, strength=1.0):
+        module_path = key[:-7] if key.endswith('.weight') else key
+        self.adapters[module_path] = (adapter, strength)
+
+    @staticmethod
+    def _resolve(root, path):
+        module = root
+        for part in path.split('.'):
+            module = module[int(part)] if part.isdigit() else getattr(module, part)
+        return module
+
+    def create_injections(self, root):
+        hook_specs = []
+        for path, (adapter, strength) in self.adapters.items():
+            module = self._resolve(root, path)
+            hook_specs.append((module, adapter, strength))
+        self.hooks = hook_specs
+
+        originals = []
+
+        def inject(_patcher):
+            for module, adapter, strength in hook_specs:
+                adapter.multiplier = strength
+                original = module.forward
+                originals.append((module, original))
+
+                def wrapped(x, *args, _original=original, _adapter=adapter, **kwargs):
+                    return _adapter.bypass_forward(_original, x, *args, **kwargs)
+
+                module.forward = wrapped
+
+        def eject(_patcher):
+            for module, original in reversed(originals):
+                module.forward = original
+            originals.clear()
+
+        return [PatcherInjection(inject, eject)]
+
+    def get_hook_count(self):
+        return len(self.hooks)
+
+
+def load_module():
+    comfy = types.ModuleType('comfy')
+    comfy.__path__ = []
+    weight_adapter = types.ModuleType('comfy.weight_adapter')
+    weight_adapter.WeightAdapterBase = WeightAdapterBase
+    weight_adapter.BypassInjectionManager = BypassInjectionManager
+    patcher_extension = types.ModuleType('comfy.patcher_extension')
+    patcher_extension.PatcherInjection = PatcherInjection
+    comfy.weight_adapter = weight_adapter
+    comfy.patcher_extension = patcher_extension
+
+    injected = {
+        'comfy': comfy,
+        'comfy.weight_adapter': weight_adapter,
+        'comfy.patcher_extension': patcher_extension,
+    }
+    old = {name: sys.modules.get(name) for name in injected}
+    sys.modules.update(injected)
+    try:
+        spec = importlib.util.spec_from_file_location('donut_model_merge_krea2_tested', MODULE_PATH)
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, value in old.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
+module = load_module()
+
+
+class TinyKrea(torch.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.diffusion_model = torch.nn.Module()
+        self.diffusion_model.first = torch.nn.Linear(2, 2, bias=True)
+        self.diffusion_model.first.register_buffer('weight_scale', torch.tensor(1.0))
+        self.diffusion_model.blocks = torch.nn.ModuleList([torch.nn.Module()])
+        self.diffusion_model.blocks[0].proj = torch.nn.Linear(2, 2, bias=False)
+        self.diffusion_model.register_parameter('raw_scale', torch.nn.Parameter(torch.ones(2)))
+
+
+class FakePatcher:
+    def __init__(self, model, key_patches=None):
+        self.model = model
+        self._key_patches = key_patches or {}
+        self.added = []
+        self.injections = {}
+        self.additional_models = {}
+        self.attachments = {}
+        self.is_injected = False
+        self.load_device = torch.device('cpu')
+        self.patches_uuid = uuid.uuid4()
+
+    def clone(self):
+        clone = FakePatcher(self.model, self._key_patches)
+        clone.injections = {key: list(value) for key, value in self.injections.items()}
+        clone.patches_uuid = self.patches_uuid
+        clone.attachments = dict(self.attachments)
+        clone.additional_models = {
+            key: [model.clone() for model in models]
+            for key, models in self.additional_models.items()
+        }
+        return clone
+
+    def is_clone(self, other):
+        return self.model is other.model
+
+    def get_key_patches(self, prefix):
+        return {
+            key: value
+            for key, value in self._key_patches.items()
+            if key.startswith(prefix)
+        }
+
+    def add_patches(self, patches, strength_patch=1.0, strength_model=1.0):
+        self.added.append((patches, strength_patch, strength_model))
+
+    def set_injections(self, key, injections):
+        self.injections[key] = injections
+
+    def set_additional_models(self, key, models):
+        self.additional_models[key] = models
+
+    def get_additional_models_with_key(self, key):
+        return self.additional_models.get(key, [])
+
+    def set_attachments(self, key, value):
+        self.attachments[key] = value
+
+
+class InputSchemaTests(unittest.TestCase):
+    def test_matches_core_krea2_controls_and_appends_execution_mode(self):
+        inputs = module.DonutModelMergeKrea2.INPUT_TYPES()
+        required = list(inputs['required'])
+        expected = [
+            'model1',
+            'model2',
+            'first.',
+            'tmlp.',
+            'txtmlp.',
+            'tproj.',
+            'txtfusion.layerwise_blocks.0.',
+            'txtfusion.layerwise_blocks.1.',
+            'txtfusion.projector.',
+            'txtfusion.refiner_blocks.0.',
+            'txtfusion.refiner_blocks.1.',
+            *[f'blocks.{index}.' for index in range(28)],
+            'last.',
+        ]
+        self.assertEqual(required, expected)
+        self.assertEqual(inputs['optional']['execution_mode'][1]['default'], 'Comfy patches')
+
+
+class AdapterTests(unittest.TestCase):
+    def test_blends_model1_and_model2_forward_outputs(self):
+        base = torch.nn.Linear(2, 1)
+        source = torch.nn.Linear(2, 1)
+        with torch.no_grad():
+            base.weight[:] = torch.tensor([[1.0, 0.0]])
+            base.bias[:] = torch.tensor([1.0])
+            source.weight[:] = torch.tensor([[0.0, 2.0]])
+            source.bias[:] = torch.tensor([-1.0])
+
+        source_root = torch.nn.Module()
+        source_root.layer = source
+        source_patcher = types.SimpleNamespace(model=source_root)
+        adapter = module._ModelBlendBypassAdapter(source_patcher, 'layer', 0.25)
+        x = torch.tensor([[2.0, 3.0]])
+
+        actual = adapter.bypass_forward(base.forward, x)
+        expected = 0.25 * base(x) + 0.75 * source(x)
+        self.assertTrue(torch.allclose(actual, expected))
+
+    def test_ratio_zero_does_not_call_model1_forward(self):
+        source = torch.nn.Linear(1, 1, bias=False)
+        source.weight.data.fill_(3.0)
+        root = torch.nn.Module()
+        root.layer = source
+        adapter = module._ModelBlendBypassAdapter(types.SimpleNamespace(model=root), 'layer', 0.0)
+
+        def fail_base(_x):
+            raise AssertionError('model1 should not execute at ratio 0')
+
+        self.assertTrue(torch.equal(adapter.bypass_forward(fail_base, torch.ones(1, 1)), torch.tensor([[3.0]])))
+
+
+class MergeTests(unittest.TestCase):
+    def test_regular_mode_uses_core_ratio_orientation_and_longest_prefix(self):
+        root1 = TinyKrea()
+        root2 = TinyKrea()
+        patches = {
+            'diffusion_model.blocks.0.proj.weight': object(),
+            'diffusion_model.raw_scale': object(),
+        }
+        model1 = FakePatcher(root1)
+        model2 = FakePatcher(root2, patches)
+
+        (merged,) = module.DonutModelMergeKrea2().merge(
+            model1,
+            model2,
+            execution_mode='Comfy patches',
+            **{'first.': 0.9, 'blocks.0.': 0.2, 'last.': 0.7},
+        )
+
+        by_key = {next(iter(call[0])): call[1:] for call in merged.added}
+        self.assertEqual(by_key['diffusion_model.blocks.0.proj.weight'], (0.8, 0.2))
+        self.assertAlmostEqual(by_key['diffusion_model.raw_scale'][0], 0.1)
+        self.assertEqual(by_key['diffusion_model.raw_scale'][1], 0.9)
+
+    def test_experimental_mode_bypasses_all_direct_linear_state(self):
+        root1 = TinyKrea()
+        root2 = TinyKrea()
+        with torch.no_grad():
+            root1.diffusion_model.first.weight.copy_(torch.eye(2))
+            root1.diffusion_model.first.bias.zero_()
+            root2.diffusion_model.first.weight.copy_(2.0 * torch.eye(2))
+            root2.diffusion_model.first.bias.fill_(1.0)
+
+        patches = {
+            'diffusion_model.first.weight': object(),
+            'diffusion_model.first.bias': object(),
+            'diffusion_model.first.weight_scale': object(),
+            'diffusion_model.raw_scale': object(),
+        }
+        model1 = FakePatcher(root1)
+        model2 = FakePatcher(root2, patches)
+
+        (merged,) = module.DonutModelMergeKrea2().merge(
+            model1,
+            model2,
+            execution_mode='Experimental bypass',
+            **{'first.': 0.25, 'last.': 1.0},
+        )
+
+        regular_keys = {next(iter(call[0])) for call in merged.added}
+        self.assertEqual(regular_keys, {'diffusion_model.raw_scale'})
+        self.assertIn(module._SOURCE_MODELS_KEY, merged.additional_models)
+        self.assertIn(module._INJECTION_KEY, merged.injections)
+        self.assertNotEqual(merged.patches_uuid, model1.patches_uuid)
+        identity_keys = [key for key in merged.attachments if key.startswith(module._CACHE_ATTACHMENT_PREFIX)]
+        self.assertEqual(len(identity_keys), 1)
+
+        outer = merged.injections[module._INJECTION_KEY][0]
+        outer.inject(merged)
+        try:
+            x = torch.tensor([[2.0, 4.0]])
+            actual = merged.model.diffusion_model.first(x)
+            # Explicit expected output: .25*x + .75*(2*x + 1)
+            expected = 0.25 * x + 0.75 * (2.0 * x + 1.0)
+            self.assertTrue(torch.allclose(actual, expected))
+        finally:
+            outer.eject(merged)
+
+    def test_patchless_bypass_gets_a_unique_cache_identity_attachment(self):
+        root1 = TinyKrea()
+        root2 = TinyKrea()
+        patches = {
+            'diffusion_model.first.weight': object(),
+            'diffusion_model.first.bias': object(),
+            'diffusion_model.first.weight_scale': object(),
+        }
+        model1 = FakePatcher(root1)
+        model2 = FakePatcher(root2, patches)
+
+        (merged,) = module.DonutModelMergeKrea2().merge(
+            model1,
+            model2,
+            execution_mode='Experimental bypass',
+            **{'first.': 0.5},
+        )
+
+        self.assertEqual(merged.added, [])
+        identity_keys = [
+            key for key in merged.attachments
+            if key.startswith(module._CACHE_ATTACHMENT_PREFIX)
+        ]
+        self.assertEqual(len(identity_keys), 1)
+        cloned = merged.clone()
+        self.assertEqual(set(cloned.attachments), set(merged.attachments))
+
+    def test_shared_model_falls_back_to_regular_patches(self):
+        root = TinyKrea()
+        patches = {'diffusion_model.first.weight': object()}
+        model1 = FakePatcher(root)
+        model2 = FakePatcher(root, patches)
+
+        (merged,) = module.DonutModelMergeKrea2().merge(
+            model1,
+            model2,
+            execution_mode='Experimental bypass',
+            **{'first.': 0.5},
+        )
+        self.assertEqual(len(merged.added), 1)
+        self.assertFalse(merged.injections)
+        self.assertFalse(merged.additional_models)
+
+    def test_existing_injection_falls_back_to_regular_patches(self):
+        root1 = TinyKrea()
+        root2 = TinyKrea()
+        patches = {'diffusion_model.first.weight': object()}
+        model1 = FakePatcher(root1)
+        model1.injections['existing'] = [object()]
+        model2 = FakePatcher(root2, patches)
+
+        (merged,) = module.DonutModelMergeKrea2().merge(
+            model1,
+            model2,
+            execution_mode='Experimental bypass',
+            **{'first.': 0.5},
+        )
+        self.assertEqual(len(merged.added), 1)
+        self.assertEqual(set(merged.injections), {'existing'})
+        self.assertFalse(merged.additional_models)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
## Summary

Adds a new `DonutModelMergeKrea2` node that mirrors ComfyUI's built-in `ModelMergeKrea2` controls and ratio direction while adding DonutNodes' two execution modes:

- `Comfy patches` (default): follows the built-in merge implementation.
- `Experimental bypass`: keeps eligible model1/model2 linear layers and their quantization state intact, then blends their forward outputs at inference time.

## Implementation details

- Preserves the built-in Krea2 component controls: first, timestep/text projections, text-fusion blocks/projector/refiners, 28 DiT blocks, and last layer.
- Uses the same ratio direction as ComfyUI core: `1.0` keeps model1 and `0.0` uses model2.
- Uses `BypassInjectionManager` for supported linear modules.
- Keeps each bypassed linear module's direct state together, including bias and quantization metadata.
- Leaves normalization, modulation, and unsupported state on ComfyUI's regular patch path.
- Registers model2 as an additional model so ComfyUI loads/offloads both models together.
- Uses clone-safe runtime injection and a unique attachment identity so different patchless ratio sets cannot be confused by the loaded-model cache.
- Falls back to regular patches for unsupported ComfyUI versions, shared underlying models, existing runtime injections, mismatched load devices, or workflows with no compatible linear targets.
- Documents that the bypass result is inference-time only and is not materialized by checkpoint-saving nodes.

## Validation

- `python -m unittest -v test_model_merge_krea2.py` — 8 tests passed.
- `python -m py_compile DonutModelMergeKrea2.py test_model_merge_krea2.py __init__.py` — passed.

The focused tests cover schema compatibility, ratio orientation, forward blending, ratio-zero fast path, quantization-state partitioning, cache identity, and regular-path fallbacks. A full Krea2 quantized GPU benchmark was not available in the test environment.