### PR TITLE
Add diffusion model saver and bypass-aware LoRA extractor

### DIFF
--- a/DonutExtractLoRA.py
+++ b/DonutExtractLoRA.py
@@ -1,0 +1,312 @@
+"""Donut Extract LoRA - raw MODEL + patched MODEL -> low-rank LoRA safetensors.
+
+Unlike ComfyUI's ModelSubtract-based extractor, this node compares ModelPatcher
+weights in float32 directly and explicitly includes Donut Experimental-bypass
+LoRA adapters. Bypass adapters normally exist only as forward hooks, so ordinary
+state-dict subtraction cannot see them.
+
+The extractor processes one model weight at a time on CPU. It does not need the
+full patched model or a dense full-model difference resident in VRAM, making it
+more practical on lower-VRAM GPUs. Large matrices use randomized low-rank SVD;
+small matrices use exact SVD.
+"""
+
+import logging
+import os
+
+import folder_paths
+import torch
+
+import comfy.lora
+import comfy.utils
+
+try:
+    from .donut_bypass_materialization import (
+        BYPASS_INJECTION_KEY,
+        get_bypass_components,
+    )
+except ImportError:
+    from donut_bypass_materialization import (
+        BYPASS_INJECTION_KEY,
+        get_bypass_components,
+    )
+
+
+OUTPUT_DTYPES = ("fp16", "bf16", "fp32")
+OUTPUT_DTYPE_MAP = {
+    "fp16": torch.float16,
+    "bf16": torch.bfloat16,
+    "fp32": torch.float32,
+}
+
+
+def _runtime_injection_keys(model):
+    injections = getattr(model, "injections", None)
+    if not isinstance(injections, dict):
+        return set()
+    return {key for key, value in injections.items() if value}
+
+
+def _convert_base_weight(base_weight, convert_func):
+    if not torch.is_tensor(base_weight):
+        raise TypeError(f"Unsupported base weight type: {type(base_weight).__name__}")
+
+    weight = base_weight.detach().to(device="cpu", dtype=torch.float32).clone()
+    if convert_func is not None:
+        try:
+            weight = convert_func(weight, inplace=True)
+        except TypeError:
+            weight = convert_func(weight)
+    if not torch.is_tensor(weight):
+        raise TypeError("Model weight conversion did not return a Tensor")
+    return weight.float().cpu()
+
+
+def _effective_weight(key, key_patches, bypass_components):
+    """Materialize one effective model weight in float32 without final fp8 rounding."""
+    if not key_patches:
+        return None
+
+    first = key_patches[0]
+    if not isinstance(first, (tuple, list)) or len(first) < 2:
+        raise TypeError(f"Unexpected get_key_patches layout for {key}")
+
+    base_weight, convert_func = first[0], first[1]
+    weight = _convert_base_weight(base_weight, convert_func)
+    patches = list(key_patches[1:])
+
+    # Donut's experimental bypass is activation-side at inference time, but for
+    # a plain additive LoRA/LoKr target its exact equivalent is an ordinary
+    # weight adapter patch at the same strength. Append it here before computing
+    # the effective weight so extraction sees what inference actually used.
+    for adapter, strength in bypass_components or ():
+        strength = float(strength)
+        if strength != 0.0:
+            patches.append((strength, adapter, 1.0, None, None))
+
+    if patches:
+        weight = comfy.lora.calculate_weight(
+            patches,
+            weight,
+            key,
+            intermediate_dtype=torch.float32,
+            original_weights={key: key_patches},
+        )
+    return weight.detach().float().cpu()
+
+
+def _factorize_delta(delta, rank):
+    """Return balanced LoRA up/down factors approximating one weight delta."""
+    if delta.ndim < 2:
+        return None
+
+    original_shape = tuple(delta.shape)
+    out_dim = original_shape[0]
+    matrix = delta.reshape(out_dim, -1).float().contiguous()
+    rows, cols = matrix.shape
+    effective_rank = min(int(rank), rows, cols)
+    if effective_rank < 1:
+        return None
+
+    if matrix.numel() == 0 or float(matrix.abs().max()) <= 1e-12:
+        return None
+
+    min_dim = min(rows, cols)
+    use_exact = matrix.numel() <= 4_000_000 or min_dim <= effective_rank + 8
+
+    if use_exact:
+        u, s, vh = torch.linalg.svd(matrix, full_matrices=False)
+        u = u[:, :effective_rank]
+        s = s[:effective_rank]
+        vh = vh[:effective_rank, :]
+    else:
+        # Randomized low-rank SVD avoids the very large temporary allocations of
+        # a full SVD on transformer projection matrices. Keep it deterministic.
+        q = min(min_dim, effective_rank + 8)
+        with torch.random.fork_rng(devices=[]):
+            torch.manual_seed(0)
+            u, s, v = torch.svd_lowrank(matrix, q=q, niter=2)
+        order = torch.argsort(s, descending=True)[:effective_rank]
+        u = u[:, order]
+        s = s[order]
+        vh = v[:, order].transpose(0, 1)
+
+    # Split singular values symmetrically. This reconstructs the same truncated
+    # SVD as (U*S)@Vh but keeps both LoRA factors numerically well-scaled.
+    root_s = torch.sqrt(torch.clamp(s, min=0.0))
+    up = u * root_s.unsqueeze(0)
+    down = root_s.unsqueeze(1) * vh
+
+    if len(original_shape) > 2:
+        up = up.reshape(out_dim, effective_rank, *([1] * (len(original_shape) - 2)))
+        down = down.reshape(effective_rank, *original_shape[1:])
+
+    return up.contiguous(), down.contiguous(), effective_rank
+
+
+class DonutExtractLoRA:
+    """Extract a diffusion-model LoRA from RAW MODEL and PATCHED MODEL."""
+
+    DESCRIPTION = (
+        "Extracts a standard low-rank LoRA representing PATCHED MODEL - RAW MODEL. "
+        "Understands Donut Experimental bypass, whose adapter effect is invisible "
+        "to ordinary ModelSubtract/state-dict LoRA extractors. Large SVDs run in "
+        "CPU memory so the full merged model does not need to fit in VRAM."
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {
+            "required": {
+                "raw_model": ("MODEL", {
+                    "tooltip": "The unmodified/base diffusion model before LoRAs or merges are applied.",
+                }),
+                "patched_model": ("MODEL", {
+                    "tooltip": "The model after LoRAs/patches. Donut Experimental bypass adapters are included.",
+                }),
+                "rank": ("INT", {
+                    "default": 32,
+                    "min": 1,
+                    "max": 4096,
+                    "step": 1,
+                    "tooltip": "Maximum SVD rank per weight. Higher ranks preserve more of the model difference and create larger LoRAs.",
+                }),
+                "filename_prefix": ("STRING", {
+                    "default": "loras/Donut_extracted_lora",
+                }),
+                "dtype": (OUTPUT_DTYPES, {
+                    "default": "fp16",
+                    "tooltip": "Storage dtype for the extracted LoRA factors. Computation is float32.",
+                }),
+            }
+        }
+
+    RETURN_TYPES = ("STRING", "STRING")
+    RETURN_NAMES = ("saved_path", "report")
+    FUNCTION = "extract"
+    OUTPUT_NODE = True
+    CATEGORY = "advanced/model_merging"
+
+    def extract(self, raw_model, patched_model, rank, filename_prefix, dtype="fp16"):
+        rank = int(rank)
+        output_dtype = OUTPUT_DTYPE_MAP[dtype]
+
+        raw_keys = raw_model.get_key_patches("diffusion_model.")
+        patched_keys = patched_model.get_key_patches("diffusion_model.")
+        raw_bypass = get_bypass_components(raw_model)
+        patched_bypass = get_bypass_components(patched_model)
+
+        raw_injections = _runtime_injection_keys(raw_model)
+        patched_injections = _runtime_injection_keys(patched_model)
+        if BYPASS_INJECTION_KEY in raw_injections and not raw_bypass:
+            raise RuntimeError(
+                "RAW MODEL has Donut Experimental-bypass injections, but their adapters "
+                "could not be recovered. Restart ComfyUI with the updated DonutNodes and retry."
+            )
+        if BYPASS_INJECTION_KEY in patched_injections and not patched_bypass:
+            raise RuntimeError(
+                "PATCHED MODEL has Donut Experimental-bypass injections, but their adapters "
+                "could not be recovered. Restart ComfyUI with the updated DonutNodes and retry."
+            )
+
+        unsupported_injections = (raw_injections | patched_injections) - {BYPASS_INJECTION_KEY}
+
+        common_keys = sorted(set(raw_keys).intersection(patched_keys))
+        output_sd = {}
+        extracted_layers = 0
+        skipped_zero = 0
+        failed_layers = []
+
+        same_base = getattr(raw_model, "clone_base_uuid", None) == getattr(
+            patched_model, "clone_base_uuid", object()
+        )
+
+        for key in common_keys:
+            if not key.endswith(".weight"):
+                continue
+            try:
+                raw_weight = _effective_weight(key, raw_keys[key], raw_bypass.get(key))
+                patched_weight = _effective_weight(key, patched_keys[key], patched_bypass.get(key))
+                if raw_weight is None or patched_weight is None:
+                    continue
+                if raw_weight.shape != patched_weight.shape:
+                    failed_layers.append(f"{key}: shape {tuple(raw_weight.shape)} != {tuple(patched_weight.shape)}")
+                    continue
+
+                delta = patched_weight - raw_weight
+                factors = _factorize_delta(delta, rank)
+                del raw_weight, patched_weight, delta
+                if factors is None:
+                    skipped_zero += 1
+                    continue
+
+                up, down, actual_rank = factors
+                base = key[:-len(".weight")]
+                output_sd[f"{base}.lora_up.weight"] = up.to(output_dtype).cpu()
+                output_sd[f"{base}.lora_down.weight"] = down.to(output_dtype).cpu()
+                # alpha/rank = 1, so applying the extracted LoRA at strength 1
+                # reconstructs the truncated SVD delta directly.
+                output_sd[f"{base}.alpha"] = torch.tensor(float(actual_rank), dtype=torch.float32)
+                extracted_layers += 1
+                del up, down
+            except Exception as exc:
+                logging.exception("[DonutExtractLoRA] Failed extracting %s", key)
+                failed_layers.append(f"{key}: {exc}")
+
+        if extracted_layers == 0:
+            detail = ""
+            if failed_layers:
+                detail = " First failure: " + failed_layers[0]
+            raise RuntimeError(
+                "No non-zero diffusion-model LoRA layers were extracted." + detail
+            )
+
+        full_output_folder, filename, counter, subfolder, filename_prefix = \
+            folder_paths.get_save_image_path(
+                filename_prefix, folder_paths.get_output_directory()
+            )
+        output_path = os.path.join(
+            full_output_folder, f"{filename}_{counter:05}_.safetensors"
+        )
+
+        metadata = {
+            "donut.extractor": "DonutExtractLoRA",
+            "donut.rank": str(rank),
+            "donut.dtype": dtype,
+            "donut.bypass_aware": "true",
+        }
+        comfy.utils.save_torch_file(output_sd, output_path, metadata=metadata)
+
+        report_parts = [
+            f"Extracted {extracted_layers} layer(s) at rank <= {rank}",
+            f"skipped {skipped_zero} zero/non-matrix layer(s)",
+        ]
+        if patched_bypass:
+            report_parts.append(
+                f"included Donut Experimental bypass on {len(patched_bypass)} weight(s)"
+            )
+        if not same_base:
+            report_parts.append(
+                "RAW and PATCHED do not share clone_base_uuid; the LoRA includes all model differences, not only attached LoRAs"
+            )
+        if unsupported_injections:
+            report_parts.append(
+                "WARNING: unsupported runtime injections were ignored: "
+                + ", ".join(sorted(unsupported_injections))
+            )
+        if failed_layers:
+            report_parts.append(f"{len(failed_layers)} layer(s) failed; see console")
+
+        report = "; ".join(report_parts)
+        print(f"[DonutExtractLoRA] {report}")
+        print(f"[DonutExtractLoRA] Saved to {output_path}")
+        return output_path, report
+
+
+NODE_CLASS_MAPPINGS = {
+    "DonutExtractLoRA": DonutExtractLoRA,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "DonutExtractLoRA": "Donut Extract LoRA (Raw → Patched)",
+}

--- a/DonutModelSave.py
+++ b/DonutModelSave.py
@@ -210,14 +210,7 @@ class DonutSave:
 
 
 class DonutModelSave(DonutSave):
-    """Save only the diffusion MODEL, with patches/LoRAs baked and dtype explicit."""
-
-    DEPRECATED = False
-    DESCRIPTION = (
-        "Saves only the diffusion model as safetensors with no workflow metadata. "
-        "Attached ModelPatcher changes such as LoRAs/merges are baked into the saved weights. "
-        "Choose bf16/fp16/fp32 to override a model that ComfyUI loaded as fp8."
-    )
+    """Legacy model-only saver ID kept for saved-workflow compatibility."""
 
     @classmethod
     def INPUT_TYPES(cls):
@@ -241,6 +234,18 @@ class DonutModelSave(DonutSave):
             filename_prefix=filename_prefix,
             dtype=dtype,
         )
