### PR TITLE
Compose Krea2 model-merge bypass with Donut LoRA bypass

### DIFF
--- a/DonutModelMergeKrea2.py
+++ b/DonutModelMergeKrea2.py
@@ -36,6 +36,24 @@ _WEIGHT_ADAPTER_BASE = getattr(comfy_weight_adapter, "WeightAdapterBase", None)
 _BYPASS_MANAGER = getattr(comfy_weight_adapter, "BypassInjectionManager", None)
 
 
+class _ComposableInjectionList(list):
+    """Runtime injections that intentionally compose with Donut LoRA bypass.
+
+    ``DonutApplyLoRAStack`` conservatively treats any truthy pre-existing
+    injection list as incompatible with LoRA forward adapters. Krea2 hard-swap
+    hooks are an exception: they replace the base linear forward with model2,
+    and a later additive LoRA hook can safely wrap that swapped forward. The
+    list therefore stays iterable for ModelPatcher but is falsey for that
+    compatibility guard. ``copy`` preserves the behavior across patcher clones.
+    """
+
+    def __bool__(self):
+        return False
+
+    def copy(self):
+        return type(self)(self)
+
+
 def _module_for_path(model_root: Any, module_path: str):
     """Resolve a dotted module path, including numeric ModuleList indices."""
     module = model_root
@@ -133,7 +151,9 @@ def _has_runtime_injections(model) -> bool:
         return True
     injections = getattr(model, "injections", {})
     if isinstance(injections, dict):
-        return any(bool(value) for value in injections.values())
+        # Injection keys indicate active runtime behavior even when a compatible
+        # injection list intentionally reports false to DonutApplyLoRAStack.
+        return bool(injections)
     return bool(injections)
 
 
@@ -420,7 +440,7 @@ class DonutModelMergeKrea2:
         merged.set_additional_models(_SOURCE_MODELS_KEY, [source])
         merged.set_injections(
             _INJECTION_KEY,
-            [_make_dynamic_bypass_injection(plans)],
+            _ComposableInjectionList([_make_dynamic_bypass_injection(plans)]),
         )
         identity_key = f"{_CACHE_ATTACHMENT_PREFIX}{uuid.uuid4().hex}"
         merged.set_attachments(identity_key, tuple(plans))

--- a/test_krea2_merge_lora_composition.py
+++ b/test_krea2_merge_lora_composition.py
@@ -1,0 +1,87 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parent
+MODULE_PATH = ROOT / "DonutModelMergeKrea2.py"
+
+
+class PatcherInjection:
+    def __init__(self, inject, eject):
+        self.inject = inject
+        self.eject = eject
+
+
+class WeightAdapterBase:
+    pass
+
+
+class BypassInjectionManager:
+    pass
+
+
+def load_module():
+    comfy = types.ModuleType("comfy")
+    comfy.__path__ = []
+    weight_adapter = types.ModuleType("comfy.weight_adapter")
+    weight_adapter.WeightAdapterBase = WeightAdapterBase
+    weight_adapter.BypassInjectionManager = BypassInjectionManager
+    patcher_extension = types.ModuleType("comfy.patcher_extension")
+    patcher_extension.PatcherInjection = PatcherInjection
+    comfy.weight_adapter = weight_adapter
+    comfy.patcher_extension = patcher_extension
+
+    injected = {
+        "comfy": comfy,
+        "comfy.weight_adapter": weight_adapter,
+        "comfy.patcher_extension": patcher_extension,
+    }
+    old = {name: sys.modules.get(name) for name in injected}
+    sys.modules.update(injected)
+    try:
+        spec = importlib.util.spec_from_file_location(
+            "donut_krea2_merge_lora_composition_tested", MODULE_PATH
+        )
+        module = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(module)
+        return module
+    finally:
+        for name, value in old.items():
+            if value is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = value
+
+
+module = load_module()
+
+
+class InjectionCompositionTests(unittest.TestCase):
+    def test_merge_injection_is_falsey_for_lora_compatibility_guard(self):
+        injections = module._ComposableInjectionList([object()])
+        self.assertFalse(injections)
+        self.assertFalse(any({module._INJECTION_KEY: injections}.values()))
+        self.assertEqual(len(injections), 1)
+
+    def test_clone_copy_preserves_falsey_compatibility_marker(self):
+        injections = module._ComposableInjectionList([object()])
+        cloned = injections.copy()
+        self.assertIsInstance(cloned, module._ComposableInjectionList)
+        self.assertFalse(cloned)
+        self.assertEqual(len(cloned), 1)
+
+    def test_model_merge_still_detects_compatible_injection_as_runtime_injection(self):
+        model = types.SimpleNamespace(
+            is_injected=False,
+            injections={
+                module._INJECTION_KEY: module._ComposableInjectionList([object()])
+            },
+        )
+        self.assertTrue(module._has_runtime_injections(model))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

Fixes an interaction between `DonutModelMergeKrea2` Experimental bypass and `Donut Apply LoRA Stack` Experimental bypass.

When a Krea2 component was hard-swapped to model2 at ratio `0.0`, the merge node installed a runtime injection. `DonutApplyLoRAStack` treats any truthy existing injection list as incompatible and falls back to regular model1 patches. For swapped `txtfusion` layers, those patches are then bypassed by the model2 forward, so the LoRA's diffusion-side text-fusion contribution can appear missing.

## Fix

- Store the Krea2 merge injection in a small list subclass that remains iterable/active for ComfyUI but is falsey to the Donut LoRA compatibility guard.
- Preserve that marker across ModelPatcher clones via an overridden `copy()`.
- Keep the Krea2 model-merge node's own runtime-injection detection strict by checking injection keys rather than value truthiness, so a second model-merge bypass still refuses to stack on top.

This lets injection order compose naturally: model2 hard-swap hook first, then the additive LoRA bypass hook wraps it, giving `model2_layer(x) + LoRA(x)` for swapped Krea2 linear targets including `txtfusion`.

## Tests

Adds focused tests for the compatibility marker, clone preservation, and model-merge runtime-injection detection.