### PR TITLE
Fix Krea2 merge bypass leaking into model1

### DIFF
--- a/DonutModelMergeKrea2.py
+++ b/DonutModelMergeKrea2.py
@@ -230,6 +230,27 @@ else:
             raise RuntimeError("Experimental bypass requires comfy.weight_adapter")
 
 
+def _eject_abandoned_bypass_injections(inner_injections):
+    """Restore forwards when ComfyUI drops a loaded merge clone.
+
+    ComfyUI keeps loaded model patchers through weak references. If a merge
+    output is disconnected, the clone can be collected before the next model
+    load and ComfyUI then switches the loaded entry back to the clone's parent.
+    Bypass hooks live on the shared underlying modules, so without this
+    finalizer the parent model would continue using model2 forwards.
+    """
+    for inner in reversed(inner_injections):
+        try:
+            # BypassInjectionManager eject callbacks do not need a live patcher;
+            # they restore the original module forwards held by their hooks.
+            inner.eject(None)
+        except Exception as error:
+            print(
+                "[DonutModelMergeKrea2] Failed to eject an abandoned bypass "
+                f"injection: {error}"
+            )
+
+
 def _make_dynamic_bypass_injection(plans):
     """Build a clone-safe injection that resolves the paired model at load time."""
     if PatcherInjection is None or _BYPASS_MANAGER is None:
@@ -263,7 +284,7 @@ def _make_dynamic_bypass_injection(plans):
             adapter = _ModelBlendBypassAdapter(source_patcher, module_path, ratio)
             manager.add_adapter(weight_key, adapter, strength=1.0)
 
-        inner_injections = manager.create_injections(model_patcher.model)
+        inner_injections = tuple(manager.create_injections(model_patcher.model))
         hook_count = manager.get_hook_count()
         if hook_count != len(plans):
             raise RuntimeError(
@@ -280,10 +301,21 @@ def _make_dynamic_bypass_injection(plans):
             for inner in reversed(injected):
                 inner.eject(model_patcher)
             raise
-        active_injections[model_patcher] = tuple(inner_injections)
+
+        cleanup = weakref.finalize(
+            model_patcher,
+            _eject_abandoned_bypass_injections,
+            inner_injections,
+        )
+        cleanup.atexit = False
+        active_injections[model_patcher] = (inner_injections, cleanup)
 
     def eject(model_patcher):
-        inner_injections = active_injections.pop(model_patcher, ())
+        active = active_injections.pop(model_patcher, None)
+        if active is None:
+            return
+        inner_injections, cleanup = active
+        cleanup.detach()
         for inner in reversed(inner_injections):
             inner.eject(model_patcher)
 

--- a/test_model_merge_krea2.py
+++ b/test_model_merge_krea2.py
@@ -1,8 +1,10 @@
+import gc
 import importlib.util
 import sys
 import types
 import unittest
 import uuid
+import weakref
 from pathlib import Path
 
 import torch
@@ -261,6 +263,39 @@ class MergeTests(unittest.TestCase):
             self.assertTrue(torch.allclose(merged.model.diffusion_model.first(x), 2.0 * x + 1.0))
         finally:
             outer.eject(merged)
+
+    def test_abandoned_merge_output_restores_shared_model1_forward(self):
+        root1 = TinyKrea()
+        root2 = TinyKrea()
+        with torch.no_grad():
+            root1.diffusion_model.first.weight.copy_(torch.eye(2))
+            root1.diffusion_model.first.bias.zero_()
+            root2.diffusion_model.first.weight.copy_(2.0 * torch.eye(2))
+            root2.diffusion_model.first.bias.fill_(1.0)
+        patches = {
+            'diffusion_model.first.weight': object(),
+            'diffusion_model.first.bias': object(),
+            'diffusion_model.first.weight_scale': object(),
+        }
+        model1 = FakePatcher(root1)
+        model2 = FakePatcher(root2, patches)
+        (merged,) = module.DonutModelMergeKrea2().merge(
+            model1,
+            model2,
+            execution_mode='Experimental bypass',
+            **{'first.': 0.0},
+        )
+        outer = merged.injections[module._INJECTION_KEY][0]
+        outer.inject(merged)
+        x = torch.tensor([[2.0, 4.0]])
+        self.assertTrue(torch.allclose(root1.diffusion_model.first(x), 2.0 * x + 1.0))
+
+        merged_ref = weakref.ref(merged)
+        del merged
+        gc.collect()
+
+        self.assertIsNone(merged_ref())
+        self.assertTrue(torch.allclose(root1.diffusion_model.first(x), x))
 
     def test_partial_ratio_uses_materialized_comfy_patches_without_runtime_source(self):
         root1 = TinyKrea()


### PR DESCRIPTION
## Problem

After running `DonutModelMergeKrea2` in `Experimental bypass` mode, disconnecting the merge node and routing `model1` directly could leave the old model2 swap active.

ComfyUI keeps loaded clone patchers through weak references. When the disconnected merge output is collected, ComfyUI can switch the loaded entry back to the clone's parent patcher without invoking the dead clone's injection ejection. The bypass hook remains installed on the shared underlying module, so the parent appears merged.

## Fix

- Register a `weakref.finalize` cleanup whenever the runtime bypass is injected.
- Eject the inner `BypassInjectionManager` injections if the owning merge-output patcher is collected.
- Detach that finalizer during the normal explicit ejection path to avoid duplicate cleanup.
- Keep `atexit` cleanup disabled, matching ComfyUI's own weak-finalizer handling.

## Regression test

Adds a test that:

1. Injects an exact model2 swap into a clone sharing model1's module.
2. Confirms the swapped model2 forward is active.
3. Drops the merge-output patcher and forces garbage collection.
4. Confirms model1's original forward is restored.

## Validation

- `python -m unittest -v test_model_merge_krea2.py` — 10 tests passed.
- `python -m py_compile DonutModelMergeKrea2.py test_model_merge_krea2.py` — passed.
- Local Git blob hashes match the branch blobs exactly.