+
+
+class DonutDiffusionModelSave(DonutModelSave):
+    """Visible diffusion-model-only save node with explicit output dtype."""
+
+    DEPRECATED = False
+    DESCRIPTION = (
+        "Saves only the diffusion MODEL as safetensors with no workflow metadata. "
+        "Attached ModelPatcher changes such as LoRAs and model merges are baked into "
+        "the saved weights. BF16 is the default so a model loaded in fp8 is not "
+        "silently re-saved as fp8."
+    )
 
 
 class DonutCheckpointSave(DonutSave):
@@ -271,10 +276,11 @@ class DonutCheckpointSave(DonutSave):
 NODE_CLASS_MAPPINGS = {
     "DonutSave": DonutSave,
     "DonutModelSave": DonutModelSave,
+    "DonutDiffusionModelSave": DonutDiffusionModelSave,
     "DonutCheckpointSave": DonutCheckpointSave,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "DonutSave": "Donut Save (No Workflow)",
-    "DonutModelSave": "Donut Diffusion Model Save (No Workflow)",
+    "DonutDiffusionModelSave": "Donut Diffusion Model Save (No Workflow)",
 }

--- a/DonutModelSave.py
+++ b/DonutModelSave.py
@@ -10,11 +10,13 @@ saved as bf16/fp16/fp32 instead.
 
 The state-dict construction path follows comfy.sd.save_checkpoint:
 load_models_gpu(...) -> ModelPatcher.state_dict_for_saving(...). This routes
