### PR TITLE
Make Krea2 model merge bypass hybrid for faster inference

### DIFF
--- a/DonutModelMergeKrea2.py
+++ b/DonutModelMergeKrea2.py
@@ -1,11 +1,10 @@
-"""Krea2 model merge with an optional quantized-weight bypass path.
+"""Krea2 model merge with an optional quantized-weight hybrid bypass path.
 
-The regular mode mirrors ComfyUI's built-in ``ModelMergeKrea2`` node.  The
-experimental mode keeps eligible linear layers from model1 and model2 intact
-and blends their forward outputs instead of materialising merged quantized
-weights.  Small/unsupported parameters continue to use ComfyUI's normal patch
-path, so the node is intentionally a hybrid rather than an all-or-nothing
-runtime replacement.
+The regular mode mirrors ComfyUI's built-in ``ModelMergeKrea2`` node. The
+experimental mode bypasses only exact model2 swaps (ratio 0.0) for compatible
+linear layers, keeping those quantized modules intact at inference time.
+Partial blends remain on ComfyUI's normal patch path so inference uses one
+materialized linear forward instead of evaluating both full model layers.
 """
 
 from __future__ import annotations
@@ -93,9 +92,9 @@ def _direct_module_state_keys(keys, module_path: str):
     """Return state keys owned directly by a module, not by its children.
 
     Quantized Comfy linear layers can own buffers such as ``weight_scale``,
