### PR TITLE
Fix Face Detailer sharpness regressions

### DIFF
--- a/DonutFaceDetailer.py
+++ b/DonutFaceDetailer.py
@@ -2,32 +2,29 @@
 DonutFaceDetailer - FaceDetailer with max_faces limit and megapixel-based sizing.
 Only processes the N largest detected faces, ignoring small background faces.
 Uses total pixel count instead of max edge length for consistent VRAM usage.
+
+Sampling canvases are aligned to 64 pixels to avoid diffusion/VAE quality loss on
+awkward spatial grids. Multi-cycle refinement stays in latent space and performs
+only one decode/downscale at the end.
 """
 
+import inspect
+import logging
 import math
+
 import numpy as np
 import torch
-import logging
-import comfy.samplers
-import comfy.sample
 import comfy.model_management
+import comfy.sample
+import comfy.samplers
 import comfy.utils
 import nodes
 from nodes import MAX_RESOLUTION
 
-# Shared detailer helpers (extracted to remove duplication; behavior-identical)
 try:
-    from .donut_detailer_core import (
-        offload_model_for_auxiliary_stage,
-        sample_and_decode,
-        scale_to_megapixels,
-    )
+    from .donut_detailer_core import offload_model_for_auxiliary_stage
 except ImportError:
-    from donut_detailer_core import (
-        offload_model_for_auxiliary_stage,
-        sample_and_decode,
-        scale_to_megapixels,
-    )
+    from donut_detailer_core import offload_model_for_auxiliary_stage
 
 try:
     from .krea2_edit_integration import (
@@ -47,11 +44,11 @@ try:
 except ImportError:
     from turbo_sampling import resolve_turbo_sampling
 
-# Import from Impact Pack
 try:
     import impact.core as core
-    from impact import utils as impact_utils
+    import impact.wildcards as impact_wildcards
     from impact import impact_sampling
+    from impact import utils as impact_utils
     from comfy_extras import nodes_differential_diffusion
     IMPACT_AVAILABLE = True
 except ImportError:
@@ -59,34 +56,89 @@ except ImportError:
     logging.warning("[DonutFaceDetailer] Impact Pack not found - node will be unavailable")
 
 
+CANVAS_MULTIPLE = 64
+
+
+def _snap_dimension(value, multiple=CANVAS_MULTIPLE):
+    return max(multiple, int(round(float(value) / multiple)) * multiple)
+
+
+def _ceil_dimension(value, multiple=CANVAS_MULTIPLE):
+    return max(multiple, int(math.ceil(float(value) / multiple)) * multiple)
+
+
+def _align_canvas(width, height, max_resolution=0, multiple=CANVAS_MULTIPLE):
+    """Snap a canvas to a diffusion-friendly grid while preserving aspect closely."""
+    width = float(width)
+    height = float(height)
+    if max_resolution > 0 and max(width, height) > max_resolution:
+        scale = max_resolution / max(width, height)
+        width *= scale
+        height *= scale
+    width = _snap_dimension(width, multiple)
+    height = _snap_dimension(height, multiple)
+    if max_resolution > 0 and max(width, height) > max_resolution:
+        max_aligned = max(multiple, int(max_resolution // multiple) * multiple)
+        scale = max_aligned / max(width, height)
+        width = _snap_dimension(width * scale, multiple)
+        height = _snap_dimension(height * scale, multiple)
+        width = min(width, max_aligned)
+        height = min(height, max_aligned)
+    return int(width), int(height)
+
+
+def _scale_to_target_pixels(width, height, target_pixels, max_resolution=0):
+    pixels = width * height
+    if pixels <= 0:
+        return _align_canvas(width, height, max_resolution)
+    scale = math.sqrt(target_pixels / pixels)
+    return _align_canvas(width * scale, height * scale, max_resolution)
+
+
+def _resize_mask(mask, height, width):
+    """Normalize 2D/BHW/BHWC/BCHW masks to BHW at target size."""
+    if isinstance(mask, np.ndarray):
+        mask = torch.from_numpy(mask)
+    mask = mask.float()
+    if mask.ndim == 2:
+        mask_4d = mask.unsqueeze(0).unsqueeze(0)
+    elif mask.ndim == 3:
+        mask_4d = mask.unsqueeze(1)
+    elif mask.ndim == 4 and mask.shape[-1] == 1:
+        mask_4d = mask.permute(0, 3, 1, 2)
+    elif mask.ndim == 4 and mask.shape[1] == 1:
+        mask_4d = mask
+    else:
+        raise ValueError(f"Unsupported mask shape: {tuple(mask.shape)}")
+    resized = torch.nn.functional.interpolate(
+        mask_4d, size=(height, width), mode="bilinear", align_corners=False,
+    )
+    return resized[:, 0]
+
+
+def _combine_conditioning(primary, extra):
+    if extra is None:
+        return primary
+    if hasattr(nodes, "ConditioningCombine"):
+        return nodes.ConditioningCombine().combine(primary, extra)[0]
+    return list(primary) + list(extra)
+
+
 if IMPACT_AVAILABLE:
     class DonutFaceDetailer:
-        """
-        FaceDetailer with max_faces limit and megapixel-based sizing.
-        Uses total pixel count (resolution) instead of max edge length for consistent VRAM usage.
-        """
+        """Face detailer with max-face filtering and megapixel target sizing."""
 
         @classmethod
-        def INPUT_TYPES(s):
+        def INPUT_TYPES(cls):
             return {"required": {
                 "image": ("IMAGE",),
                 "model": ("MODEL",),
                 "clip": ("CLIP",),
                 "vae": ("VAE",),
-                "resolution": ("INT", {
-                    "default": 1024,
-                    "min": 256,
-                    "max": 4096,
-                    "step": 64,
-                    "tooltip": "Target resolution as equivalent square size (e.g., 1024 = 1024x1024 pixels)"
-                }),
-                "max_resolution": ("INT", {
-                    "default": 0,
-                    "min": 0,
-                    "max": 4096,
-                    "step": 64,
-                    "tooltip": "Maximum edge length (0 = no limit). Clamps if megapixel scaling would exceed this."
-                }),
+                "resolution": ("INT", {"default": 1024, "min": 256, "max": 4096, "step": 64,
+                    "tooltip": "Equivalent square target size. Sampling canvases are snapped to 64-pixel multiples."}),
+                "max_resolution": ("INT", {"default": 0, "min": 0, "max": 4096, "step": 64,
+                    "tooltip": "Maximum edge length (0 = no limit)."}),
                 "guide_size_for": ("BOOLEAN", {"default": True, "label_on": "bbox", "label_off": "crop_region"}),
                 "seed": ("INT", {"default": 0, "min": 0, "max": 0xffffffffffffffff}),
                 "steps": ("INT", {"default": 20, "min": 1, "max": 10000}),
@@ -99,62 +151,40 @@ if IMPACT_AVAILABLE:
                 "feather": ("INT", {"default": 5, "min": 0, "max": 100, "step": 1}),
                 "noise_mask": ("BOOLEAN", {"default": True, "label_on": "enabled", "label_off": "disabled"}),
                 "force_inpaint": ("BOOLEAN", {"default": True, "label_on": "enabled", "label_off": "disabled"}),
-
                 "bbox_threshold": ("FLOAT", {"default": 0.5, "min": 0.0, "max": 1.0, "step": 0.01}),
                 "bbox_dilation": ("INT", {"default": 10, "min": -512, "max": 512, "step": 1}),
                 "bbox_crop_factor": ("FLOAT", {"default": 3.0, "min": 1.0, "max": 10, "step": 0.1}),
-
                 "sam_detection_hint": (["center-1", "horizontal-2", "vertical-2", "rect-4", "diamond-4", "mask-area", "mask-points", "mask-point-bbox", "none"],),
                 "sam_dilation": ("INT", {"default": 0, "min": -512, "max": 512, "step": 1}),
                 "sam_threshold": ("FLOAT", {"default": 0.93, "min": 0.0, "max": 1.0, "step": 0.01}),
                 "sam_bbox_expansion": ("INT", {"default": 0, "min": 0, "max": 1000, "step": 1}),
                 "sam_mask_hint_threshold": ("FLOAT", {"default": 0.7, "min": 0.0, "max": 1.0, "step": 0.01}),
                 "sam_mask_hint_use_negative": (["False", "Small", "Outter"],),
-
                 "drop_size": ("INT", {"min": 1, "max": MAX_RESOLUTION, "step": 1, "default": 10}),
                 "bbox_detector": ("BBOX_DETECTOR",),
                 "wildcard": ("STRING", {"multiline": True, "dynamicPrompts": False}),
                 "cycle": ("INT", {"default": 1, "min": 1, "max": 10, "step": 1}),
-
-                "max_faces": ("INT", {
-                    "default": 2,
-                    "min": 1,
-                    "max": 20,
-                    "step": 1,
-                    "tooltip": "Maximum number of faces to process (largest by area)"
-                }),
-            },
-                "optional": {
-                    "sam_model_opt": ("SAM_MODEL",),
-                    "segm_detector_opt": ("SEGM_DETECTOR",),
-                    "detailer_hook": ("DETAILER_HOOK",),
-                    "inpaint_model": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled"}),
-                    "noise_mask_feather": ("INT", {"default": 20, "min": 0, "max": 100, "step": 1}),
-                    "scheduler_func_opt": ("SCHEDULER_FUNC",),
-                    "edit_mode": ("BOOLEAN", {
-                        "default": False,
-                        "tooltip": "Use natural 1-MiP Krea2 conditioning and pad the generated face target to a 32-pixel grid at the configured denoise.",
-                    }),
-                    "edit_prompt": ("STRING", {"forceInput": True}),
-                    "edit_model": ("MODEL", {
-                        "tooltip": "Optional Krea2 model with the Identity Edit LoRA already applied. Falls back to model.",
-                    }),
-                    "face_reference": ("IMAGE", {
-                        "tooltip": "Required in edit mode. The connected bbox detector extracts the identity face independently of its image position.",
-                    }),
-                    "edit_negative_prompt": ("STRING", {"forceInput": True}),
-                    "grounding_px": ("INT", {"default": 768, "min": 0, "max": 4096, "step": 64}),
-                    "vary_seed_per_face": ("BOOLEAN", {
-                        "default": False,
-                        "label_on": "per-face",
-                        "label_off": "shared",
-                        "tooltip": "Use a unique seed offset for each detected face. Off preserves the same seed across faces.",
-                    }),
-                    "turbo_mode": ("BOOLEAN", {
-                        "default": False,
-                        "tooltip": "Treat steps as the model's supported Turbo steps and snap denoise to the nearest valid scheduler point.",
-                    }),
-                }}
+                "max_faces": ("INT", {"default": 2, "min": 1, "max": 20, "step": 1,
+                    "tooltip": "Maximum number of faces to process (largest by area)"}),
+            }, "optional": {
+                "sam_model_opt": ("SAM_MODEL",),
+                "segm_detector_opt": ("SEGM_DETECTOR",),
+                "detailer_hook": ("DETAILER_HOOK",),
+                "inpaint_model": ("BOOLEAN", {"default": False, "label_on": "enabled", "label_off": "disabled"}),
+                "noise_mask_feather": ("INT", {"default": 20, "min": 0, "max": 100, "step": 1}),
+                "scheduler_func_opt": ("SCHEDULER_FUNC",),
+                "edit_mode": ("BOOLEAN", {"default": False,
+                    "tooltip": "Use Krea2 identity edit conditioning for each detected face."}),
+                "edit_prompt": ("STRING", {"forceInput": True}),
+                "edit_model": ("MODEL", {"tooltip": "Optional Krea2 model with the Identity Edit LoRA already applied. Falls back to model."}),
+                "face_reference": ("IMAGE", {"tooltip": "Required in edit mode. The bbox detector extracts the identity face from this image."}),
+                "edit_negative_prompt": ("STRING", {"forceInput": True}),
+                "grounding_px": ("INT", {"default": 768, "min": 0, "max": 4096, "step": 64}),
+                "vary_seed_per_face": ("BOOLEAN", {"default": False, "label_on": "per-face", "label_off": "shared",
+                    "tooltip": "Use a unique seed offset for each detected face."}),
+                "turbo_mode": ("BOOLEAN", {"default": False,
+                    "tooltip": "Snap denoise to a valid Turbo scheduler point."}),
+            }}
 
         RETURN_TYPES = ("IMAGE", "IMAGE", "IMAGE", "MASK", "DETAILER_PIPE", "IMAGE")
         RETURN_NAMES = ("image", "cropped_refined", "cropped_enhanced_alpha", "mask", "detailer_pipe", "cnet_images")
@@ -163,408 +193,341 @@ if IMPACT_AVAILABLE:
         CATEGORY = "ImpactPack/Simple"
 
         @staticmethod
-        def enhance_detail_megapixel(image, model, clip, vae, resolution, max_resolution, guide_size_for_bbox, bbox, seed, steps, cfg,
-                                      sampler_name, scheduler, positive, negative, denoise,
-                                      noise_mask, force_inpaint, noise_mask_feather=0,
-                                      inpaint_model=False, detailer_hook=None, scheduler_func=None,
-                                      edit_mode=False, edit_prompt="Enhance facial details while preserving identity.",
-                                      edit_negative_prompt="", grounding_px=768, edit_model=None,
-                                      face_reference_crop=None):
-            """
-            Enhanced detail function using megapixel-based sizing.
-            Scales crop region to target total pixel count regardless of aspect ratio.
-            """
-            if noise_mask is not None:
-                noise_mask = impact_utils.tensor_gaussian_blur_mask(noise_mask, noise_mask_feather)
-                noise_mask = noise_mask.squeeze(3)
-
-            h = image.shape[1]
-            w = image.shape[2]
-
-            bbox_h = bbox[3] - bbox[1]
+        def enhance_detail_megapixel(
+            image, model, clip, vae, resolution, max_resolution, guide_size_for_bbox,
+            bbox, seed, steps, cfg, sampler_name, scheduler, positive, negative,
+            denoise, noise_mask, force_inpaint, noise_mask_feather=0,
+            inpaint_model=False, detailer_hook=None, scheduler_func=None,
+            edit_mode=False, edit_prompt="Enhance facial details while preserving identity.",
+            edit_negative_prompt="", grounding_px=768, edit_model=None,
+            face_reference_crop=None, cycle=1, wildcard_opt=None,
+            wildcard_concat_mode=None,
+        ):
+            h, w = image.shape[1:3]
             bbox_w = bbox[2] - bbox[0]
-
-            # Calculate target dimensions using megapixel approach
+            bbox_h = bbox[3] - bbox[1]
             if guide_size_for_bbox:
-                # Scale based on bbox - smaller faces get more upscaling
                 bbox_pixels = bbox_w * bbox_h
                 if bbox_pixels > resolution:
                     logging.info("[DonutFaceDetailer] Segment skip [bbox larger than target]")
                     return None, None
                 if bbox_pixels > 0:
                     scale = math.sqrt(resolution / bbox_pixels)
-                    new_w = int(round(w * scale / 8) * 8)
-                    new_h = int(round(h * scale / 8) * 8)
-                    # Apply max_resolution clamp
-                    if max_resolution > 0 and (new_w > max_resolution or new_h > max_resolution):
-                        clamp_scale = max_resolution / max(new_w, new_h)
-                        new_w = int(round(new_w * clamp_scale / 8) * 8)
-                        new_h = int(round(new_h * clamp_scale / 8) * 8)
-                    new_w = max(64, new_w)
-                    new_h = max(64, new_h)
+                    new_w, new_h = _align_canvas(w * scale, h * scale, max_resolution)
                 else:
-                    new_w, new_h = w, h
+                    new_w, new_h = _align_canvas(w, h, max_resolution)
             else:
-                # Scale based on crop region
                 crop_pixels = w * h
                 if crop_pixels > resolution:
                     logging.info("[DonutFaceDetailer] Segment skip [crop larger than target]")
                     return None, None
-                new_w, new_h = scale_to_megapixels(w, h, resolution, max_resolution)
+                new_w, new_h = _scale_to_target_pixels(w, h, resolution, max_resolution)
 
-            # Calculate effective upscale factor
-            upscale = new_w / w
-
-            if not force_inpaint:
-                if upscale <= 1.0:
-                    logging.info(f"[DonutFaceDetailer] Segment skip [upscale={upscale:.2f}]")
+            upscale = new_w / max(w, 1)
+            if upscale <= 1.0:
+                if not force_inpaint:
+                    logging.info("[DonutFaceDetailer] Segment skip [upscale=%.2f]", upscale)
                     return None, None
+                new_w = _ceil_dimension(w)
+                new_h = _ceil_dimension(h)
+                upscale = new_w / max(w, 1)
 
-                if new_w == 0 or new_h == 0:
-                    logging.info(f"[DonutFaceDetailer] Segment skip [zero size]")
-                    return None, None
-            else:
-                if upscale <= 1.0 or new_w == 0 or new_h == 0:
-                    logging.info("[DonutFaceDetailer] Force inpaint with original size")
-                    upscale = 1.0
-                    new_w = w
-                    new_h = h
-
-            if detailer_hook is not None:
+            if detailer_hook is not None and hasattr(detailer_hook, "touch_scaled_size"):
                 new_w, new_h = detailer_hook.touch_scaled_size(new_w, new_h)
+                new_w, new_h = _align_canvas(new_w, new_h, max_resolution)
 
-            logging.info(f"[DonutFaceDetailer] Crop {w}x{h} -> {new_w}x{new_h} ({new_w*new_h:,} pixels, target {resolution:,})")
-
-            # Scale image
+            logging.info("[DonutFaceDetailer] Crop %dx%d -> %dx%d (%d pixels, target %d)",
+                         w, h, new_w, new_h, new_w * new_h, resolution)
             scaled_image = impact_utils.tensor_resize(image, new_w, new_h)
+            if noise_mask is not None:
+                noise_mask = impact_utils.tensor_gaussian_blur_mask(noise_mask, noise_mask_feather)
+                noise_mask = _resize_mask(noise_mask, new_h, new_w)
+            if detailer_hook is not None and hasattr(detailer_hook, "post_upscale"):
+                scaled_image = detailer_hook.post_upscale(scaled_image, noise_mask)
+
             target_image = scaled_image
             target_padding = (0, 0, 0, 0)
-
-            sampling_model = model
+            sampling_model = edit_model if edit_mode and edit_model is not None else model
             sampling_positive = positive
             sampling_negative = negative
+            wildcard_positive = None
+            if wildcard_opt:
+                sampling_model, _, wildcard_positive = impact_wildcards.process_with_loras(wildcard_opt, sampling_model, clip)
+                if not edit_mode:
+                    if wildcard_concat_mode == "concat":
+                        sampling_positive = nodes.ConditioningConcat().concat(sampling_positive, wildcard_positive)[0]
+                    else:
+                        sampling_positive = wildcard_positive
+
             if edit_mode:
                 if face_reference_crop is None:
                     raise ValueError("DonutFaceDetailer edit_mode requires face_reference.")
                 target_image, target_padding = pad_image_to_multiple(scaled_image)
-                sampling_model, sampling_positive, sampling_negative, _source_latent, _conditioning_image = prepare_krea2_edit(
-                    edit_model if edit_model is not None else model,
-                    clip, vae, face_reference_crop, edit_prompt,
-                    edit_negative_prompt, grounding_px,
-                    target_image.shape[2], target_image.shape[1],
-                )
-                latent_image = impact_utils.to_latent_image(target_image, vae)
-            else:
-                # Encode to latent for regular img2img sampling.
-                latent_image = impact_utils.to_latent_image(scaled_image, vae)
+                sampling_model, sampling_positive, sampling_negative, _, _ = prepare_krea2_edit(
+                    sampling_model, clip, vae, face_reference_crop, edit_prompt,
+                    edit_negative_prompt, grounding_px, target_image.shape[2], target_image.shape[1])
+                if wildcard_positive is not None:
+                    sampling_positive = _combine_conditioning(sampling_positive, wildcard_positive)
+                if noise_mask is not None and any(target_padding):
+                    left, top, right, bottom = target_padding
+                    noise_mask = torch.nn.functional.pad(noise_mask, (left, right, top, bottom), value=0)
 
             if (noise_mask is not None and noise_mask_feather > 0
-                    and 'denoise_mask_function' not in sampling_model.model_options):
-                sampling_model = nodes_differential_diffusion.DifferentialDiffusion().execute(
-                    sampling_model,
-                )[0]
+                    and "denoise_mask_function" not in sampling_model.model_options):
+                sampling_model = nodes_differential_diffusion.DifferentialDiffusion().execute(sampling_model)[0]
 
-            # Scale mask if present using torch interpolate
-            if noise_mask is not None:
-                # Ensure mask is 4D (N, C, H, W) for interpolate
-                orig_shape = noise_mask.shape
-                if len(orig_shape) == 2:
-                    mask_4d = noise_mask.unsqueeze(0).unsqueeze(0)
-                elif len(orig_shape) == 3:
-                    mask_4d = noise_mask.unsqueeze(0)
+            if inpaint_model and noise_mask is not None and not edit_mode:
+                encode = nodes.InpaintModelConditioning().encode
+                if "noise_mask" in inspect.signature(encode).parameters:
+                    sampling_positive, sampling_negative, latent_image = encode(
+                        sampling_positive, sampling_negative, target_image, vae,
+                        mask=noise_mask, noise_mask=True)
                 else:
-                    mask_4d = noise_mask
-                mask_4d = mask_4d.float()
-                noise_mask = torch.nn.functional.interpolate(
-                    mask_4d, size=(new_h, new_w), mode='bilinear', align_corners=False
-                )
-                # Restore original dimensions
-                if len(orig_shape) == 2:
-                    noise_mask = noise_mask.squeeze(0).squeeze(0)
-                elif len(orig_shape) == 3:
-                    noise_mask = noise_mask.squeeze(0)
+                    sampling_positive, sampling_negative, latent_image = encode(
+                        sampling_positive, sampling_negative, target_image, vae, noise_mask)
+            else:
+                latent_image = impact_utils.to_latent_image(target_image, vae)
+                if noise_mask is not None:
+                    latent_image["noise_mask"] = noise_mask.reshape((-1, 1, noise_mask.shape[-2], noise_mask.shape[-1]))
 
-                if edit_mode and any(target_padding):
-                    left, top, right, bottom = target_padding
-                    noise_mask = torch.nn.functional.pad(
-                        noise_mask, (left, right, top, bottom), value=0,
-                    )
-
-            # Hook pre-processing
-            if detailer_hook is not None:
-                latent_image = detailer_hook.touch_latent(latent_image)
-
-            # Prepare noise mask for latent
-            if noise_mask is not None:
-                latent_image['noise_mask'] = noise_mask.reshape((-1, 1, noise_mask.shape[-2], noise_mask.shape[-1]))
-
-            # Sample -> VAE decode -> 5D->4D video-VAE reshape (shared helper)
-            refined_image = sample_and_decode(sampling_model, seed, steps, cfg, sampler_name, scheduler,
-                                              sampling_positive, sampling_negative, latent_image, denoise,
-                                              vae, impact_sampling, scheduler_func=scheduler_func)
-
+            if detailer_hook is not None and hasattr(detailer_hook, "post_encode"):
+                latent_image = detailer_hook.post_encode(latent_image)
+            skip_sampling = bool(detailer_hook is not None and hasattr(detailer_hook, "get_skip_sampling")
+                                 and detailer_hook.get_skip_sampling())
+            if skip_sampling:
+                refined_image = target_image
+            else:
+                refined_latent = latent_image
+                sampler_opt = detailer_hook.get_custom_sampler() if (
+                    detailer_hook is not None and hasattr(detailer_hook, "get_custom_sampler")) else None
+                for cycle_index in range(max(1, int(cycle))):
+                    cycle_seed = (seed + cycle_index * 1000) & 0xffffffffffffffff
+                    model2, seed2, steps2, cfg2 = sampling_model, cycle_seed, steps, cfg
+                    sampler2, scheduler2 = sampler_name, scheduler
+                    positive2, negative2 = sampling_positive, sampling_negative
+                    latent2, denoise2, noise = refined_latent, denoise, None
+                    if detailer_hook is not None:
+                        if hasattr(detailer_hook, "set_steps"):
+                            detailer_hook.set_steps((cycle_index, cycle))
+                        if hasattr(detailer_hook, "cycle_latent"):
+                            refined_latent = detailer_hook.cycle_latent(refined_latent)
+                            latent2 = refined_latent
+                        if hasattr(detailer_hook, "pre_ksample"):
+                            (model2, seed2, steps2, cfg2, sampler2, scheduler2,
+                             positive2, negative2, latent2, denoise2) = detailer_hook.pre_ksample(
+                                sampling_model, cycle_seed, steps, cfg, sampler_name, scheduler,
+                                sampling_positive, sampling_negative, refined_latent, denoise)
+                        if hasattr(detailer_hook, "get_custom_noise"):
+                            noise, touched = detailer_hook.get_custom_noise(
+                                seed2, torch.zeros_like(latent2["samples"]), is_touched=False)
+                            if not touched:
+                                noise = None
+                    refined_latent = impact_sampling.ksampler_wrapper(
+                        model2, seed2, steps2, cfg2, sampler2, scheduler2,
+                        positive2, negative2, latent2, denoise2, noise=noise,
+                        scheduler_func=scheduler_func, sampler_opt=sampler_opt)
+                if detailer_hook is not None and hasattr(detailer_hook, "pre_decode"):
+                    refined_latent = detailer_hook.pre_decode(refined_latent)
+                refined_image = vae.decode(refined_latent["samples"])
+                if refined_image.ndim == 5:
+                    refined_image = refined_image.reshape((-1,) + tuple(refined_image.shape[-3:]))
+            if detailer_hook is not None and hasattr(detailer_hook, "post_decode"):
+                refined_image = detailer_hook.post_decode(refined_image)
             if edit_mode and any(target_padding):
                 refined_image = crop_image_padding(refined_image, target_padding)
-
-            # Hook post-processing
-            if detailer_hook is not None:
-                refined_image = detailer_hook.post_detection(refined_image)
-
             return refined_image, None
 
         @staticmethod
-        def enhance_face(image, model, clip, vae, resolution, max_resolution, guide_size_for_bbox, seed, steps, cfg,
-                         sampler_name, scheduler, positive, negative, denoise, feather, noise_mask_enabled, force_inpaint,
-                         bbox_threshold, bbox_dilation, bbox_crop_factor,
-                         sam_detection_hint, sam_dilation, sam_threshold, sam_bbox_expansion, sam_mask_hint_threshold,
-                         sam_mask_hint_use_negative, drop_size, bbox_detector, max_faces,
-                         segm_detector=None, sam_model_opt=None, wildcard_opt=None, detailer_hook=None,
-                         cycle=1, inpaint_model=False, noise_mask_feather=0, scheduler_func_opt=None,
-                         edit_mode=False, edit_prompt="Enhance facial details while preserving identity.",
-                         edit_negative_prompt="", grounding_px=768, edit_model=None,
-                         face_reference=None, vary_seed_per_face=False, turbo_mode=False):
-
+        def enhance_face(
+            image, model, clip, vae, resolution, max_resolution, guide_size_for_bbox,
+            seed, steps, cfg, sampler_name, scheduler, positive, negative, denoise,
+            feather, noise_mask_enabled, force_inpaint, bbox_threshold, bbox_dilation,
+            bbox_crop_factor, sam_detection_hint, sam_dilation, sam_threshold,
+            sam_bbox_expansion, sam_mask_hint_threshold, sam_mask_hint_use_negative,
+            drop_size, bbox_detector, max_faces, segm_detector=None, sam_model_opt=None,
+            wildcard_opt=None, detailer_hook=None, cycle=1, inpaint_model=False,
+            noise_mask_feather=0, scheduler_func_opt=None, edit_mode=False,
+            edit_prompt="Enhance facial details while preserving identity.",
+            edit_negative_prompt="", grounding_px=768, edit_model=None,
+            face_reference=None, vary_seed_per_face=False, turbo_mode=False,
+        ):
             if turbo_mode:
                 supported_steps = steps
                 steps, denoise, matched_denoise = resolve_turbo_sampling(steps, denoise, scheduler)
-                logging.info(
-                    "[DonutFaceDetailer] Turbo: %d supported steps -> %d steps at scheduler denoise=%.3f (ComfyUI denoise=%.3f)",
-                    supported_steps, steps, matched_denoise, denoise,
-                )
-
-            # Free the diffusion model for detection without evicting unrelated models.
+                logging.info("[DonutFaceDetailer] Turbo: %d supported steps -> %d steps at scheduler denoise=%.3f (ComfyUI denoise=%.3f)",
+                             supported_steps, steps, matched_denoise, denoise)
             offload_model_for_auxiliary_stage(model, comfy.model_management)
-
             if edit_mode and face_reference is None:
                 raise ValueError("DonutFaceDetailer edit_mode requires face_reference.")
 
-            # Detect generated faces. Reference detection happens after final
-            # SAM/segmentation refinement so pairing uses the actual targets.
-            bbox_detector.setAux('face')
+            bbox_detector.setAux("face")
             try:
-                segs = bbox_detector.detect(
-                    image, bbox_threshold, bbox_dilation, bbox_crop_factor,
-                    drop_size, detailer_hook=detailer_hook,
-                )
+                segs = bbox_detector.detect(image, bbox_threshold, bbox_dilation, bbox_crop_factor,
+                                            drop_size, detailer_hook=detailer_hook)
             finally:
                 bbox_detector.setAux(None)
-
-            reference_faces = []
-
-            # bbox + sam combination
             if sam_model_opt is not None:
                 sam_mask = core.make_sam_mask(sam_model_opt, segs, image, sam_detection_hint, sam_dilation,
                                               sam_threshold, sam_bbox_expansion, sam_mask_hint_threshold,
                                               sam_mask_hint_use_negative)
                 segs = core.segs_bitwise_and_mask(segs, sam_mask)
-
             elif segm_detector is not None:
                 segm_segs = segm_detector.detect(image, bbox_threshold, bbox_dilation, bbox_crop_factor, drop_size)
-
-                if (hasattr(segm_detector, 'override_bbox_by_segm') and segm_detector.override_bbox_by_segm and
-                        not (detailer_hook is not None and not hasattr(detailer_hook, 'override_bbox_by_segm'))):
+                if (hasattr(segm_detector, "override_bbox_by_segm") and segm_detector.override_bbox_by_segm
+                        and not (detailer_hook is not None and not hasattr(detailer_hook, "override_bbox_by_segm"))):
                     segs = segm_segs
                 else:
-                    segm_mask = core.segs_to_combined_mask(segm_segs)
-                    segs = core.segs_bitwise_and_mask(segs, segm_mask)
+                    segs = core.segs_bitwise_and_mask(segs, core.segs_to_combined_mask(segm_segs))
 
             def segment_area(seg):
-                return (
-                    (seg.bbox[2] - seg.bbox[0])
-                    * (seg.bbox[3] - seg.bbox[1])
-                )
-
+                return (seg.bbox[2] - seg.bbox[0]) * (seg.bbox[3] - seg.bbox[1])
             def has_nonzero_mask(seg):
                 mask = seg.cropped_mask
                 if mask is None:
                     return False
-                if torch.is_tensor(mask):
-                    return bool(torch.count_nonzero(mask))
-                return bool(np.count_nonzero(mask))
+                return bool(torch.count_nonzero(mask)) if torch.is_tensor(mask) else bool(np.count_nonzero(mask))
 
             final_faces = [seg for seg in segs[1] if has_nonzero_mask(seg)]
             final_faces.sort(key=segment_area, reverse=True)
             segs = (segs[0], final_faces[:max_faces])
-
+            reference_faces = []
             if edit_mode and segs[1]:
-                bbox_detector.setAux('face')
+                bbox_detector.setAux("face")
                 try:
-                    reference_segs = bbox_detector.detect(
-                        face_reference, bbox_threshold, bbox_dilation,
-                        bbox_crop_factor, drop_size,
-                        detailer_hook=detailer_hook,
-                    )
+                    reference_segs = bbox_detector.detect(face_reference, bbox_threshold, bbox_dilation,
+                                                          bbox_crop_factor, drop_size, detailer_hook=detailer_hook)
                 finally:
                     bbox_detector.setAux(None)
-                reference_faces = sorted(
-                    reference_segs[1], key=segment_area, reverse=True,
-                )
+                reference_faces = sorted([seg for seg in reference_segs[1] if has_nonzero_mask(seg)],
+                                         key=segment_area, reverse=True)
                 if not reference_faces:
-                    raise ValueError(
-                        "DonutFaceDetailer found no face in face_reference."
-                    )
+                    raise ValueError("DonutFaceDetailer found no face in face_reference.")
 
-            # Process each segment with megapixel-based sizing
-            if len(segs[1]) > 0:
+            wildcard_concat_mode = None
+            wildcard_chooser = None
+            wildcard_mode = None
+            if wildcard_opt:
+                wildcard_text = wildcard_opt
+                if wildcard_text.startswith("[CONCAT]"):
+                    wildcard_concat_mode, wildcard_text = "concat", wildcard_text[8:]
+                wildcard_mode, wildcard_chooser = impact_wildcards.process_wildcard_for_segs(wildcard_text)
+
+            if segs[1]:
                 enhanced_img = image.clone()
-                cropped_enhanced = []
-                cropped_enhanced_alpha = []
-                cnet_pil_list = []
-
+                cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list = [], [], []
                 for face_index, seg in enumerate(segs[1]):
-                    # Get crop region
-                    cropped_image = seg.cropped_image
-                    cropped_mask = seg.cropped_mask
-                    crop_region = seg.crop_region
-                    bbox = seg.bbox
-
+                    crop_region, bbox, cropped_mask = seg.crop_region, seg.bbox, seg.cropped_mask
+                    cropped_image = impact_utils.crop_image(enhanced_img, crop_region)
                     face_reference_crop = None
                     if edit_mode:
-                        reference_seg = reference_faces[
-                            min(face_index, len(reference_faces) - 1)
-                        ]
+                        reference_seg = reference_faces[min(face_index, len(reference_faces) - 1)]
                         face_reference_crop = reference_seg.cropped_image
                         if face_reference_crop is None:
-                            face_reference_crop = impact_utils.crop_image(
-                                face_reference, reference_seg.crop_region,
-                            )
+                            face_reference_crop = impact_utils.crop_image(face_reference, reference_seg.crop_region)
+                    noise_mask = (_resize_mask(cropped_mask, cropped_image.shape[1], cropped_image.shape[2])
+                                  if noise_mask_enabled and cropped_mask is not None else None)
 
-                    if cropped_image is None:
-                        cropped_image = impact_utils.crop_image(image, crop_region)
-
-                    if noise_mask_enabled and cropped_mask is not None:
-                        # Convert to tensor if numpy array
-                        if isinstance(cropped_mask, np.ndarray):
-                            cropped_mask = torch.from_numpy(cropped_mask)
-                        # Resize mask using torch interpolate - ensure 4D (N, C, H, W)
-                        orig_shape = cropped_mask.shape
-                        if len(orig_shape) == 2:
-                            mask_4d = cropped_mask.unsqueeze(0).unsqueeze(0)
-                        elif len(orig_shape) == 3:
-                            mask_4d = cropped_mask.unsqueeze(0)
+                    wildcard_item, wildcard_seed = None, None
+                    if wildcard_chooser is not None:
+                        if wildcard_mode == "LAB":
+                            wildcard_item = wildcard_chooser.get(seg)
                         else:
-                            mask_4d = cropped_mask
-                        mask_4d = mask_4d.float()
-                        noise_mask = torch.nn.functional.interpolate(
-                            mask_4d, size=(cropped_image.shape[1], cropped_image.shape[2]), mode='bilinear', align_corners=False
-                        ).squeeze(0).squeeze(0)
+                            wildcard_seed, wildcard_item = wildcard_chooser.get(seg)
+                        if wildcard_item and wildcard_item.strip() == "[SKIP]":
+                            continue
+                        if wildcard_item and wildcard_item.strip() == "[STOP]":
+                            break
+                    if wildcard_seed is not None:
+                        face_seed = wildcard_seed
+                    elif vary_seed_per_face:
+                        face_seed = (seed + face_index) & 0xffffffffffffffff
                     else:
-                        noise_mask = None
+                        face_seed = seed
 
-                    # Run detail enhancement cycles
-                    enhanced_cropped = cropped_image
-                    face_seed = (
-                        seed + face_index if vary_seed_per_face else seed
-                    ) & 0xffffffffffffffff
-                    for c in range(cycle):
-                        cycle_seed = (face_seed + c * 1000) & 0xffffffffffffffff
-                        result, _ = DonutFaceDetailer.enhance_detail_megapixel(
-                            enhanced_cropped, model, clip, vae, resolution, max_resolution, guide_size_for_bbox, bbox, cycle_seed, steps, cfg,
-                            sampler_name, scheduler, positive, negative, denoise,
-                            noise_mask if c == 0 else None, force_inpaint, noise_mask_feather,
-                            inpaint_model, detailer_hook, scheduler_func_opt,
-                            edit_mode, edit_prompt, edit_negative_prompt, grounding_px,
-                            edit_model, face_reference_crop)
-
-                        if result is not None:
-                            # Resize back to original crop size
-                            enhanced_cropped = impact_utils.tensor_resize(result, cropped_image.shape[2], cropped_image.shape[1])
-
-                    # Paste back
-                    if enhanced_cropped is not None:
-                        # Prepare mask for pasting with feathering
-                        paste_mask = impact_utils.to_tensor(seg.cropped_mask)
-                        paste_mask = impact_utils.tensor_gaussian_blur_mask(paste_mask, feather)
-                        enhanced_img = enhanced_img.cpu()
-                        enhanced_cropped = enhanced_cropped.cpu()
-                        impact_utils.tensor_paste(enhanced_img, enhanced_cropped, (crop_region[0], crop_region[1]), paste_mask)
-                        cropped_enhanced.append(enhanced_cropped)
-
-                        # Create alpha version (just use the enhanced image for now)
-                        cropped_enhanced_alpha.append(enhanced_cropped)
-
+                    result, _ = DonutFaceDetailer.enhance_detail_megapixel(
+                        cropped_image, model, clip, vae, resolution, max_resolution,
+                        guide_size_for_bbox, bbox, face_seed, steps, cfg, sampler_name,
+                        scheduler, positive, negative, denoise, noise_mask, force_inpaint,
+                        noise_mask_feather, inpaint_model, detailer_hook, scheduler_func_opt,
+                        edit_mode, edit_prompt, edit_negative_prompt, grounding_px, edit_model,
+                        face_reference_crop, cycle=cycle, wildcard_opt=wildcard_item,
+                        wildcard_concat_mode=wildcard_concat_mode)
+                    if result is None:
+                        continue
+                    enhanced_cropped = impact_utils.tensor_resize(result, cropped_image.shape[2], cropped_image.shape[1])
+                    paste_mask = impact_utils.tensor_gaussian_blur_mask(impact_utils.to_tensor(seg.cropped_mask), feather)
+                    enhanced_img, enhanced_cropped = enhanced_img.cpu(), enhanced_cropped.cpu()
+                    impact_utils.tensor_paste(enhanced_img, enhanced_cropped,
+                                              (crop_region[0], crop_region[1]), paste_mask)
+                    if detailer_hook is not None and hasattr(detailer_hook, "post_paste"):
+                        enhanced_img = detailer_hook.post_paste(enhanced_img)
+                    cropped_enhanced.append(enhanced_cropped)
+                    enhanced_alpha = impact_utils.tensor_convert_rgba(enhanced_cropped)
+                    alpha_mask = paste_mask
+                    if alpha_mask.shape[1:3] != enhanced_alpha.shape[1:3]:
+                        alpha_mask = impact_utils.tensor_resize(alpha_mask, enhanced_alpha.shape[2], enhanced_alpha.shape[1])
+                    impact_utils.tensor_putalpha(enhanced_alpha, alpha_mask)
+                    cropped_enhanced_alpha.append(enhanced_alpha)
             else:
-                enhanced_img = image
-                cropped_enhanced = []
-                cropped_enhanced_alpha = []
-                cnet_pil_list = []
+                enhanced_img, cropped_enhanced, cropped_enhanced_alpha, cnet_pil_list = image, [], [], []
 
-            # Generate combined mask
             mask = core.segs_to_combined_mask(segs)
-
-            if len(cropped_enhanced) == 0:
+            if not cropped_enhanced:
                 cropped_enhanced = [impact_utils.empty_pil_tensor()]
-
-            if len(cropped_enhanced_alpha) == 0:
+            if not cropped_enhanced_alpha:
                 cropped_enhanced_alpha = [impact_utils.empty_pil_tensor()]
-
-            if len(cnet_pil_list) == 0:
+            if not cnet_pil_list:
                 cnet_pil_list = [impact_utils.empty_pil_tensor()]
-
             return enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list
 
-        def doit(self, image, model, clip, vae, resolution, max_resolution, guide_size_for, seed, steps, cfg, sampler_name,
-                 scheduler, positive, negative, denoise, feather, noise_mask, force_inpaint,
-                 bbox_threshold, bbox_dilation, bbox_crop_factor,
-                 sam_detection_hint, sam_dilation, sam_threshold, sam_bbox_expansion, sam_mask_hint_threshold,
-                 sam_mask_hint_use_negative, drop_size, bbox_detector, wildcard, cycle, max_faces,
-                 sam_model_opt=None, segm_detector_opt=None, detailer_hook=None, inpaint_model=False,
-                 noise_mask_feather=0, scheduler_func_opt=None, edit_mode=False,
-                 edit_prompt="Enhance facial details while preserving identity.",
-                 edit_negative_prompt="", grounding_px=768, edit_model=None,
-                 face_reference=None, vary_seed_per_face=False, turbo_mode=False):
-
-            # Convert resolution from square side length to total pixels
-            resolution = resolution * resolution
-
-            result_img = None
-            result_mask = None
-            result_cropped_enhanced = []
-            result_cropped_enhanced_alpha = []
-            result_cnet_images = []
-
+        def doit(
+            self, image, model, clip, vae, resolution, max_resolution, guide_size_for,
+            seed, steps, cfg, sampler_name, scheduler, positive, negative, denoise,
+            feather, noise_mask, force_inpaint, bbox_threshold, bbox_dilation,
+            bbox_crop_factor, sam_detection_hint, sam_dilation, sam_threshold,
+            sam_bbox_expansion, sam_mask_hint_threshold, sam_mask_hint_use_negative,
+            drop_size, bbox_detector, wildcard, cycle, max_faces, sam_model_opt=None,
+            segm_detector_opt=None, detailer_hook=None, inpaint_model=False,
+            noise_mask_feather=0, scheduler_func_opt=None, edit_mode=False,
+            edit_prompt="Enhance facial details while preserving identity.",
+            edit_negative_prompt="", grounding_px=768, edit_model=None,
+            face_reference=None, vary_seed_per_face=False, turbo_mode=False,
+        ):
+            resolution *= resolution
+            result_img = result_mask = None
+            result_cropped_enhanced, result_cropped_enhanced_alpha, result_cnet_images = [], [], []
             if len(image) > 1:
                 logging.warning("[DonutFaceDetailer] WARN: Not designed for video. Use Detailer For AnimateDiff.")
-
-            for i, single_image in enumerate(image):
+            for index, single_image in enumerate(image):
                 single_face_reference = None
                 if face_reference is not None:
-                    reference_index = min(i, len(face_reference) - 1)
+                    reference_index = min(index, len(face_reference) - 1)
                     single_face_reference = face_reference[reference_index].unsqueeze(0)
-                enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list = \
-                    DonutFaceDetailer.enhance_face(
-                        single_image.unsqueeze(0), model, clip, vae, resolution, max_resolution, guide_size_for,
-                        seed + i, steps, cfg, sampler_name, scheduler, positive, negative, denoise, feather,
-                        noise_mask, force_inpaint, bbox_threshold, bbox_dilation, bbox_crop_factor,
-                        sam_detection_hint, sam_dilation, sam_threshold, sam_bbox_expansion,
-                        sam_mask_hint_threshold, sam_mask_hint_use_negative, drop_size, bbox_detector,
-                        max_faces, segm_detector_opt, sam_model_opt, wildcard, detailer_hook,
-                        cycle=cycle, inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather,
-                        scheduler_func_opt=scheduler_func_opt, edit_mode=edit_mode,
-                        edit_prompt=edit_prompt, edit_negative_prompt=edit_negative_prompt,
-                        grounding_px=grounding_px, edit_model=edit_model,
-                        face_reference=single_face_reference,
-                        vary_seed_per_face=vary_seed_per_face,
-                        turbo_mode=turbo_mode)
-
+                enhanced_img, cropped_enhanced, cropped_enhanced_alpha, mask, cnet_pil_list = DonutFaceDetailer.enhance_face(
+                    single_image.unsqueeze(0), model, clip, vae, resolution, max_resolution,
+                    guide_size_for, seed + index, steps, cfg, sampler_name, scheduler,
+                    positive, negative, denoise, feather, noise_mask, force_inpaint,
+                    bbox_threshold, bbox_dilation, bbox_crop_factor, sam_detection_hint,
+                    sam_dilation, sam_threshold, sam_bbox_expansion, sam_mask_hint_threshold,
+                    sam_mask_hint_use_negative, drop_size, bbox_detector, max_faces,
+                    segm_detector_opt, sam_model_opt, wildcard, detailer_hook, cycle=cycle,
+                    inpaint_model=inpaint_model, noise_mask_feather=noise_mask_feather,
+                    scheduler_func_opt=scheduler_func_opt, edit_mode=edit_mode,
+                    edit_prompt=edit_prompt, edit_negative_prompt=edit_negative_prompt,
+                    grounding_px=grounding_px, edit_model=edit_model,
+                    face_reference=single_face_reference, vary_seed_per_face=vary_seed_per_face,
+                    turbo_mode=turbo_mode)
                 result_img = torch.cat((result_img, enhanced_img), dim=0) if result_img is not None else enhanced_img
                 result_mask = torch.cat((result_mask, mask), dim=0) if result_mask is not None else mask
                 result_cropped_enhanced.extend(cropped_enhanced)
                 result_cropped_enhanced_alpha.extend(cropped_enhanced_alpha)
                 result_cnet_images.extend(cnet_pil_list)
-
-            pipe = (model, clip, vae, positive, negative, wildcard, bbox_detector, segm_detector_opt, sam_model_opt,
-                    detailer_hook, None, None, None, None)
+            pipe = (model, clip, vae, positive, negative, wildcard, bbox_detector,
+                    segm_detector_opt, sam_model_opt, detailer_hook, None, None, None, None)
             return result_img, result_cropped_enhanced, result_cropped_enhanced_alpha, result_mask, pipe, result_cnet_images
 
-    NODE_CLASS_MAPPINGS = {
-        "DonutFaceDetailer": DonutFaceDetailer,
-    }
-
-    NODE_DISPLAY_NAME_MAPPINGS = {
-        "DonutFaceDetailer": "Face Detailer (Max Faces)",
-    }
-
+    NODE_CLASS_MAPPINGS = {"DonutFaceDetailer": DonutFaceDetailer}
+    NODE_DISPLAY_NAME_MAPPINGS = {"DonutFaceDetailer": "Face Detailer (Max Faces)"}
 else:
     NODE_CLASS_MAPPINGS = {}
     NODE_DISPLAY_NAME_MAPPINGS = {}

--- a/test_donut_face_detailer.py
+++ b/test_donut_face_detailer.py
@@ -6,10 +6,14 @@ import unittest
 
 import numpy as np
 import torch
-import donut_detailer_core as lifecycle_core
+import torch.nn.functional as F
 
 
 lifecycle_calls = []
+sample_calls = []
+resize_calls = []
+encode_calls = []
+wildcard_calls = []
 
 
 class FakeModel:
@@ -18,15 +22,27 @@ class FakeModel:
         self.model_options = model_options or {}
 
 
+class FakeVAE:
+    def __init__(self):
+        self.decode_calls = 0
+
+    def decode(self, samples):
+        self.decode_calls += 1
+        return samples[:, :3].permute(0, 2, 3, 1).contiguous()
+
+
 class FakeSegment:
     def __init__(self, name, bbox, mask_value=1.0):
         self.name = name
         self.bbox = bbox
         self.crop_region = bbox
-        height = max(1, bbox[3] - bbox[1])
-        width = max(1, bbox[2] - bbox[0])
-        self.cropped_mask = np.full((height, width), mask_value, dtype=np.float32)
-        self.cropped_image = torch.zeros(1, height, width, 3)
+        h = max(1, bbox[3] - bbox[1])
+        w = max(1, bbox[2] - bbox[0])
+        self.cropped_mask = np.full((h, w), mask_value, dtype=np.float32)
+        self.cropped_image = torch.zeros(1, h, w, 3)
+        self.confidence = 1.0
+        self.label = "face"
+        self.control_net_wrapper = None
 
 
 class FakeDetector:
@@ -39,8 +55,7 @@ class FakeDetector:
     def setAux(self, value):
         self.aux = value
 
-    def detect(self, image, threshold, dilation, crop_factor, drop_size,
-               detailer_hook=None):
+    def detect(self, image, threshold, dilation, crop_factor, drop_size, detailer_hook=None):
         is_reference = bool(float(image.mean()) > 0.5)
         self.calls.append("reference" if is_reference else "target")
         segments = self.reference_segments if is_reference else self.target_segments
@@ -50,385 +65,419 @@ class FakeDetector:
 fake_comfy = types.ModuleType("comfy")
 fake_comfy.__path__ = []
 fake_samplers = types.ModuleType("comfy.samplers")
-fake_samplers.KSampler = types.SimpleNamespace(
-    SAMPLERS=["euler"], SCHEDULERS=["simple"],
-)
+fake_samplers.KSampler = types.SimpleNamespace(SAMPLERS=["euler"], SCHEDULERS=["simple"])
 fake_sample = types.ModuleType("comfy.sample")
 fake_management = types.ModuleType("comfy.model_management")
 fake_management.unload_all_models = lambda: None
-fake_utils = types.ModuleType("comfy.utils")
+fake_utils_mod = types.ModuleType("comfy.utils")
 fake_comfy.samplers = fake_samplers
 fake_comfy.sample = fake_sample
 fake_comfy.model_management = fake_management
-fake_comfy.utils = fake_utils
+fake_comfy.utils = fake_utils_mod
 
 fake_nodes = types.ModuleType("nodes")
 fake_nodes.MAX_RESOLUTION = 16384
 
+
+class FakeInpaintModelConditioning:
+    calls = []
+
+    def encode(self, positive, negative, image, vae, mask=None, noise_mask=True):
+        self.calls.append((image.shape, mask.shape, noise_mask))
+        latent = fake_to_latent_image(image, vae)
+        latent["inpaint"] = True
+        return positive, negative, latent
+
+
+class FakeConditioningConcat:
+    def concat(self, a, b):
+        return (list(a) + list(b),)
+
+
+class FakeConditioningCombine:
+    def combine(self, a, b):
+        return (list(a) + list(b),)
+
+
+fake_nodes.InpaintModelConditioning = FakeInpaintModelConditioning
+fake_nodes.ConditioningConcat = FakeConditioningConcat
+fake_nodes.ConditioningCombine = FakeConditioningCombine
+
 fake_detailer_core = types.ModuleType("donut_detailer_core")
-fake_detailer_core.scale_to_megapixels = lambda w, h, resolution, maximum: (w, h)
-fake_detailer_core.sample_and_decode = lambda *args, **kwargs: args[0]
 fake_detailer_core.offload_model_for_auxiliary_stage = (
-    lambda model, model_management: lifecycle_calls.append(model)
+    lambda model, management: lifecycle_calls.append(model)
 )
 
 fake_krea = types.ModuleType("krea2_edit_integration")
 fake_krea.crop_image_padding = lambda image, padding: image
 fake_krea.pad_image_to_multiple = lambda image: (image, (0, 0, 0, 0))
-fake_krea.prepare_krea2_edit = lambda *args, **kwargs: (
-    args[0], args[3], args[3], {"samples": torch.zeros(1, 1, 1, 1)}, args[3],
+fake_krea.prepare_krea2_edit = lambda model, clip, vae, ref, prompt, negative, grounding, width, height: (
+    FakeModel("prepared"), ["edit-positive"], ["edit-negative"],
+    {"samples": torch.zeros(1, 4, 8, 8)}, ref,
 )
+
+fake_turbo = types.ModuleType("turbo_sampling")
+fake_turbo.resolve_turbo_sampling = lambda steps, denoise, scheduler: (2, 0.25, 0.308)
 
 fake_impact = types.ModuleType("impact")
 fake_impact.__path__ = []
 fake_impact_core = types.ModuleType("impact.core")
 fake_impact_utils = types.ModuleType("impact.utils")
 fake_impact_sampling = types.ModuleType("impact.impact_sampling")
+fake_wildcards = types.ModuleType("impact.wildcards")
 fake_impact.core = fake_impact_core
 fake_impact.utils = fake_impact_utils
 fake_impact.impact_sampling = fake_impact_sampling
+fake_impact.wildcards = fake_wildcards
 
-fake_impact_core.segs_to_combined_mask = lambda segs: torch.zeros(
-    1, segs[0][0], segs[0][1],
+
+def fake_tensor_resize(image, width, height):
+    resize_calls.append((image.shape[2], image.shape[1], width, height, image.shape[-1]))
+    nchw = image.permute(0, 3, 1, 2).float()
+    out = F.interpolate(nchw, size=(height, width), mode="bilinear", align_corners=False)
+    return out.permute(0, 2, 3, 1).contiguous()
+
+
+def fake_to_latent_image(image, vae):
+    encode_calls.append(tuple(image.shape))
+    nchw = image.permute(0, 3, 1, 2).float()
+    if nchw.shape[1] < 4:
+        extra = torch.zeros(nchw.shape[0], 4 - nchw.shape[1], nchw.shape[2], nchw.shape[3])
+        nchw = torch.cat([nchw, extra], dim=1)
+    return {"samples": nchw}
+
+
+def fake_tensor_paste(dest, src, left_top, mask):
+    x, y = left_top
+    h, w = src.shape[1:3]
+    m = mask
+    if isinstance(m, np.ndarray):
+        m = torch.from_numpy(m)
+    if m.ndim == 2:
+        m = m[None, ..., None]
+    elif m.ndim == 3:
+        m = m[..., None]
+    if m.shape[1:3] != (h, w):
+        m = fake_tensor_resize(m, w, h)
+    dest[:, y:y+h, x:x+w] = dest[:, y:y+h, x:x+w] * (1 - m) + src * m
+
+
+def fake_tensor_convert_rgba(image):
+    if image.shape[-1] == 4:
+        return image.clone()
+    alpha = torch.ones(*image.shape[:-1], 1, dtype=image.dtype)
+    return torch.cat([image[..., :3], alpha], dim=-1)
+
+
+def fake_tensor_putalpha(image, mask):
+    if mask.ndim == 3:
+        mask = mask[..., None]
+    image[..., 3:4] = mask[..., :1]
+
+
+fake_impact_utils.tensor_resize = fake_tensor_resize
+fake_impact_utils.to_latent_image = fake_to_latent_image
+fake_impact_utils.crop_image = lambda image, region: image[:, region[1]:region[3], region[0]:region[2], :]
+fake_impact_utils.to_tensor = lambda value: torch.as_tensor(value).float()
+fake_impact_utils.tensor_gaussian_blur_mask = lambda mask, feather: (
+    torch.as_tensor(mask).float()[None, ..., None]
+    if torch.as_tensor(mask).ndim == 2 else torch.as_tensor(mask).float()
 )
+fake_impact_utils.tensor_paste = fake_tensor_paste
+fake_impact_utils.tensor_convert_rgba = fake_tensor_convert_rgba
+fake_impact_utils.tensor_putalpha = fake_tensor_putalpha
+fake_impact_utils.empty_pil_tensor = lambda: torch.zeros(1, 1, 1, 3)
+
+fake_impact_core.segs_to_combined_mask = lambda segs: torch.zeros(1, segs[0][0], segs[0][1])
 fake_impact_core.make_sam_mask = lambda *args, **kwargs: object()
 fake_impact_core.segs_bitwise_and_mask = lambda segs, mask: segs
-fake_impact_utils.tensor_gaussian_blur_mask = lambda mask, feather: torch.ones(
-    1, mask.shape[-2], mask.shape[-1], 1,
-)
-fake_impact_utils.tensor_resize = lambda image, width, height: torch.zeros(
-    image.shape[0], height, width, image.shape[-1],
-)
-fake_impact_utils.to_latent_image = lambda image, vae: {
-    "samples": torch.zeros(image.shape[0], 1, image.shape[1], image.shape[2]),
-}
-fake_impact_utils.crop_image = lambda image, region: image[
-    :, region[1]:region[3], region[0]:region[2], :
-]
-fake_impact_utils.to_tensor = lambda mask: torch.as_tensor(mask).float()
-fake_impact_utils.tensor_paste = lambda *args, **kwargs: None
-fake_impact_utils.empty_pil_tensor = lambda: torch.zeros(1, 1, 1, 3)
+
+
+def fake_ksampler_wrapper(model, seed, steps, cfg, sampler, scheduler, positive, negative, latent, denoise, **kwargs):
+    sample_calls.append({
+        "model": model, "seed": seed, "steps": steps,
+        "positive": positive, "negative": negative, "latent": latent,
+        "sampler_opt": kwargs.get("sampler_opt"), "noise": kwargs.get("noise"),
+    })
+    out = dict(latent)
+    out["samples"] = latent["samples"] + 0.01
+    return out
+
+
+fake_impact_sampling.ksampler_wrapper = fake_ksampler_wrapper
+
+
+class FakeChooser:
+    def __init__(self, text):
+        self.text = text
+
+    def get(self, seg):
+        return None, self.text
+
+
+fake_wildcards.process_wildcard_for_segs = lambda text: (None, FakeChooser(text))
+
+
+def fake_process_with_loras(text, model, clip):
+    wildcard_calls.append((text, model))
+    return FakeModel("wildcard-model", model.model_options), clip, ["wild-positive"]
+
+
+fake_wildcards.process_with_loras = fake_process_with_loras
 
 fake_comfy_extras = types.ModuleType("comfy_extras")
 fake_comfy_extras.__path__ = []
 fake_dd = types.ModuleType("comfy_extras.nodes_differential_diffusion")
 fake_dd.DifferentialDiffusion = type(
-    "DifferentialDiffusion",
-    (),
-    {"execute": lambda self, model: (model,)},
+    "DifferentialDiffusion", (), {"execute": lambda self, model: (model,)}
 )
 fake_comfy_extras.nodes_differential_diffusion = fake_dd
 
-_fake_modules = {
+_modules = {
     "comfy": fake_comfy,
     "comfy.samplers": fake_samplers,
     "comfy.sample": fake_sample,
     "comfy.model_management": fake_management,
-    "comfy.utils": fake_utils,
+    "comfy.utils": fake_utils_mod,
     "nodes": fake_nodes,
     "donut_detailer_core": fake_detailer_core,
     "krea2_edit_integration": fake_krea,
+    "turbo_sampling": fake_turbo,
     "impact": fake_impact,
     "impact.core": fake_impact_core,
     "impact.utils": fake_impact_utils,
     "impact.impact_sampling": fake_impact_sampling,
+    "impact.wildcards": fake_wildcards,
     "comfy_extras": fake_comfy_extras,
     "comfy_extras.nodes_differential_diffusion": fake_dd,
 }
 _missing = object()
-_previous_modules = {name: sys.modules.get(name, _missing) for name in _fake_modules}
-sys.modules.update(_fake_modules)
+_previous = {name: sys.modules.get(name, _missing) for name in _modules}
+sys.modules.update(_modules)
 try:
     spec = importlib.util.spec_from_file_location(
-        "donut_face_detailer_tested",
-        Path(__file__).with_name("DonutFaceDetailer.py"),
+        "donut_face_detailer_tested", Path(__file__).with_name("DonutFaceDetailer.py")
     )
     module = importlib.util.module_from_spec(spec)
     spec.loader.exec_module(module)
 finally:
-    for name, previous in _previous_modules.items():
-        if previous is _missing:
+    for name, old in _previous.items():
+        if old is _missing:
             sys.modules.pop(name, None)
         else:
-            sys.modules[name] = previous
+            sys.modules[name] = old
 
 
 class DonutFaceDetailerTests(unittest.TestCase):
     def setUp(self):
         lifecycle_calls.clear()
-        self.original_prepare = module.prepare_krea2_edit
-        self.original_sample = module.sample_and_decode
+        sample_calls.clear()
+        resize_calls.clear()
+        encode_calls.clear()
+        wildcard_calls.clear()
+        FakeInpaintModelConditioning.calls.clear()
+        self.original_enhance = module.DonutFaceDetailer.enhance_detail_megapixel
         self.original_dd = module.nodes_differential_diffusion.DifferentialDiffusion
         self.original_sam_and = module.core.segs_bitwise_and_mask
-        self.original_enhance = module.DonutFaceDetailer.enhance_detail_megapixel
+        self.original_prepare = module.prepare_krea2_edit
 
     def tearDown(self):
-        module.prepare_krea2_edit = self.original_prepare
-        module.sample_and_decode = self.original_sample
+        module.DonutFaceDetailer.enhance_detail_megapixel = self.original_enhance
         module.nodes_differential_diffusion.DifferentialDiffusion = self.original_dd
         module.core.segs_bitwise_and_mask = self.original_sam_and
-        module.DonutFaceDetailer.enhance_detail_megapixel = self.original_enhance
+        module.prepare_krea2_edit = self.original_prepare
 
     def detail_kwargs(self, **overrides):
         values = {
-            "image": torch.zeros(1, 32, 32, 3),
-            "model": FakeModel("base"),
-            "clip": object(),
-            "vae": object(),
-            "resolution": 1024 * 1024,
-            "max_resolution": 0,
-            "guide_size_for_bbox": False,
-            "bbox": (0, 0, 32, 32),
-            "seed": 7,
-            "steps": 2,
-            "cfg": 1.0,
-            "sampler_name": "euler",
-            "scheduler": "simple",
-            "positive": object(),
-            "negative": object(),
-            "denoise": 0.4,
-            "noise_mask": torch.ones(32, 32),
+            "image": torch.zeros(1, 300, 500, 3), "model": FakeModel("base"),
+            "clip": object(), "vae": FakeVAE(), "resolution": 1024 * 1024,
+            "max_resolution": 0, "guide_size_for_bbox": False,
+            "bbox": (0, 0, 200, 200), "seed": 7, "steps": 4, "cfg": 1.0,
+            "sampler_name": "euler", "scheduler": "simple", "positive": ["pos"],
+            "negative": ["neg"], "denoise": 0.4, "noise_mask": None,
             "force_inpaint": True,
-            "noise_mask_feather": 8,
-            "edit_mode": True,
-            "edit_model": FakeModel("edit"),
-            "face_reference_crop": torch.ones(1, 32, 32, 3),
         }
         values.update(overrides)
         return values
 
     def face_kwargs(self, detector, **overrides):
         values = {
-            "image": torch.zeros(1, 64, 64, 3),
-            "model": FakeModel("base"),
-            "clip": object(),
-            "vae": object(),
-            "resolution": 1024 * 1024,
-            "max_resolution": 0,
-            "guide_size_for_bbox": False,
-            "seed": 20,
-            "steps": 2,
-            "cfg": 1.0,
-            "sampler_name": "euler",
-            "scheduler": "simple",
-            "positive": object(),
-            "negative": object(),
-            "denoise": 0.4,
-            "feather": 0,
-            "noise_mask_enabled": False,
-            "force_inpaint": True,
-            "bbox_threshold": 0.2,
-            "bbox_dilation": 0,
-            "bbox_crop_factor": 1.0,
-            "sam_detection_hint": "center-1",
-            "sam_dilation": 0,
-            "sam_threshold": 0.9,
-            "sam_bbox_expansion": 0,
-            "sam_mask_hint_threshold": 0.7,
-            "sam_mask_hint_use_negative": "False",
-            "drop_size": 1,
-            "bbox_detector": detector,
-            "max_faces": 2,
-            "cycle": 1,
+            "image": torch.zeros(1, 64, 64, 3), "model": FakeModel("base"),
+            "clip": object(), "vae": FakeVAE(), "resolution": 1024 * 1024,
+            "max_resolution": 0, "guide_size_for_bbox": False, "seed": 20,
+            "steps": 4, "cfg": 1.0, "sampler_name": "euler", "scheduler": "simple",
+            "positive": ["pos"], "negative": ["neg"], "denoise": 0.4, "feather": 0,
+            "noise_mask_enabled": False, "force_inpaint": True, "bbox_threshold": 0.2,
+            "bbox_dilation": 0, "bbox_crop_factor": 1.0, "sam_detection_hint": "center-1",
+            "sam_dilation": 0, "sam_threshold": 0.9, "sam_bbox_expansion": 0,
+            "sam_mask_hint_threshold": 0.7, "sam_mask_hint_use_negative": "False",
+            "drop_size": 1, "bbox_detector": detector, "max_faces": 2, "cycle": 1,
         }
         values.update(overrides)
         return values
 
-    def test_differential_diffusion_patches_prepared_edit_model(self):
-        prepared = FakeModel("prepared")
-        patched = FakeModel("patched")
-        calls = {"dd": [], "sample": []}
+    def test_sampling_canvas_is_64_aligned_and_cycles_stay_latent(self):
+        vae = FakeVAE()
+        result, _ = module.DonutFaceDetailer.enhance_detail_megapixel(
+            **self.detail_kwargs(vae=vae, cycle=3))
+        self.assertEqual(len(encode_calls), 1)
+        self.assertEqual(len(sample_calls), 3)
+        self.assertEqual(vae.decode_calls, 1)
+        target_h, target_w = result.shape[1:3]
+        self.assertEqual(target_w % 64, 0)
+        self.assertEqual(target_h % 64, 0)
+        self.assertEqual([call["seed"] for call in sample_calls], [7, 1007, 2007])
 
+    def test_max_resolution_remains_aligned(self):
+        result, _ = module.DonutFaceDetailer.enhance_detail_megapixel(
+            **self.detail_kwargs(max_resolution=1024))
+        h, w = result.shape[1:3]
+        self.assertLessEqual(max(h, w), 1024)
+        self.assertEqual(h % 64, 0)
+        self.assertEqual(w % 64, 0)
+
+    def test_inpaint_model_conditioning_is_used(self):
+        module.DonutFaceDetailer.enhance_detail_megapixel(
+            **self.detail_kwargs(noise_mask=torch.ones(300, 500),
+                                 noise_mask_feather=0, inpaint_model=True))
+        self.assertEqual(len(FakeInpaintModelConditioning.calls), 1)
+        self.assertTrue(sample_calls[0]["latent"].get("inpaint"))
+
+    def test_wildcard_conditioning_reaches_sampler(self):
+        module.DonutFaceDetailer.enhance_detail_megapixel(
+            **self.detail_kwargs(wildcard_opt="sharp portrait"))
+        self.assertEqual(wildcard_calls[0][0], "sharp portrait")
+        self.assertEqual(sample_calls[0]["model"].name, "wildcard-model")
+        self.assertEqual(sample_calls[0]["positive"], ["wild-positive"])
+
+    def test_differential_diffusion_patches_actual_edit_model(self):
+        prepared, patched, dd_calls = FakeModel("prepared"), FakeModel("patched"), []
         module.prepare_krea2_edit = lambda *args, **kwargs: (
-            prepared, object(), object(), {"samples": torch.zeros(1, 1, 1, 1)}, object(),
-        )
-
-        class FakeDifferentialDiffusion:
+            prepared, ["edit-pos"], ["edit-neg"], {}, None)
+        class DD:
             def execute(self, model):
-                calls["dd"].append(model)
+                dd_calls.append(model)
                 return (patched,)
-
-        module.nodes_differential_diffusion.DifferentialDiffusion = FakeDifferentialDiffusion
-
-        def sample(model, *args, **kwargs):
-            calls["sample"].append(model)
-            return torch.zeros(1, 32, 32, 3)
-
-        module.sample_and_decode = sample
-        module.DonutFaceDetailer.enhance_detail_megapixel(**self.detail_kwargs())
-
-        self.assertEqual(calls["dd"], [prepared])
-        self.assertEqual(calls["sample"], [patched])
+        module.nodes_differential_diffusion.DifferentialDiffusion = DD
+        module.DonutFaceDetailer.enhance_detail_megapixel(**self.detail_kwargs(
+            image=torch.zeros(1, 64, 64, 3), bbox=(0, 0, 32, 32),
+            noise_mask=torch.ones(64, 64), noise_mask_feather=8, edit_mode=True,
+            edit_model=FakeModel("edit"), face_reference_crop=torch.ones(1, 64, 64, 3)))
+        self.assertEqual(dd_calls, [prepared])
+        self.assertIs(sample_calls[0]["model"], patched)
 
     def test_existing_denoise_mask_function_skips_differential_diffusion(self):
-        prepared = FakeModel("prepared", {"denoise_mask_function": object()})
         calls = []
-        module.prepare_krea2_edit = lambda *args, **kwargs: (
-            prepared, object(), object(), {"samples": torch.zeros(1, 1, 1, 1)}, object(),
-        )
-
-        class FakeDifferentialDiffusion:
+        class DD:
             def execute(self, model):
                 calls.append(model)
                 return (model,)
-
-        module.nodes_differential_diffusion.DifferentialDiffusion = FakeDifferentialDiffusion
-        module.sample_and_decode = lambda *args, **kwargs: torch.zeros(1, 32, 32, 3)
-
-        module.DonutFaceDetailer.enhance_detail_megapixel(**self.detail_kwargs())
-
+        module.nodes_differential_diffusion.DifferentialDiffusion = DD
+        module.DonutFaceDetailer.enhance_detail_megapixel(**self.detail_kwargs(
+            model=FakeModel("base", {"denoise_mask_function": object()}),
+            noise_mask=torch.ones(300, 500), noise_mask_feather=8))
         self.assertEqual(calls, [])
 
-    def test_final_refinement_discards_empty_masks_then_applies_max_faces(self):
-        large = FakeSegment("large", (0, 0, 50, 50))
-        medium = FakeSegment("medium", (0, 0, 40, 40))
-        small = FakeSegment("small", (0, 0, 30, 30))
-        detector = FakeDetector([large, medium, small])
-        sampled = []
+    def test_progressive_overlapping_face_crops_use_current_image(self):
+        detector = FakeDetector([
+            FakeSegment("first", (0, 0, 32, 32)), FakeSegment("second", (0, 0, 32, 32))])
+        means = []
+        def enhance(image, *args, **kwargs):
+            means.append(float(image.mean()))
+            return image + 1.0, None
+        module.DonutFaceDetailer.enhance_detail_megapixel = staticmethod(enhance)
+        _, _, alpha, _, _ = module.DonutFaceDetailer.enhance_face(**self.face_kwargs(detector))
+        self.assertEqual(means, [0.0, 1.0])
+        self.assertEqual(alpha[0].shape[-1], 4)
 
+    def test_final_refinement_removes_empty_masks_before_max_faces(self):
+        large, medium, small = (FakeSegment("large", (0, 0, 50, 50)),
+                                FakeSegment("medium", (0, 0, 40, 40)),
+                                FakeSegment("small", (0, 0, 30, 30)))
+        detector, sampled = FakeDetector([large, medium, small]), []
         def refined(segs, mask):
-            return (
-                segs[0],
-                [
-                    FakeSegment("refined-large", large.bbox, mask_value=0),
-                    FakeSegment("refined-medium", medium.bbox),
-                    FakeSegment("refined-small", small.bbox),
-                ],
-            )
-
+            return segs[0], [FakeSegment("large-empty", large.bbox, 0),
+                             FakeSegment("medium", medium.bbox), FakeSegment("small", small.bbox)]
         module.core.segs_bitwise_and_mask = refined
         module.DonutFaceDetailer.enhance_detail_megapixel = staticmethod(
-            lambda image, *args, **kwargs: (sampled.append(image.shape[2]) or image, None)
-        )
-
-        module.DonutFaceDetailer.enhance_face(**self.face_kwargs(
-            detector, max_faces=1, sam_model_opt=object(),
-        ))
-
+            lambda image, *args, **kwargs: (sampled.append(image.shape[2]) or image, None))
+        module.DonutFaceDetailer.enhance_face(**self.face_kwargs(detector, max_faces=1, sam_model_opt=object()))
         self.assertEqual(sampled, [40])
-        self.assertTrue(np.any(large.cropped_mask))
 
-    def test_detection_offloads_only_the_active_model_family(self):
-        detector = FakeDetector([])
-        model = FakeModel("base")
-
-        module.DonutFaceDetailer.enhance_face(**self.face_kwargs(
-            detector, model=model,
-        ))
-
-        self.assertEqual(lifecycle_calls, [model])
-
-    def test_targeted_offload_uses_current_comfy_api(self):
-        calls = []
-        manager = types.SimpleNamespace(
-            unload_model_and_clones=lambda model: calls.append(("targeted", model)),
-            unload_all_models=lambda: calls.append(("global", None)),
-        )
-        model = object()
-
-        lifecycle_core.offload_model_for_auxiliary_stage(model, manager)
-
-        self.assertEqual(calls, [("targeted", model)])
-
-    def test_targeted_offload_has_legacy_fallback(self):
-        calls = []
-        manager = types.SimpleNamespace(
-            unload_all_models=lambda: calls.append("global"),
-        )
-
-        lifecycle_core.offload_model_for_auxiliary_stage(object(), manager)
-
-        self.assertEqual(calls, ["global"])
-
-    def test_segmentation_override_is_sorted_limited_and_detects_reference(self):
-        reference_large = FakeSegment("reference-large", (0, 0, 45, 45))
-        reference_small = FakeSegment("reference-small", (0, 0, 20, 20))
-        detector = FakeDetector([], [reference_small, reference_large])
-        target_small = FakeSegment("target-small", (0, 0, 15, 15))
-        target_large = FakeSegment("target-large", (0, 0, 35, 35))
-        target_medium = FakeSegment("target-medium", (0, 0, 25, 25))
-        pairings = []
-
-        class FakeSegmDetector:
-            override_bbox_by_segm = True
-
-            def detect(self, *args, **kwargs):
-                return ((64, 64), [target_small, target_large, target_medium])
-
-        def enhance(image, *args, **kwargs):
-            face_reference_crop = args[-1]
-            pairings.append((image.shape[2], face_reference_crop.shape[2]))
-            return image, None
-
-        module.DonutFaceDetailer.enhance_detail_megapixel = staticmethod(enhance)
-        module.DonutFaceDetailer.enhance_face(**self.face_kwargs(
-            detector,
-            max_faces=2,
-            segm_detector=FakeSegmDetector(),
-            edit_mode=True,
-            edit_model=FakeModel("edit"),
-            face_reference=torch.ones(1, 64, 64, 3),
-        ))
-
-        self.assertEqual(detector.calls, ["target", "reference"])
-        self.assertEqual(pairings, [(35, 45), (25, 20)])
-
-    def test_face_seed_toggle_preserves_shared_default_and_can_increment(self):
-        first = FakeSegment("first", (0, 0, 30, 30))
-        second = FakeSegment("second", (0, 0, 20, 20))
-        detector = FakeDetector([first, second])
-
-        def run(vary, seed=20, cycle=2):
-            seeds = []
-
+    def test_cycles_are_passed_inside_once_and_seed_can_vary_per_face(self):
+        detector = FakeDetector([FakeSegment("first", (0, 0, 30, 30)),
+                                 FakeSegment("second", (32, 0, 52, 20))])
+        def run(vary):
+            seen = []
             def enhance(image, model, clip, vae, resolution, max_resolution,
-                        guide_size_for_bbox, bbox, seed, *args, **kwargs):
-                seeds.append(seed)
+                        guide_size_for_bbox, bbox, seed, *args, cycle=1, **kwargs):
+                seen.append((seed, cycle))
                 return image, None
-
             module.DonutFaceDetailer.enhance_detail_megapixel = staticmethod(enhance)
             module.DonutFaceDetailer.enhance_face(**self.face_kwargs(
-                detector,
-                seed=seed,
-                cycle=cycle,
-                vary_seed_per_face=vary,
-            ))
-            return seeds
+                detector, cycle=3, vary_seed_per_face=vary))
+            return seen
+        self.assertEqual(run(False), [(20, 3), (20, 3)])
+        self.assertEqual(run(True), [(20, 3), (21, 3)])
 
-        self.assertEqual(run(False), [20, 1020, 20, 1020])
-        self.assertEqual(run(True), [20, 1020, 21, 1021])
-        self.assertEqual(
-            run(True, seed=0xffffffffffffffff, cycle=1),
-            [0xffffffffffffffff, 0],
-        )
+    def test_current_hook_lifecycle_is_used(self):
+        events = []
+        class Hook:
+            def touch_scaled_size(self, w, h): events.append("touch_scaled_size"); return w, h
+            def post_upscale(self, image, mask): events.append("post_upscale"); return image
+            def post_encode(self, latent): events.append("post_encode"); return latent
+            def get_skip_sampling(self): return False
+            def get_custom_sampler(self): events.append("get_custom_sampler"); return "custom"
+            def set_steps(self, step): events.append(("set_steps", step))
+            def cycle_latent(self, latent): events.append("cycle_latent"); return latent
+            def pre_ksample(self, model, seed, steps, cfg, sampler, scheduler, positive, negative, latent, denoise):
+                events.append("pre_ksample")
+                return model, seed, steps, cfg, sampler, scheduler, positive, negative, latent, denoise
+            def get_custom_noise(self, seed, noise, is_touched=False): events.append("get_custom_noise"); return noise, True
+            def pre_decode(self, latent): events.append("pre_decode"); return latent
+            def post_decode(self, image): events.append("post_decode"); return image
+        module.DonutFaceDetailer.enhance_detail_megapixel(
+            **self.detail_kwargs(detailer_hook=Hook(), cycle=2))
+        for name in ["touch_scaled_size", "post_upscale", "post_encode", "get_custom_sampler",
+                     "cycle_latent", "pre_ksample", "get_custom_noise", "pre_decode", "post_decode"]:
+            self.assertIn(name, events)
+        self.assertEqual(sample_calls[0]["sampler_opt"], "custom")
 
-    def test_seed_toggle_is_optional_and_defaults_to_shared(self):
-        optional = module.DonutFaceDetailer.INPUT_TYPES()["optional"]
-        names = list(optional)
+    def test_detection_offloads_only_active_model(self):
+        detector, model = FakeDetector([]), FakeModel("base")
+        module.DonutFaceDetailer.enhance_face(**self.face_kwargs(detector, model=model))
+        self.assertEqual(lifecycle_calls, [model])
 
-        self.assertIn("vary_seed_per_face", optional)
-        self.assertFalse(optional["vary_seed_per_face"][1]["default"])
-        self.assertGreater(
-            names.index("vary_seed_per_face"),
-            names.index("grounding_px"),
-        )
-
-    def test_turbo_mode_resolves_sampling_for_every_face(self):
-        detector = FakeDetector([FakeSegment("face", (0, 0, 32, 32))])
-        resolved = []
-
+    def test_turbo_mode_resolves_before_face_sampling(self):
+        detector, seen = FakeDetector([FakeSegment("face", (0, 0, 32, 32))]), []
         def enhance(image, model, clip, vae, resolution, max_resolution,
                     guide_size_for_bbox, bbox, seed, steps, cfg, sampler_name,
                     scheduler, positive, negative, denoise, *args, **kwargs):
-            resolved.append((steps, denoise))
+            seen.append((steps, denoise))
             return image, None
-
         module.DonutFaceDetailer.enhance_detail_megapixel = staticmethod(enhance)
         module.DonutFaceDetailer.enhance_face(**self.face_kwargs(
-            detector, steps=8, denoise=0.20, turbo_mode=True,
-        ))
+            detector, steps=8, denoise=0.2, turbo_mode=True))
+        self.assertEqual(seen, [(2, 0.25)])
 
-        self.assertEqual(resolved, [(2, 0.25)])
+    def test_edit_reference_pairing_happens_after_final_face_selection(self):
+        target_large, target_small = (FakeSegment("target-large", (0, 0, 35, 35)),
+                                      FakeSegment("target-small", (40, 0, 60, 20)))
+        ref_large, ref_small = (FakeSegment("ref-large", (0, 0, 45, 45)),
+                                FakeSegment("ref-small", (48, 0, 64, 16)))
+        detector, pairs = FakeDetector([target_small, target_large], [ref_small, ref_large]), []
+        def enhance(image, *args, **kwargs):
+            ref = kwargs.get("face_reference_crop")
+            if ref is None and len(args) >= 27:
+                ref = args[26]
+            pairs.append((image.shape[2], ref.shape[2]))
+            return image, None
+        module.DonutFaceDetailer.enhance_detail_megapixel = staticmethod(enhance)
+        module.DonutFaceDetailer.enhance_face(**self.face_kwargs(
+            detector, edit_mode=True, edit_model=FakeModel("edit"),
+            face_reference=torch.ones(1, 64, 64, 3)))
+        self.assertEqual(detector.calls, ["target", "reference"])
+        self.assertEqual(pairs, [(35, 45), (20, 16)])
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes the quality regressions and correctness issues in the existing `Face Detailer (Max Faces)` node.

Key changes:
- snap diffusion sampling canvases to 64-pixel multiples
- prevent force-inpaint from pre-downscaling a face before diffusion
- keep multi-cycle refinement in latent space, with one encode/decode/downscale instead of repeated image round-trips
- crop each face from the progressively enhanced image so overlapping faces do not paste stale/softer pixels back over earlier results
- wire `inpaint_model` through `InpaintModelConditioning`
- restore wildcard/LoRA conditioning, including per-segment wildcard selection and Krea edit conditioning preservation
- align the node with the current Impact detailer-hook lifecycle (`post_upscale`, `post_encode`, custom sampler/noise, `cycle_latent`, `pre_ksample`, `pre_decode`, `post_decode`, `post_paste`) instead of calling `post_detection` on an IMAGE
- return a real RGBA `cropped_enhanced_alpha` output
- retain final-mask filtering/max-face selection, Differential Diffusion on the actual edit sampling model, Turbo routing, and reference-face pairing

The regression suite was expanded to cover 64-grid geometry, latent-only cycles, single decode behavior, inpaint conditioning, wildcard routing, Differential Diffusion, progressive overlapping crops, RGBA alpha output, current hook lifecycle, max-face filtering, Turbo routing, and edit reference pairing.