-through ComfyUI's LazyCastingParam machinery, so patches such as LoRAs and model
-merges are materialized into the saved weights while still supporting low-VRAM
-partial loading.
+through ComfyUI's LazyCastingParam machinery, so ordinary patches are materialized
+one weight at a time. Donut Experimental-bypass LoRAs are first converted on a
+temporary clone to equivalent ordinary adapter patches, so bypass inference is
+also baked into saved weights without densifying the whole model in VRAM.
 """
 
+from contextlib import nullcontext
 import os
 
 import folder_paths
@@ -29,8 +31,18 @@ from comfy.cli_args import args
 
 try:
     from .model_lifecycle import offload_models
+    from .donut_bypass_materialization import (
+        clone_with_bypass_as_regular_patches,
+        get_bypass_components,
+    )
+    from .DonutExtractLoRA import DonutExtractLoRA
 except ImportError:
     from model_lifecycle import offload_models
+    from donut_bypass_materialization import (
+        clone_with_bypass_as_regular_patches,
+        get_bypass_components,
+    )
+    from DonutExtractLoRA import DonutExtractLoRA
 
 
 DTYPE_OPTIONS = ["original", "bf16", "fp16", "fp32", "fp8_e4m3fn", "fp8_e5m2"]
@@ -113,7 +125,7 @@ def _materialize_and_cast(sd, dtype):
             if not t.is_contiguous():
                 t = t.contiguous()
         out[k] = t
-        # Release the original wrapper/reference promptly while building output.
+        # Drop the original entry so wrappers can be released promptly.
         sd[k] = None
 
     return out
@@ -124,33 +136,40 @@ def _save_via_comfy(model, clip, vae, output_path, filename, counter, dtype):
     Faithful reproduction of comfy.sd.save_checkpoint with:
       - workflow metadata stripped
       - optional dtype conversion
+      - Donut Experimental-bypass adapters serialized as ordinary patches
     """
-    metadata, extra_keys = _build_modelspec_metadata(model, filename, counter)
-    if args.disable_metadata:
-        metadata = {}
+    bypass_components = get_bypass_components(model)
+    use_ejected = getattr(model, "use_ejected", None)
+    context = use_ejected() if bypass_components and callable(use_ejected) else nullcontext()
 
-    clip_sd = None
-    load_models = [model]
-    if clip is not None:
-        load_models.append(clip.load_model())
-        clip_sd = clip.get_sd()
-    vae_sd = None
-    if vae is not None:
-        vae_sd = vae.get_sd()
+    with context:
+        save_model = clone_with_bypass_as_regular_patches(model)
 
-    # Do not force_patch_weights here. ComfyUI's normal load_models_gpu path may
-    # partially load large models on low-VRAM systems, and LazyCastingParam
-    # materialization below bakes patches during the CPU state-dict pass.
-    comfy.model_management.load_models_gpu(load_models)
+        metadata, extra_keys = _build_modelspec_metadata(save_model, filename, counter)
+        if args.disable_metadata:
+            metadata = {}
 
-    clip_vision_sd = None
-    sd = model.state_dict_for_saving(clip_sd, vae_sd, clip_vision_sd)
-    for k in extra_keys:
-        sd[k] = extra_keys[k]
+        clip_sd = None
+        load_models = [save_model]
+        if clip is not None:
+            load_models.append(clip.load_model())
+            clip_sd = clip.get_sd()
+        vae_sd = None
+        if vae is not None:
+            vae_sd = vae.get_sd()
 
-    sd = _materialize_and_cast(sd, dtype)
+        # Do not force_patch_weights. Normal partial loading is important on
+        # low-VRAM systems; LazyCastingParam applies regular and converted-bypass
+        # patches as each saved tensor is moved to CPU.
+        comfy.model_management.load_models_gpu(load_models)
 
-    offload_models(comfy.model_management, *load_models)
+        clip_vision_sd = None
+        sd = save_model.state_dict_for_saving(clip_sd, vae_sd, clip_vision_sd)
+        for k in extra_keys:
+            sd[k] = extra_keys[k]
+
+        sd = _materialize_and_cast(sd, dtype)
+        offload_models(comfy.model_management, *load_models)
 
     comfy.utils.save_torch_file(sd, output_path, metadata=metadata)
 
@@ -242,9 +261,9 @@ class DonutDiffusionModelSave(DonutModelSave):
     DEPRECATED = False
     DESCRIPTION = (
         "Saves only the diffusion MODEL as safetensors with no workflow metadata. "
-        "Attached ModelPatcher changes such as LoRAs and model merges are baked into "
-        "the saved weights. BF16 is the default so a model loaded in fp8 is not "
-        "silently re-saved as fp8."
+        "Ordinary ModelPatcher changes and Donut Experimental-bypass LoRAs are baked "
+        "into the saved weights. BF16 is the default so a model loaded in fp8 is "
+        "not silently re-saved as fp8."
     )
 
 