-    ``input_scale`` and ``pre_quant_scale`` in addition to weight/bias.  When a
-    layer is bypassed, all of those direct keys must remain with their original
-    model so each full module forward uses internally consistent metadata.
+    ``input_scale`` and ``pre_quant_scale`` in addition to weight/bias. When a
+    layer is swapped at runtime, all direct keys stay with their original model
+    so the source module uses internally consistent quantization metadata.
     """
     prefix = f"{module_path}."
     direct = set()
@@ -171,7 +170,7 @@ def _bypass_prerequisite_error(model1, model2):
 
 if _WEIGHT_ADAPTER_BASE is not None:
     class _ModelBlendBypassAdapter(_WEIGHT_ADAPTER_BASE):
-        """Blend two complete linear forwards without rebuilding either weight."""
+        """Swap one compatible linear forward to model2 without rebuilding weight."""
 
         name = "donut_model_merge"
 
@@ -180,14 +179,10 @@ if _WEIGHT_ADAPTER_BASE is not None:
             self.module_path = module_path
             self.model1_ratio = float(model1_ratio)
             self.loaded_keys = set()
-            # BypassForwardHook moves adapter weights to the compute device.  This
-            # adapter owns none; the source patcher manages its model's weights.
             self.weights = ()
             self._source_module = None
 
         def _get_source_module(self):
-            # Resolve lazily: additional models may apply object patches after the
-            # output model's injection is installed but before the first forward.
             if self._source_module is None:
                 source_root = getattr(self.source_patcher, "model", None)
                 source_module = _module_for_path(source_root, self.module_path)
@@ -203,26 +198,12 @@ if _WEIGHT_ADAPTER_BASE is not None:
             ratio = self.model1_ratio
             if ratio >= 1.0:
                 return original_forward(x, *args, **kwargs)
-
-            source_out = self._get_source_module()(x, *args, **kwargs)
-            if ratio <= 0.0:
-                return source_out
-
-            base_out = original_forward(x, *args, **kwargs)
-            if not torch.is_tensor(base_out) or not torch.is_tensor(source_out):
-                raise TypeError(
-                    "Donut Krea2 merge bypass expected tensor outputs from both "
-                    f"linear layers at '{self.module_path}'"
-                )
-            if base_out.shape != source_out.shape:
+            if ratio != 0.0:
                 raise RuntimeError(
-                    "Donut Krea2 merge bypass received different output shapes at "
-                    f"'{self.module_path}': {tuple(base_out.shape)} vs "
-                    f"{tuple(source_out.shape)}"
+                    "Donut Krea2 merge bypass received a partial ratio. Partial "
+                    "blends must stay on Comfy's materialized patch path."
                 )
-            if source_out.device != base_out.device or source_out.dtype != base_out.dtype:
-                source_out = source_out.to(device=base_out.device, dtype=base_out.dtype)
-            return base_out * ratio + source_out * (1.0 - ratio)
+            return self._get_source_module()(x, *args, **kwargs)
 else:
     class _ModelBlendBypassAdapter:  # pyright: ignore[reportRedeclaration]
         def __init__(self, *args, **kwargs):
@@ -300,6 +281,7 @@ def _regular_merge(model1, model2, ratios):
 
 
 def _build_bypass_plans(base_model, source_model, patch_keys, ratios):
+    """Plan only exact model2 swaps; partial ratios are deliberately materialized."""
     plans = []
     bypassed_keys = set()
     seen_paths = set()
@@ -313,7 +295,7 @@ def _build_bypass_plans(base_model, source_model, patch_keys, ratios):
         seen_paths.add(module_path)
 
         ratio = _ratio_for_key(key, ratios)
-        if ratio >= 1.0:
+        if ratio != 0.0:
             continue
 
         base_module = _module_for_weight_key(base_model.model, key)
@@ -332,7 +314,7 @@ def _build_bypass_plans(base_model, source_model, patch_keys, ratios):
 
 
 class DonutModelMergeKrea2:
-    """ComfyUI ModelMergeKrea2 plus an opt-in forward-time merge bypass."""
+    """ComfyUI ModelMergeKrea2 plus an opt-in hybrid runtime bypass."""
 
     class_type = "CUSTOM"
     aux_id = "DonutsDelivery/ComfyUI-DonutNodes"
@@ -371,11 +353,12 @@ class DonutModelMergeKrea2:
                 "execution_mode": (list(_EXECUTION_MODES), {
                     "default": "Comfy patches",
                     "tooltip": (
-                        "Experimental bypass keeps eligible model1/model2 linear "
-                        "weights intact and blends their forward outputs, avoiding "
-                        "rebuilt merged quantized weights. Unsupported tensors use "
-                        "Comfy patches. Partial ratios run both linear layers and the "
-                        "runtime result is not materialized when saving a checkpoint."
+                        "Experimental bypass is hybrid: exact 0.0 model2 swaps use "
+                        "runtime forwarding for compatible linear layers, while "
+                        "partial ratios use normal Comfy merged weights so inference "
+                        "runs one linear forward instead of two. Exact 1.0 keeps "
+                        "model1 unchanged. Runtime swaps are not materialized when "
+                        "saving a checkpoint."
                     ),
                 }),
             },
@@ -386,8 +369,8 @@ class DonutModelMergeKrea2:
     CATEGORY = "model/merging/model specific"
     DESCRIPTION = (
         "Krea2 component merge with the same controls as ComfyUI's built-in node. "
-        "Experimental bypass is intended for inference with quantized models; use "
-        "Comfy patches when the merged weights must be saved."
+        "Experimental bypass accelerates hard model1/model2 component swaps while "
+        "keeping partial blends on Comfy's single-forward materialized merge path."
     )
 
     def merge(self, model1, model2, execution_mode="Comfy patches", **ratios):
@@ -414,42 +397,40 @@ class DonutModelMergeKrea2:
             ratios,
         )
 
-        if not plans:
-            print(
-                "[DonutModelMergeKrea2] Experimental bypass found no compatible "
-                "linear targets; using Comfy patches"
-            )
-            return (_regular_merge(model1, model2, ratios),)
-
         regular_count = 0
+        partial_count = 0
         for key, patch in patches.items():
             if key in bypassed_keys:
                 continue
             ratio = _ratio_for_key(key, ratios)
             if ratio >= 1.0:
                 continue
+            if 0.0 < ratio < 1.0:
+                partial_count += 1
             merged.add_patches({key: patch}, 1.0 - ratio, ratio)
             regular_count += 1
+
+        if not plans:
+            print(
+                "[DonutModelMergeKrea2] Experimental bypass used Comfy patches "
+                f"for {partial_count} partial state key(s); no runtime swaps needed"
+            )
+            return (merged,)
 
         merged.set_additional_models(_SOURCE_MODELS_KEY, [source])
         merged.set_injections(
             _INJECTION_KEY,
             [_make_dynamic_bypass_injection(plans)],
         )
-        # ModelPatcher treats two patchless models with the same injection and
-        # attachment *keys* as equivalent; it does not compare injection payloads.
-        # A clone-stable, per-result attachment key prevents different ratio sets
-        # from sharing a loaded-model cache entry. The UUID also distinguishes
-        # results that retain one or more regular patches.
         identity_key = f"{_CACHE_ATTACHMENT_PREFIX}{uuid.uuid4().hex}"
         merged.set_attachments(identity_key, tuple(plans))
         if hasattr(merged, "patches_uuid"):
             merged.patches_uuid = uuid.uuid4()
 
         print(
-            "[DonutModelMergeKrea2] Experimental bypass attached "
-            f"{len(plans)} model-blend forward hook(s); kept {regular_count} "
-            "state key(s) on Comfy's regular patch path"
+            "[DonutModelMergeKrea2] Experimental hybrid attached "
+            f"{len(plans)} exact model2 swap hook(s); kept {regular_count} "
+            f"state key(s) on Comfy's regular path ({partial_count} partial)"
         )
         return (merged,)
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Custom nodes for ComfyUI focused on LoRA management, model merging, and image en
 ## Features
 
 - **Block-weighted LoRA stacking** with per-block strength control, CivitAI integration, and an experimental quantized-model bypass mode
-- **Krea2 component model merging** with regular patches or an experimental quantized forward bypass
+- **Krea2 component model merging** with regular patches or an experimental hybrid hard-swap bypass
 - **Donut Detailers** for per-block model tuning and face/object enhancement
 - **TeaCache acceleration** for faster SDXL inference
 - **Tiled upscaling** with seamless blending
@@ -52,7 +52,7 @@ Install `ComfyUI-DonutLocalAutomation` alongside this package to keep the origin
 | DonutKSamplerCFG | CFG sampling with curve control |
 | DonutSpectralNoiseSharpener | Reference-based spectral sharpening |
 | ModelMergeZIT | ZIT model merging |
-| DonutModelMergeKrea2 | Krea2 component merging with optional quantized forward bypass |
+| DonutModelMergeKrea2 | Krea2 component merging with optional hybrid hard-swap bypass |
 | DonutModelSave | Save merged models |
 
 ### Experimental quantized LoRA bypass
@@ -81,23 +81,24 @@ their previous behavior.
 ComfyUI's built-in `ModelMergeKrea2`: `1.0` keeps `model1`, while `0.0` uses
 `model2`. Its optional `execution_mode` also defaults to `Comfy patches`.
 
-In `Experimental bypass`, eligible linear layers keep both models' quantized
-weights intact and evaluate:
+`Experimental bypass` uses a hybrid strategy optimized for inference:
 
-`ratio * model1_layer(x) + (1 - ratio) * model2_layer(x)`
+- `1.0` keeps the `model1` component unchanged.
+- `0.0` uses a runtime hard swap to the compatible `model2` linear layer, keeping that layer's original weight, bias, and quantization metadata intact.
+- Partial ratios such as `0.25`, `0.5`, and `0.75` use ComfyUI's normal materialized merge patches so inference executes one merged linear forward instead of two full model forwards.
 
-Direct state owned by those linear layers—including bias and quantization
-metadata—stays with its original model. Normalization, modulation, and other
-unsupported tensors still use ComfyUI's regular merge patches. A ratio of
-`0.0` runs only the `model2` layer, `1.0` runs only `model1`, and a partial
-ratio runs both linear layers, trading more inference compute and model memory
-for avoiding rebuilt merged quantized weights.
+This avoids the main performance problem of the original experimental version,
+which evaluated both full linear layers for every partial blend. Unsupported
+hard-swap targets still use ComfyUI's regular patch path. Model2 is retained as
+an additional runtime model only when at least one compatible exact `0.0` swap
+is active.
 
-The bypass is an inference-time result and is not materialized by checkpoint
-saving. Select `Comfy patches` before `DonutModelSave` or another checkpoint
-save node. Inputs that share the same underlying model, use different load
-devices, or already contain runtime injections automatically use the regular
-compatibility path instead of failing.
+Runtime hard swaps are inference-time behavior and are not materialized by
+checkpoint saving. Select `Comfy patches` before `DonutModelSave` or another
+checkpoint save node when you need fully saved merged weights. Inputs that
+share the same underlying model, use different load devices, or already contain
+runtime injections automatically use the regular compatibility path instead of
+failing.
 
 ### Fusion-aware Krea2 LoRA safety
 

--- a/test_model_merge_krea2.py
+++ b/test_model_merge_krea2.py
@@ -176,43 +176,24 @@ class InputSchemaTests(unittest.TestCase):
         inputs = module.DonutModelMergeKrea2.INPUT_TYPES()
         required = list(inputs['required'])
         expected = [
-            'model1',
-            'model2',
-            'first.',
-            'tmlp.',
-            'txtmlp.',
-            'tproj.',
-            'txtfusion.layerwise_blocks.0.',
-            'txtfusion.layerwise_blocks.1.',
-            'txtfusion.projector.',
-            'txtfusion.refiner_blocks.0.',
+            'model1', 'model2', 'first.', 'tmlp.', 'txtmlp.', 'tproj.',
+            'txtfusion.layerwise_blocks.0.', 'txtfusion.layerwise_blocks.1.',
+            'txtfusion.projector.', 'txtfusion.refiner_blocks.0.',
             'txtfusion.refiner_blocks.1.',
-            *[f'blocks.{index}.' for index in range(28)],
-            'last.',
+            *[f'blocks.{index}.' for index in range(28)], 'last.',
         ]
         self.assertEqual(required, expected)
         self.assertEqual(inputs['optional']['execution_mode'][1]['default'], 'Comfy patches')
 
 
 class AdapterTests(unittest.TestCase):
-    def test_blends_model1_and_model2_forward_outputs(self):
-        base = torch.nn.Linear(2, 1)
+    def test_partial_ratio_is_rejected_by_runtime_adapter(self):
         source = torch.nn.Linear(2, 1)
-        with torch.no_grad():
-            base.weight[:] = torch.tensor([[1.0, 0.0]])
-            base.bias[:] = torch.tensor([1.0])
-            source.weight[:] = torch.tensor([[0.0, 2.0]])
-            source.bias[:] = torch.tensor([-1.0])
-
         source_root = torch.nn.Module()
         source_root.layer = source
-        source_patcher = types.SimpleNamespace(model=source_root)
-        adapter = module._ModelBlendBypassAdapter(source_patcher, 'layer', 0.25)
-        x = torch.tensor([[2.0, 3.0]])
-
-        actual = adapter.bypass_forward(base.forward, x)
-        expected = 0.25 * base(x) + 0.75 * source(x)
-        self.assertTrue(torch.allclose(actual, expected))
+        adapter = module._ModelBlendBypassAdapter(types.SimpleNamespace(model=source_root), 'layer', 0.25)
+        with self.assertRaisesRegex(RuntimeError, 'Partial blends'):
+            adapter.bypass_forward(lambda x: x, torch.ones(1, 2))
 
     def test_ratio_zero_does_not_call_model1_forward(self):
         source = torch.nn.Linear(1, 1, bias=False)
@@ -237,20 +218,16 @@ class MergeTests(unittest.TestCase):
         }
         model1 = FakePatcher(root1)
         model2 = FakePatcher(root2, patches)
-
         (merged,) = module.DonutModelMergeKrea2().merge(
-            model1,
-            model2,
-            execution_mode='Comfy patches',
+            model1, model2, execution_mode='Comfy patches',
             **{'first.': 0.9, 'blocks.0.': 0.2, 'last.': 0.7},
         )
-
         by_key = {next(iter(call[0])): call[1:] for call in merged.added}
         self.assertEqual(by_key['diffusion_model.blocks.0.proj.weight'], (0.8, 0.2))
         self.assertAlmostEqual(by_key['diffusion_model.raw_scale'][0], 0.1)
         self.assertEqual(by_key['diffusion_model.raw_scale'][1], 0.9)
 
-    def test_experimental_mode_bypasses_all_direct_linear_state(self):
+    def test_experimental_mode_bypasses_exact_model2_linear_state(self):
         root1 = TinyKrea()
         root2 = TinyKrea()
         with torch.no_grad():
@@ -258,7 +235,6 @@ class MergeTests(unittest.TestCase):
             root1.diffusion_model.first.bias.zero_()
             root2.diffusion_model.first.weight.copy_(2.0 * torch.eye(2))
             root2.diffusion_model.first.bias.fill_(1.0)
-
         patches = {
             'diffusion_model.first.weight': object(),
             'diffusion_model.first.bias': object(),
@@ -267,14 +243,10 @@ class MergeTests(unittest.TestCase):
         }
         model1 = FakePatcher(root1)
         model2 = FakePatcher(root2, patches)
-
         (merged,) = module.DonutModelMergeKrea2().merge(
-            model1,
-            model2,
-            execution_mode='Experimental bypass',
-            **{'first.': 0.25, 'last.': 1.0},
+            model1, model2, execution_mode='Experimental bypass',
+            **{'first.': 0.0, 'last.': 1.0},
         )
-
         regular_keys = {next(iter(call[0])) for call in merged.added}
         self.assertEqual(regular_keys, {'diffusion_model.raw_scale'})
         self.assertIn(module._SOURCE_MODELS_KEY, merged.additional_models)
@@ -282,19 +254,15 @@ class MergeTests(unittest.TestCase):
         self.assertNotEqual(merged.patches_uuid, model1.patches_uuid)
         identity_keys = [key for key in merged.attachments if key.startswith(module._CACHE_ATTACHMENT_PREFIX)]
         self.assertEqual(len(identity_keys), 1)
-
         outer = merged.injections[module._INJECTION_KEY][0]
         outer.inject(merged)
         try:
             x = torch.tensor([[2.0, 4.0]])
-            actual = merged.model.diffusion_model.first(x)
-            # Explicit expected output: .25*x + .75*(2*x + 1)
-            expected = 0.25 * x + 0.75 * (2.0 * x + 1.0)
-            self.assertTrue(torch.allclose(actual, expected))
+            self.assertTrue(torch.allclose(merged.model.diffusion_model.first(x), 2.0 * x + 1.0))
         finally:
             outer.eject(merged)
 
-    def test_patchless_bypass_gets_a_unique_cache_identity_attachment(self):
+    def test_partial_ratio_uses_materialized_comfy_patches_without_runtime_source(self):
         root1 = TinyKrea()
         root2 = TinyKrea()
         patches = {
@@ -304,19 +272,31 @@ class MergeTests(unittest.TestCase):
         }
         model1 = FakePatcher(root1)
         model2 = FakePatcher(root2, patches)
-
         (merged,) = module.DonutModelMergeKrea2().merge(
-            model1,
-            model2,
-            execution_mode='Experimental bypass',
-            **{'first.': 0.5},
+            model1, model2, execution_mode='Experimental bypass', **{'first.': 0.5},
         )
+        self.assertEqual(len(merged.added), 3)
+        for _, strength_patch, strength_model in merged.added:
+            self.assertEqual((strength_patch, strength_model), (0.5, 0.5))
+        self.assertFalse(merged.injections)
+        self.assertFalse(merged.additional_models)
+        self.assertFalse(merged.attachments)
 
+    def test_patchless_exact_swap_gets_a_unique_cache_identity_attachment(self):
+        root1 = TinyKrea()
+        root2 = TinyKrea()
+        patches = {
+            'diffusion_model.first.weight': object(),
+            'diffusion_model.first.bias': object(),
+            'diffusion_model.first.weight_scale': object(),
+        }
+        model1 = FakePatcher(root1)
+        model2 = FakePatcher(root2, patches)
+        (merged,) = module.DonutModelMergeKrea2().merge(
+            model1, model2, execution_mode='Experimental bypass', **{'first.': 0.0},
+        )
         self.assertEqual(merged.added, [])
-        identity_keys = [
-            key for key in merged.attachments
-            if key.startswith(module._CACHE_ATTACHMENT_PREFIX)
-        ]
+        identity_keys = [key for key in merged.attachments if key.startswith(module._CACHE_ATTACHMENT_PREFIX)]
         self.assertEqual(len(identity_keys), 1)
         cloned = merged.clone()
         self.assertEqual(set(cloned.attachments), set(merged.attachments))
@@ -326,12 +306,8 @@ class MergeTests(unittest.TestCase):
         patches = {'diffusion_model.first.weight': object()}
         model1 = FakePatcher(root)
         model2 = FakePatcher(root, patches)
-
         (merged,) = module.DonutModelMergeKrea2().merge(
-            model1,
-            model2,
-            execution_mode='Experimental bypass',
-            **{'first.': 0.5},
+            model1, model2, execution_mode='Experimental bypass', **{'first.': 0.0},
         )
         self.assertEqual(len(merged.added), 1)
         self.assertFalse(merged.injections)
@@ -344,12 +320,8 @@ class MergeTests(unittest.TestCase):
         model1 = FakePatcher(root1)
         model1.injections['existing'] = [object()]
         model2 = FakePatcher(root2, patches)
-
         (merged,) = module.DonutModelMergeKrea2().merge(
-            model1,
-            model2,
-            execution_mode='Experimental bypass',
-            **{'first.': 0.5},
+            model1, model2, execution_mode='Experimental bypass', **{'first.': 0.0},
         )
         self.assertEqual(len(merged.added), 1)
         self.assertEqual(set(merged.injections), {'existing'})


### PR DESCRIPTION
## Summary

Changes `DonutModelMergeKrea2` so `Experimental bypass` no longer evaluates both full model layers for partial ratios.

## New strategy

- `ratio == 1.0`: keep model1 unchanged.
- `ratio == 0.0`: use runtime bypass for compatible model2 linear layers.
- `0.0 < ratio < 1.0`: use normal Comfy materialized merge patches, so inference executes one merged linear forward instead of two full forwards.

Model2 is retained as an additional runtime model only when at least one compatible exact 0.0 swap is active. Unsupported exact swaps continue on the normal Comfy patch path.

## Why

The previous implementation matched the merge equation by computing both full layer forwards for partial ratios. Unlike LoRA bypass, the model2 contribution is full-rank, so that doubled the expensive linear compute and often erased any inference-speed benefit.

## Validation

Focused local test suite: `python -m unittest -v test_model_merge_krea2.py` — **9/9 passed**.

Tests cover schema compatibility, regular ratio orientation, exact model2 runtime swaps, rejection of accidental partial runtime adapters, partial-ratio materialization with no runtime model2, cache identity, and compatibility fallbacks.