@@ -278,9 +297,11 @@ NODE_CLASS_MAPPINGS = {
     "DonutModelSave": DonutModelSave,
     "DonutDiffusionModelSave": DonutDiffusionModelSave,
     "DonutCheckpointSave": DonutCheckpointSave,
+    "DonutExtractLoRA": DonutExtractLoRA,
 }
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "DonutSave": "Donut Save (No Workflow)",
     "DonutDiffusionModelSave": "Donut Diffusion Model Save (No Workflow)",
+    "DonutExtractLoRA": "Donut Extract LoRA (Raw → Patched)",
 }

--- a/DonutModelSave.py
+++ b/DonutModelSave.py
@@ -1,14 +1,18 @@
 """
-DonutModelSave / DonutCheckpointSave
+DonutSave / DonutModelSave / DonutCheckpointSave
 
-Mirrors ComfyUI's stock CheckpointSave / ModelSave behavior exactly, but:
-  - Strips the embedded workflow (no `prompt` / `extra_pnginfo` in metadata)
-  - Adds an optional dtype conversion (fp8/fp16/bf16/fp32)
+No-workflow save nodes with explicit dtype control.
 
-The state-dict construction path is the same as comfy.sd.save_checkpoint:
+DonutModelSave is the dedicated diffusion-model-only saver: it accepts only MODEL,
+never CLIP/VAE, and writes under diffusion_models/ by default. This is useful when
+ComfyUI loaded a model in fp8 but the desired baked LoRA/merge output should be
+saved as bf16/fp16/fp32 instead.
+
+The state-dict construction path follows comfy.sd.save_checkpoint:
 load_models_gpu(...) -> ModelPatcher.state_dict_for_saving(...). This routes
-through ComfyUI's LazyCastingParam machinery, which is the canonical way
-patches (LoRAs, merges) get baked into a saved checkpoint.
+through ComfyUI's LazyCastingParam machinery, so patches such as LoRAs and model
+merges are materialized into the saved weights while still supporting low-VRAM
+partial loading.
 """
 
 import os
@@ -29,7 +33,7 @@ except ImportError:
     from model_lifecycle import offload_models
 
 
-DTYPE_OPTIONS = ["original", "fp8_e4m3fn", "fp8_e5m2", "fp16", "bf16", "fp32"]
+DTYPE_OPTIONS = ["original", "bf16", "fp16", "fp32", "fp8_e4m3fn", "fp8_e5m2"]
 
 DTYPE_MAP = {
     "fp16": torch.float16,
@@ -87,10 +91,12 @@ def _build_modelspec_metadata(model, filename, counter):
 
 def _materialize_and_cast(sd, dtype):
     """
-    Walk the state dict, force-materialize any LazyCastingParam wrappers
-    (this is what causes patches/LoRAs to actually get applied to the
-    saved tensors), and optionally cast floating-point tensors to a
-    target dtype. Result lives on CPU and is contiguous.
+    Force-materialize patched/LazyCastingParam tensors and optionally cast them.
+
+    The completed state dict is CPU-resident. This avoids requiring the full baked
+    model to fit in VRAM; ComfyUI can use its normal partial-loading path while
+    patched weights are materialized for saving. System RAM must still be large
+    enough for the completed output state dict.
     """
     target_dtype = DTYPE_MAP.get(dtype) if dtype != "original" else None
 
@@ -98,8 +104,8 @@ def _materialize_and_cast(sd, dtype):
     keys = list(sd.keys())
     for k in keys:
         t = sd[k]
-        # LazyCastingParam.to("cpu") triggers patch_weight_to_device, which
-        # is the canonical way patched weights get materialized for save.
+        # LazyCastingParam.to("cpu") triggers patch_weight_to_device, which is
+        # the canonical path that bakes attached ModelPatcher patches/LoRAs.
         if isinstance(t, torch.Tensor):
             t = t.to("cpu")
             if target_dtype is not None and t.is_floating_point():
@@ -107,7 +113,7 @@ def _materialize_and_cast(sd, dtype):
             if not t.is_contiguous():
                 t = t.contiguous()
         out[k] = t
-        # Drop the original entry so we release the wrapper promptly.
+        # Release the original wrapper/reference promptly while building output.
         sd[k] = None
 
     return out
@@ -119,14 +125,10 @@ def _save_via_comfy(model, clip, vae, output_path, filename, counter, dtype):
       - workflow metadata stripped
       - optional dtype conversion
     """
-    # Build modelspec metadata exactly the way CheckpointSave would,
-    # but without prompt / extra_pnginfo. args.disable_metadata is
-    # respected too — if the user disabled metadata globally we emit none.
     metadata, extra_keys = _build_modelspec_metadata(model, filename, counter)
     if args.disable_metadata:
         metadata = {}
 
-    # --- the rest mirrors comfy.sd.save_checkpoint exactly ---
     clip_sd = None
     load_models = [model]
     if clip is not None:
@@ -136,11 +138,9 @@ def _save_via_comfy(model, clip, vae, output_path, filename, counter, dtype):
     if vae is not None:
         vae_sd = vae.get_sd()
 
-    # Match comfy.sd.save_checkpoint exactly: no force_patch_weights.
-    # Patches that aren't physically applied in-place are wrapped in
-    # LazyCastingParam and resolved when we call .to("cpu") below.
-    # (force_patch_weights=True would assert-fail under partial loading,
-    # which is what kicks in on low-VRAM systems.)
+    # Do not force_patch_weights here. ComfyUI's normal load_models_gpu path may
+    # partially load large models on low-VRAM systems, and LazyCastingParam
+    # materialization below bakes patches during the CPU state-dict pass.
     comfy.model_management.load_models_gpu(load_models)
 
     clip_vision_sd = None
@@ -148,10 +148,8 @@ def _save_via_comfy(model, clip, vae, output_path, filename, counter, dtype):
     for k in extra_keys:
         sd[k] = extra_keys[k]
 
-    # Materialize lazy wrappers, optionally cast dtype, ensure contiguous.
     sd = _materialize_and_cast(sd, dtype)
 
-    # Free only the model families materialized by this save operation.
     offload_models(comfy.model_management, *load_models)
 
     comfy.utils.save_torch_file(sd, output_path, metadata=metadata)
@@ -161,12 +159,7 @@ class DonutSave:
     """
     Connection-driven unified save node. Saves the diffusion model only when
     clip/vae are unwired, or a full checkpoint (model + clip + vae) when they
-    are connected. Behaves like ComfyUI's stock ModelSave / CheckpointSave
-    nodes, except no workflow is embedded and dtype is selectable.
-
-    The save() method here is the shared engine; DonutModelSave and
-    DonutCheckpointSave are thin alias subclasses that keep their original
-    INPUT_TYPES for byte-identical deserialization of saved workflows.
+    are connected. No workflow metadata is embedded and dtype is selectable.
     """
 
     def __init__(self):
@@ -178,7 +171,10 @@ class DonutSave:
             "required": {
                 "model": ("MODEL",),
                 "filename_prefix": ("STRING", {"default": "ComfyUI"}),
-                "dtype": (DTYPE_OPTIONS, {"default": "original"}),
+                "dtype": (DTYPE_OPTIONS, {
+                    "default": "original",
+                    "tooltip": "Output floating-point dtype. 'original' preserves the loaded dtype, including fp8 if the model was loaded as fp8.",
+                }),
             },
             "optional": {
                 "clip": ("CLIP",),
@@ -214,23 +210,32 @@ class DonutSave:
 
 
 class DonutModelSave(DonutSave):
-    """
-    Alias of DonutSave preserving the original ModelSave INPUT_TYPES
-    (model + filename_prefix + dtype, no clip/vae). Delegates to
-    DonutSave.save().
-    """
+    """Save only the diffusion MODEL, with patches/LoRAs baked and dtype explicit."""
+
+    DEPRECATED = False
+    DESCRIPTION = (
+        "Saves only the diffusion model as safetensors with no workflow metadata. "
+        "Attached ModelPatcher changes such as LoRAs/merges are baked into the saved weights. "
+        "Choose bf16/fp16/fp32 to override a model that ComfyUI loaded as fp8."
+    )
 
     @classmethod
     def INPUT_TYPES(cls):
         return {
             "required": {
                 "model": ("MODEL",),
-                "filename_prefix": ("STRING", {"default": "diffusion_models/ComfyUI"}),
-                "dtype": (DTYPE_OPTIONS, {"default": "original"}),
+                "filename_prefix": ("STRING", {
+                    "default": "diffusion_models/ComfyUI",
+                    "tooltip": "Saved under ComfyUI/output by default; use diffusion_models/... for model-library style organization.",
+                }),
+                "dtype": (DTYPE_OPTIONS, {
+                    "default": "bf16",
+                    "tooltip": "Saved weight dtype. BF16 is the default to avoid accidentally preserving an fp8-loaded model. 'original' keeps the currently loaded dtype.",
+                }),
             }
         }
 
-    def save(self, model, filename_prefix, dtype="original"):
+    def save(self, model, filename_prefix, dtype="bf16"):
         return super().save(
             model=model,
             filename_prefix=filename_prefix,
@@ -239,11 +244,7 @@ class DonutModelSave(DonutSave):
 
 
 class DonutCheckpointSave(DonutSave):
-    """
-    Alias of DonutSave preserving the original CheckpointSave INPUT_TYPES
-    (model + clip + vae + filename_prefix + dtype). Delegates to
-    DonutSave.save().
-    """
+    """Legacy full checkpoint alias (model + CLIP + VAE)."""
 
     @classmethod
     def INPUT_TYPES(cls):
@@ -275,4 +276,5 @@ NODE_CLASS_MAPPINGS = {
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "DonutSave": "Donut Save (No Workflow)",
+    "DonutModelSave": "Donut Diffusion Model Save (No Workflow)",
 }

--- a/donut_bypass_materialization.py
+++ b/donut_bypass_materialization.py
@@ -4,30 +4,93 @@ Experimental bypass keeps adapter math in forward hooks instead of changing the
 ModelPatcher weight state. That is ideal for quantized/low-VRAM inference, but a
 plain state-dict save or ModelSubtract cannot see those adapters.
 
-Donut records the lightweight adapter objects on the ModelPatcher as an
-attachment. Consumers that need real weights (model saving or LoRA extraction)
-can clone the patcher, remove the runtime injection, and register the exact same
-adapters on ComfyUI's ordinary patch path. LazyCastingParam can then materialize
-one weight at a time without constructing a dense full-model delta in memory.
+Newer Donut builds may record adapter components as a ModelPatcher attachment.
+For compatibility with already-created bypass models, these helpers can also
+recover the BypassInjectionManager captured by ComfyUI's PatcherInjection
+closures. Consumers then clone the patcher, remove the runtime injection, and
+register the exact same adapters on ComfyUI's ordinary patch path. This lets
+LazyCastingParam materialize one weight at a time without constructing a dense
+full-model delta in memory.
 """
 
 BYPASS_ATTACHMENT_KEY = "donut_bypass_lora_components_v1"
 BYPASS_INJECTION_KEY = "donut_bypass_lora"
 
 
+def _flatten_adapter(adapter, strength):
+    """Expand Donut's composite bypass adapter back into its components."""
+    components = getattr(adapter, "components", None)
+    if isinstance(components, (list, tuple)) and components:
+        flattened = []
+        valid = True
+        for item in components:
+            if not isinstance(item, (list, tuple)) or len(item) != 2:
+                valid = False
+                break
+            child, child_strength = item
+            flattened.append((child, float(strength) * float(child_strength)))
+        if valid:
+            return flattened
+    return [(adapter, float(strength))]
+
+
+def _discover_components_from_injections(model):
+    """Recover bypass adapters from ComfyUI's injection closure when possible."""
+    getter = getattr(model, "get_injections", None)
+    if callable(getter):
+        injections = getter(BYPASS_INJECTION_KEY) or []
+    else:
+        injections = getattr(model, "injections", {}).get(BYPASS_INJECTION_KEY, [])
+
+    managers = []
+    seen_managers = set()
+    for injection in injections:
+        for callback_name in ("inject", "eject"):
+            callback = getattr(injection, callback_name, None)
+            closure = getattr(callback, "__closure__", None)
+            if not closure:
+                continue
+            for cell in closure:
+                try:
+                    candidate = cell.cell_contents
+                except ValueError:
+                    continue
+                adapters = getattr(candidate, "adapters", None)
+                if not isinstance(adapters, dict):
+                    continue
+                marker = id(candidate)
+                if marker in seen_managers:
+                    continue
+                seen_managers.add(marker)
+                managers.append(candidate)
+
+    discovered = {}
+    for manager in managers:
+        for module_key, adapter_entry in manager.adapters.items():
+            if not isinstance(adapter_entry, (list, tuple)) or len(adapter_entry) != 2:
+                continue
+            adapter, strength = adapter_entry
+            weight_key = module_key if str(module_key).endswith(".weight") else f"{module_key}.weight"
+            discovered.setdefault(weight_key, []).extend(_flatten_adapter(adapter, strength))
+    return discovered
+
+
 def get_bypass_components(model):
-    """Return {weight_key: [(adapter, strength), ...]} recorded on a model."""
+    """Return {weight_key: [(adapter, strength), ...]} for Donut bypass LoRAs."""
     getter = getattr(model, "get_attachment", None)
-    if not callable(getter):
-        return {}
-    value = getter(BYPASS_ATTACHMENT_KEY)
-    if not isinstance(value, dict):
-        return {}
-    return value
+    if callable(getter):
+        value = getter(BYPASS_ATTACHMENT_KEY)
+        if isinstance(value, dict) and value:
+            return value
+
+    # Older bypass models did not persist explicit extraction metadata. The
+    # injection manager itself still owns the exact adapter objects, so recover
+    # them from its closure rather than pretending the state dict contains them.
+    return _discover_components_from_injections(model)
 
 
 def attach_bypass_components(model, adapters_by_key):
-    """Merge newly attached bypass components into clone-persistent metadata."""
+    """Merge bypass components into clone-persistent ModelPatcher metadata."""
     if not adapters_by_key:
         return model
 
@@ -46,17 +109,17 @@ def attach_bypass_components(model, adapters_by_key):
 
 
 def clone_with_bypass_as_regular_patches(model):
-    """Clone a model and turn recorded bypass adapters into normal weight patches.
+    """Clone a model and turn Donut bypass adapters into normal weight patches.
 
     Callers should preferably invoke this while ``model.use_ejected()`` is active
     if the source model is currently injected. The returned clone no longer owns
     Donut's bypass injection/metadata, so serialization cannot double-apply it.
     """
     components_by_key = get_bypass_components(model)
-    converted = model.clone()
-
     if not components_by_key:
-        return converted
+        return model
+
+    converted = model.clone()
 
     remover = getattr(converted, "remove_injections", None)
     if callable(remover):

--- a/donut_bypass_materialization.py
+++ b/donut_bypass_materialization.py
@@ -4,13 +4,13 @@ Experimental bypass keeps adapter math in forward hooks instead of changing the
 ModelPatcher weight state. That is ideal for quantized/low-VRAM inference, but a
 plain state-dict save or ModelSubtract cannot see those adapters.
 
-Newer Donut builds may record adapter components as a ModelPatcher attachment.
-For compatibility with already-created bypass models, these helpers can also
-recover the BypassInjectionManager captured by ComfyUI's PatcherInjection
-closures. Consumers then clone the patcher, remove the runtime injection, and
-register the exact same adapters on ComfyUI's ordinary patch path. This lets
-LazyCastingParam materialize one weight at a time without constructing a dense
-full-model delta in memory.
+New Donut bypass applications record adapter components as a ModelPatcher
+attachment. For compatibility with already-created bypass models, these helpers
+can also recover the BypassInjectionManager captured by ComfyUI's
+PatcherInjection closures. Consumers then clone the patcher, remove the runtime
+injection, and register the exact same adapters on ComfyUI's ordinary patch path.
+This lets LazyCastingParam materialize one weight at a time without constructing
+a dense full-model delta in memory.
 """
 
 BYPASS_ATTACHMENT_KEY = "donut_bypass_lora_components_v1"
@@ -32,6 +32,14 @@ def _flatten_adapter(adapter, strength):
         if valid:
             return flattened
     return [(adapter, float(strength))]
+
+
+def _get_attached_components(model):
+    getter = getattr(model, "get_attachment", None)
+    if not callable(getter):
+        return {}
+    value = getter(BYPASS_ATTACHMENT_KEY)
+    return value if isinstance(value, dict) else {}
 
 
 def _discover_components_from_injections(model):
@@ -77,11 +85,9 @@ def _discover_components_from_injections(model):
 
 def get_bypass_components(model):
     """Return {weight_key: [(adapter, strength), ...]} for Donut bypass LoRAs."""
-    getter = getattr(model, "get_attachment", None)
-    if callable(getter):
-        value = getter(BYPASS_ATTACHMENT_KEY)
-        if isinstance(value, dict) and value:
-            return value
+    attached = _get_attached_components(model)
+    if attached:
+        return attached
 
     # Older bypass models did not persist explicit extraction metadata. The
     # injection manager itself still owns the exact adapter objects, so recover
@@ -94,9 +100,11 @@ def attach_bypass_components(model, adapters_by_key):
     if not adapters_by_key:
         return model
 
+    # Only merge the explicit attachment here. Calling get_bypass_components()
+    # would rediscover the same injection manager and duplicate every component.
     merged = {
         key: list(components)
-        for key, components in get_bypass_components(model).items()
+        for key, components in _get_attached_components(model).items()
     }
     for key, components in adapters_by_key.items():
         merged.setdefault(key, []).extend(list(components))
@@ -106,6 +114,41 @@ def attach_bypass_components(model, adapters_by_key):
         raise RuntimeError("This ComfyUI ModelPatcher does not support attachments.")
     setter(BYPASS_ATTACHMENT_KEY, merged)
     return model
+
+
+def install_bypass_recording_patch():
+    """Make future Donut bypass results persist their adapter components.
+
+    The existing apply implementation already constructs ComfyUI's
+    BypassInjectionManager. Wrapping it after import lets us recover that exact
+    manager once and store its adapters as clone-persistent metadata without
+    changing the inference implementation itself.
+    """
+    try:
+        from . import DonutSafeApplyLoRAStack as safe_module
+    except ImportError:
+        try:
+            import DonutSafeApplyLoRAStack as safe_module
+        except ImportError:
+            return False
+
+    original = getattr(safe_module, "_apply_bypass_applications", None)
+    if not callable(original):
+        return False
+    if getattr(original, "_donut_records_bypass_components", False):
+        return True
+
+    def wrapped(model, applications):
+        result = original(model, applications)
+        discovered = _discover_components_from_injections(result)
+        if discovered:
+            attach_bypass_components(result, discovered)
+        return result
+
+    wrapped._donut_records_bypass_components = True
+    wrapped._donut_original = original
+    safe_module._apply_bypass_applications = wrapped
+    return True
 
 
 def clone_with_bypass_as_regular_patches(model):

--- a/donut_bypass_materialization.py
+++ b/donut_bypass_materialization.py
@@ -180,3 +180,10 @@ def clone_with_bypass_as_regular_patches(model):
             converted.add_patches({key: adapter}, strength)
 
     return converted
+
+
+# In normal package loading, DonutSafeApplyLoRAStack is imported before
+# DonutModelSave (which imports this helper), so this patches the already-loaded
+# bypass application function. The function is idempotent and harmless in tests
+# or older environments where the safe stack module is unavailable.
+install_bypass_recording_patch()

--- a/donut_bypass_materialization.py
+++ b/donut_bypass_materialization.py
@@ -1,0 +1,76 @@
+"""Helpers for serializing Donut's experimental bypass LoRA adapters.
+
+Experimental bypass keeps adapter math in forward hooks instead of changing the
+ModelPatcher weight state. That is ideal for quantized/low-VRAM inference, but a
+plain state-dict save or ModelSubtract cannot see those adapters.
+
+Donut records the lightweight adapter objects on the ModelPatcher as an
+attachment. Consumers that need real weights (model saving or LoRA extraction)
+can clone the patcher, remove the runtime injection, and register the exact same
+adapters on ComfyUI's ordinary patch path. LazyCastingParam can then materialize
+one weight at a time without constructing a dense full-model delta in memory.
+"""
+
+BYPASS_ATTACHMENT_KEY = "donut_bypass_lora_components_v1"
+BYPASS_INJECTION_KEY = "donut_bypass_lora"
+
+
+def get_bypass_components(model):
+    """Return {weight_key: [(adapter, strength), ...]} recorded on a model."""
+    getter = getattr(model, "get_attachment", None)
+    if not callable(getter):
+        return {}
+    value = getter(BYPASS_ATTACHMENT_KEY)
+    if not isinstance(value, dict):
+        return {}
+    return value
+
+
+def attach_bypass_components(model, adapters_by_key):
+    """Merge newly attached bypass components into clone-persistent metadata."""
+    if not adapters_by_key:
+        return model
+
+    merged = {
+        key: list(components)
+        for key, components in get_bypass_components(model).items()
+    }
+    for key, components in adapters_by_key.items():
+        merged.setdefault(key, []).extend(list(components))
+
+    setter = getattr(model, "set_attachments", None)
+    if not callable(setter):
+        raise RuntimeError("This ComfyUI ModelPatcher does not support attachments.")
+    setter(BYPASS_ATTACHMENT_KEY, merged)
+    return model
+
+
+def clone_with_bypass_as_regular_patches(model):
+    """Clone a model and turn recorded bypass adapters into normal weight patches.
+
+    Callers should preferably invoke this while ``model.use_ejected()`` is active
+    if the source model is currently injected. The returned clone no longer owns
+    Donut's bypass injection/metadata, so serialization cannot double-apply it.
+    """
+    components_by_key = get_bypass_components(model)
+    converted = model.clone()
+
+    if not components_by_key:
+        return converted
+
+    remover = getattr(converted, "remove_injections", None)
+    if callable(remover):
+        remover(BYPASS_INJECTION_KEY)
+
+    attachment_remover = getattr(converted, "remove_attachments", None)
+    if callable(attachment_remover):
+        attachment_remover(BYPASS_ATTACHMENT_KEY)
+
+    for key, components in components_by_key.items():
+        for adapter, strength in components:
+            strength = float(strength)
+            if strength == 0.0:
+                continue
+            converted.add_patches({key: adapter}, strength)
+
+    return converted

--- a/test_donut_extract_lora.py
+++ b/test_donut_extract_lora.py
@@ -1,0 +1,196 @@
+import importlib.util
+from pathlib import Path
+import sys
+import types
+import unittest
+
+import torch
+
+
+# Minimal Comfy/folder stubs so pure extraction helpers can be imported in a
+# normal Python test process without starting ComfyUI.
+fake_comfy = types.ModuleType("comfy")
+fake_comfy.__path__ = []
+fake_lora = types.ModuleType("comfy.lora")
+fake_utils = types.ModuleType("comfy.utils")
+fake_comfy.lora = fake_lora
+fake_comfy.utils = fake_utils
+
+
+def fake_calculate_weight(patches, weight, key, **kwargs):
+    out = weight.clone()
+    for patch in patches:
+        strength, adapter = patch[0], patch[1]
+        if hasattr(adapter, "delta"):
+            out = out + float(strength) * adapter.delta.to(out)
+    return out
+
+
+fake_lora.calculate_weight = fake_calculate_weight
+fake_utils.save_torch_file = lambda *args, **kwargs: None
+
+fake_folder_paths = types.ModuleType("folder_paths")
+fake_folder_paths.get_output_directory = lambda: "/tmp"
+fake_folder_paths.get_save_image_path = lambda prefix, output: (
+    output, "test", 1, "", prefix,
+)
+
+_previous = {
+    name: sys.modules.get(name)
+    for name in ("comfy", "comfy.lora", "comfy.utils", "folder_paths")
+}
+sys.modules["comfy"] = fake_comfy
+sys.modules["comfy.lora"] = fake_lora
+sys.modules["comfy.utils"] = fake_utils
+sys.modules["folder_paths"] = fake_folder_paths
+
+try:
+    helper_spec = importlib.util.spec_from_file_location(
+        "donut_bypass_materialization",
+        Path(__file__).with_name("donut_bypass_materialization.py"),
+    )
+    helper = importlib.util.module_from_spec(helper_spec)
+    helper_spec.loader.exec_module(helper)
+    sys.modules["donut_bypass_materialization"] = helper
+
+    extract_spec = importlib.util.spec_from_file_location(
+        "donut_extract_lora_tested",
+        Path(__file__).with_name("DonutExtractLoRA.py"),
+    )
+    extract = importlib.util.module_from_spec(extract_spec)
+    extract_spec.loader.exec_module(extract)
+finally:
+    for name, previous in _previous.items():
+        if previous is None:
+            sys.modules.pop(name, None)
+        else:
+            sys.modules[name] = previous
+
+
+class Adapter:
+    def __init__(self, delta):
+        self.delta = delta
+
+
+class CompositeAdapter:
+    def __init__(self, components):
+        self.components = components
+
+
+class FakeInjectionModel:
+    def __init__(self, manager):
+        def inject_all(model_patcher):
+            return manager
+
+        def eject_all(model_patcher):
+            return manager
+
+        injection = types.SimpleNamespace(inject=inject_all, eject=eject_all)
+        self.injections = {helper.BYPASS_INJECTION_KEY: [injection]}
+        self.attachments = {}
+        self.added = []
+
+    def get_attachment(self, key):
+        return self.attachments.get(key)
+
+    def get_injections(self, key):
+        return self.injections.get(key, [])
+
+    def clone(self):
+        clone = FakeInjectionModel.__new__(FakeInjectionModel)
+        clone.injections = {k: list(v) for k, v in self.injections.items()}
+        clone.attachments = dict(self.attachments)
+        clone.added = []
+        return clone
+
+    def remove_injections(self, key):
+        self.injections.pop(key, None)
+
+    def remove_attachments(self, key):
+        self.attachments.pop(key, None)
+
+    def add_patches(self, patches, strength):
+        self.added.append((patches, strength))
+
+
+class DonutExtractLoRATests(unittest.TestCase):
+    def test_rank_factorization_reconstructs_low_rank_matrix(self):
+        left = torch.tensor([[1.0, 2.0], [3.0, -1.0], [0.5, 4.0]])
+        right = torch.tensor([[2.0, 0.0, 1.0, -1.0], [1.0, 3.0, -2.0, 0.5]])
+        delta = left @ right
+
+        up, down, rank = extract._factorize_delta(delta, 2)
+
+        self.assertEqual(rank, 2)
+        self.assertTrue(torch.allclose(up @ down, delta, atol=1e-4, rtol=1e-4))
+
+    def test_conv_factorization_uses_standard_lora_shapes(self):
+        torch.manual_seed(4)
+        up_true = torch.randn(5, 2)
+        down_true = torch.randn(2, 3 * 3 * 3)
+        delta = (up_true @ down_true).reshape(5, 3, 3, 3)
+
+        up, down, rank = extract._factorize_delta(delta, 2)
+
+        self.assertEqual(rank, 2)
+        self.assertEqual(tuple(up.shape), (5, 2, 1, 1))
+        self.assertEqual(tuple(down.shape), (2, 3, 3, 3))
+        reconstructed = (up.flatten(1) @ down.flatten(1)).reshape(delta.shape)
+        self.assertTrue(torch.allclose(reconstructed, delta, atol=1e-4, rtol=1e-4))
+
+    def test_effective_weight_includes_bypass_adapter(self):
+        base = torch.zeros(3, 4)
+        regular = Adapter(torch.ones(3, 4))
+        bypass = Adapter(torch.full((3, 4), 2.0))
+        key_patches = [
+            (base, lambda value, **kwargs: value),
+            (0.5, regular, 1.0, None, None),
+        ]
+
+        result = extract._effective_weight(
+            "diffusion_model.layer.weight",
+            key_patches,
+            [(bypass, 0.25)],
+        )
+
+        expected = torch.ones(3, 4)
+        self.assertTrue(torch.allclose(result, expected))
+
+    def test_discovers_and_flattens_existing_bypass_manager(self):
+        a = Adapter(torch.ones(2, 2))
+        b = Adapter(torch.ones(2, 2))
+        manager = types.SimpleNamespace(adapters={
+            "diffusion_model.layer": (CompositeAdapter([(a, 0.5), (b, 0.25)]), 2.0),
+        })
+        model = FakeInjectionModel(manager)
+
+        components = helper.get_bypass_components(model)
+
+        self.assertIn("diffusion_model.layer.weight", components)
+        self.assertEqual(components["diffusion_model.layer.weight"], [(a, 1.0), (b, 0.5)])
+
+    def test_converts_bypass_to_regular_patches_without_dense_delta(self):
+        adapter = Adapter(torch.ones(2, 2))
+        manager = types.SimpleNamespace(adapters={
+            "diffusion_model.layer": (adapter, 0.75),
+        })
+        model = FakeInjectionModel(manager)
+
+        converted = helper.clone_with_bypass_as_regular_patches(model)
+
+        self.assertNotIn(helper.BYPASS_INJECTION_KEY, converted.injections)
+        self.assertEqual(len(converted.added), 1)
+        patches, strength = converted.added[0]
+        self.assertIs(patches["diffusion_model.layer.weight"], adapter)
+        self.assertEqual(strength, 0.75)
+
+    def test_node_schema_has_raw_patched_and_rank(self):
+        required = extract.DonutExtractLoRA.INPUT_TYPES()["required"]
+        self.assertIn("raw_model", required)
+        self.assertIn("patched_model", required)
+        self.assertIn("rank", required)
+        self.assertEqual(required["rank"][1]["default"], 32)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Adds two serialization tools for diffusion-model workflows, including Donut's `Experimental bypass` LoRA execution mode.

### Donut Diffusion Model Save (No Workflow)
- visible dedicated node with only `MODEL`, filename prefix, and dtype
- saves diffusion weights only — no CLIP/VAE and no workflow metadata
- explicit `original`, BF16, FP16, FP32, and FP8 output dtype choices
- defaults to BF16 so a model loaded in fp8 is not accidentally re-saved as fp8
- uses ComfyUI's lazy/partial-loading state-dict path so the complete baked model does not need to reside in VRAM at once
- converts Donut Experimental-bypass LoRA adapters to equivalent ordinary patches on a temporary clone before serialization, so bypass LoRAs are actually baked into the saved model

### Donut Extract LoRA (Raw → Patched)
- inputs: RAW MODEL, PATCHED MODEL, rank, filename prefix, and output dtype
- computes effective weights in float32 directly from ModelPatcher patch data, avoiding final fp8 weight rounding during extraction
- explicitly recovers Donut Experimental-bypass adapters, which normal ModelSubtract/state-dict extractors cannot see because bypass lives in forward hooks
- supports existing in-memory bypass models by recovering their ComfyUI BypassInjectionManager adapters from the injection closure
- future bypass results also persist clone-safe adapter metadata automatically
- processes one weight at a time on CPU and uses exact SVD for smaller matrices / randomized low-rank SVD for large transformer projections
- writes generic Comfy-compatible `diffusion_model.*.lora_up/down.weight` keys with alpha=rank so strength 1 represents the truncated SVD delta directly
- reports if RAW/PATCHED are not clones of the same base or if unsupported runtime injections are present

Focused unit tests cover low-rank reconstruction, convolution LoRA shapes, inclusion of bypass deltas, recovery/flattening of composite bypass adapters, conversion of bypass adapters back to ordinary patches without a dense full-model delta, and node schema.