### PR TITLE
Fix DonutExtractLoRA on quantized model state dicts

### DIFF
--- a/DonutExtractLoRA.py
+++ b/DonutExtractLoRA.py
@@ -9,6 +9,11 @@ The extractor processes one model weight at a time on CPU. It does not need the
 full patched model or a dense full-model difference resident in VRAM, making it
 more practical on lower-VRAM GPUs. Large matrices use randomized low-rank SVD;
 small matrices use exact SVD.
+
+Quantized ComfyUI models may expose auxiliary state-dict entries such as
+``weight_scale``/``input_scale`` that are not real module attributes. We never
+feed those entries through ModelPatcher.get_key_patches(); instead we enumerate
+only actual ``*.weight`` targets and reproduce get_key_patches for those keys.
 """
 
 import logging
@@ -18,6 +23,7 @@ import folder_paths
 import torch
 
 import comfy.lora
+import comfy.model_patcher
 import comfy.utils
 
 try:
@@ -47,19 +53,121 @@ def _runtime_injection_keys(model):
     return {key for key, value in injections.items() if value}
 
 
-def _convert_base_weight(base_weight, convert_func):
-    if not torch.is_tensor(base_weight):
-        raise TypeError(f"Unsupported base weight type: {type(base_weight).__name__}")
+def _identity(value, **kwargs):
+    return value
 
-    weight = base_weight.detach().to(device="cpu", dtype=torch.float32).clone()
+
+def _weight_target_keys(model, bypass_components=None):
+    """Return real diffusion-model weight targets, excluding quant metadata.
+
+    Quantized state dicts can contain entries such as ``*.weight_scale`` and
+    ``*.input_scale``. Those are serialization metadata, not LoRA targets, and
+    calling ModelPatcher.get_key_patches() on the full state dict can try to
+    resolve them as normal module attributes. Restricting the scan to the
+    canonical ``*.weight`` keys avoids that failure and is also exactly what a
+    standard LoRA can represent.
+    """
+    keys = set()
+
+    try:
+        state_dict = model.model.state_dict()
+        keys.update(
+            key for key in state_dict.keys()
+            if key.startswith("diffusion_model.") and key.endswith(".weight")
+        )
+    except Exception:
+        logging.exception("[DonutExtractLoRA] Could not enumerate model state dict")
+
+    patches = getattr(model, "patches", {})
+    if isinstance(patches, dict):
+        keys.update(
+            key for key in patches.keys()
+            if isinstance(key, str)
+            and key.startswith("diffusion_model.")
+            and key.endswith(".weight")
+        )
+
+    if isinstance(bypass_components, dict):
+        keys.update(
+            key for key in bypass_components.keys()
+            if isinstance(key, str)
+            and key.startswith("diffusion_model.")
+            and key.endswith(".weight")
+        )
+
+    return keys
+
+
+def _single_key_patches(model, key):
+    """Reproduce ModelPatcher.get_key_patches() for one real weight key.
+
+    Doing this one key at a time avoids ComfyUI's quantization bookkeeping keys
+    while preserving physically patched backups, hook backups, conversion
+    functions, and the ordered regular patch stack.
+    """
+    try:
+        weight, _set_func, convert_func = comfy.model_patcher.get_key_weight(
+            model.model, key
+        )
+    except (AttributeError, IndexError, KeyError, TypeError) as exc:
+        raise RuntimeError(f"Could not resolve model weight {key}: {exc}") from exc
+
+    backup = getattr(model, "backup", {}).get(key)
+    if backup is not None:
+        weight = backup.weight
+
+    hook_backup = getattr(model, "hook_backup", {}).get(key)
+    if hook_backup is not None:
+        weight = hook_backup[0]
+
+    if convert_func is None:
+        convert_func = _identity
+
+    result = [(weight, convert_func)]
+    patches = getattr(model, "patches", {})
+    if key in patches:
+        result.extend(patches[key])
+    return result
+
+
+def _get_extractable_key_patches(model, bypass_components=None):
+    """Return get_key_patches-style entries for only actual LoRA weight targets."""
+    output = {}
+    for key in sorted(_weight_target_keys(model, bypass_components)):
+        try:
+            output[key] = _single_key_patches(model, key)
+        except Exception as exc:
+            # A model may expose a serialization-only weight-like key without a
+            # resolvable live module. Do not let one exotic layer abort every
+            # otherwise extractable LoRA layer.
+            logging.warning("[DonutExtractLoRA] Skipping unresolved weight %s: %s", key, exc)
+    return output
+
+
+def _convert_base_weight(base_weight, convert_func):
+    """Convert a normal or quantized model weight to CPU float32."""
+    value = base_weight
+
+    # Comfy quantized modules commonly provide convert_weight(), which
+    # dequantizes QuantizedTensor. Apply the model's own conversion before doing
+    # any dtype conversion ourselves so per-format scale information is honored.
     if convert_func is not None:
         try:
-            weight = convert_func(weight, inplace=True)
+            value = convert_func(value, inplace=False)
         except TypeError:
-            weight = convert_func(weight)
-    if not torch.is_tensor(weight):
-        raise TypeError("Model weight conversion did not return a Tensor")
-    return weight.float().cpu()
+            try:
+                value = convert_func(value, inplace=True)
+            except TypeError:
+                value = convert_func(value)
+
+    dequantize = getattr(value, "dequantize", None)
+    if callable(dequantize):
+        value = dequantize()
+
+    if not torch.is_tensor(value):
+        raise TypeError(f"Unsupported base weight type: {type(value).__name__}")
+
+    return value.detach().to(device="cpu", dtype=torch.float32).clone()
 
 
 def _effective_weight(key, key_patches, bypass_components):
@@ -69,16 +177,17 @@ def _effective_weight(key, key_patches, bypass_components):
 
     first = key_patches[0]
     if not isinstance(first, (tuple, list)) or len(first) < 2:
-        raise TypeError(f"Unexpected get_key_patches layout for {key}")
+        raise TypeError(f"Unexpected key-patch layout for {key}")
 
     base_weight, convert_func = first[0], first[1]
     weight = _convert_base_weight(base_weight, convert_func)
     patches = list(key_patches[1:])
 
     # Donut's experimental bypass is activation-side at inference time, but for
-    # a plain additive LoRA/LoKr target its exact equivalent is an ordinary
-    # weight adapter patch at the same strength. Append it here before computing
-    # the effective weight so extraction sees what inference actually used.
+    # the bypass-compatible additive adapters Donut permits, its exact
+    # serialization equivalent is an ordinary weight-adapter patch at the same
+    # strength. Append those adapters before computing the effective weight so
+    # extraction sees what inference actually used.
     for adapter, strength in bypass_components or ():
         strength = float(strength)
         if strength != 0.0:
@@ -150,8 +259,9 @@ class DonutExtractLoRA:
     DESCRIPTION = (
         "Extracts a standard low-rank LoRA representing PATCHED MODEL - RAW MODEL. "
         "Understands Donut Experimental bypass, whose adapter effect is invisible "
-        "to ordinary ModelSubtract/state-dict LoRA extractors. Large SVDs run in "
-        "CPU memory so the full merged model does not need to fit in VRAM."
+        "to ordinary ModelSubtract/state-dict LoRA extractors. Quantization metadata "
+        "is ignored safely, and large SVDs run in CPU memory so the full merged "
+        "model does not need to fit in VRAM."
     )
 
     @classmethod
@@ -191,10 +301,10 @@ class DonutExtractLoRA:
         rank = int(rank)
         output_dtype = OUTPUT_DTYPE_MAP[dtype]
 
-        raw_keys = raw_model.get_key_patches("diffusion_model.")
-        patched_keys = patched_model.get_key_patches("diffusion_model.")
         raw_bypass = get_bypass_components(raw_model)
         patched_bypass = get_bypass_components(patched_model)
+        raw_keys = _get_extractable_key_patches(raw_model, raw_bypass)
+        patched_keys = _get_extractable_key_patches(patched_model, patched_bypass)
 
         raw_injections = _runtime_injection_keys(raw_model)
         patched_injections = _runtime_injection_keys(patched_model)
@@ -222,8 +332,6 @@ class DonutExtractLoRA:
         )
 
         for key in common_keys:
-            if not key.endswith(".weight"):
-                continue
             try:
                 raw_weight = _effective_weight(key, raw_keys[key], raw_bypass.get(key))
                 patched_weight = _effective_weight(key, patched_keys[key], patched_bypass.get(key))
@@ -274,6 +382,7 @@ class DonutExtractLoRA:
             "donut.rank": str(rank),
             "donut.dtype": dtype,
             "donut.bypass_aware": "true",
+            "donut.quant_metadata_safe": "true",
         }
         comfy.utils.save_torch_file(output_sd, output_path, metadata=metadata)
 

--- a/test_donut_extract_lora.py
+++ b/test_donut_extract_lora.py
@@ -13,8 +13,10 @@ fake_comfy = types.ModuleType("comfy")
 fake_comfy.__path__ = []
 fake_lora = types.ModuleType("comfy.lora")
 fake_utils = types.ModuleType("comfy.utils")
+fake_model_patcher = types.ModuleType("comfy.model_patcher")
 fake_comfy.lora = fake_lora
 fake_comfy.utils = fake_utils
+fake_comfy.model_patcher = fake_model_patcher
 
 
 def fake_calculate_weight(patches, weight, key, **kwargs):
@@ -26,7 +28,18 @@ def fake_calculate_weight(patches, weight, key, **kwargs):
     return out
 
 
+def fake_get_key_weight(model, key):
+    obj = model
+    parts = key.split(".")
+    for part in parts[:-1]:
+        obj = getattr(obj, part)
+    # Deliberately use getattr here: requesting weight_scale from the fake
+    # quantized Linear will raise exactly like the real ComfyUI failure.
+    return getattr(obj, parts[-1]), None, None
+
+
 fake_lora.calculate_weight = fake_calculate_weight
+fake_model_patcher.get_key_weight = fake_get_key_weight
 fake_utils.save_torch_file = lambda *args, **kwargs: None
 
 fake_folder_paths = types.ModuleType("folder_paths")
@@ -37,10 +50,17 @@ fake_folder_paths.get_save_image_path = lambda prefix, output: (
 
 _previous = {
     name: sys.modules.get(name)
-    for name in ("comfy", "comfy.lora", "comfy.utils", "folder_paths")
+    for name in (
+        "comfy",
+        "comfy.lora",
+        "comfy.model_patcher",
+        "comfy.utils",
+        "folder_paths",
+    )
 }
 sys.modules["comfy"] = fake_comfy
 sys.modules["comfy.lora"] = fake_lora
+sys.modules["comfy.model_patcher"] = fake_model_patcher
 sys.modules["comfy.utils"] = fake_utils
 sys.modules["folder_paths"] = fake_folder_paths
 
@@ -113,6 +133,35 @@ class FakeInjectionModel:
         self.added.append((patches, strength))
 
 
+class FakeQuantizedPatcher:
+    """State dict exposes scale metadata that the live Linear does not own."""
+
+    def __init__(self):
+        layer = types.SimpleNamespace(weight=torch.randn(4, 3))
+        diffusion_model = types.SimpleNamespace(layer=layer)
+        self.model = types.SimpleNamespace(diffusion_model=diffusion_model)
+        self.patches = {}
+        self.backup = {}
+        self.hook_backup = {}
+
+        def state_dict():
+            return {
+                "diffusion_model.layer.weight": layer.weight,
+                "diffusion_model.layer.weight_scale": torch.tensor(0.125),
+                "diffusion_model.layer.input_scale": torch.tensor(0.5),
+            }
+
+        self.model.state_dict = state_dict
+
+
+class FakeQuantizedValue:
+    def __init__(self, tensor):
+        self.tensor = tensor
+
+    def dequantize(self):
+        return self.tensor
+
+
 class DonutExtractLoRATests(unittest.TestCase):
     def test_rank_factorization_reconstructs_low_rank_matrix(self):
         left = torch.tensor([[1.0, 2.0], [3.0, -1.0], [0.5, 4.0]])
@@ -155,6 +204,23 @@ class DonutExtractLoRATests(unittest.TestCase):
 
         expected = torch.ones(3, 4)
         self.assertTrue(torch.allclose(result, expected))
+
+    def test_quantized_metadata_keys_are_not_resolved_as_module_weights(self):
+        model = FakeQuantizedPatcher()
+
+        patches = extract._get_extractable_key_patches(model)
+
+        self.assertEqual(list(patches), ["diffusion_model.layer.weight"])
+        self.assertTrue(torch.equal(patches["diffusion_model.layer.weight"][0][0], model.model.diffusion_model.layer.weight))
+
+    def test_quantized_value_is_dequantized_before_float32_extraction(self):
+        expected = torch.tensor([[1.25, -2.5], [3.75, 4.0]], dtype=torch.float16)
+        value = FakeQuantizedValue(expected)
+
+        result = extract._convert_base_weight(value, lambda x, **kwargs: x)
+
+        self.assertEqual(result.dtype, torch.float32)
+        self.assertTrue(torch.equal(result, expected.float()))
 
     def test_discovers_and_flattens_existing_bypass_manager(self):
         a = Adapter(torch.ones(2, 2))


### PR DESCRIPTION
Fixes `DonutExtractLoRA` crashing on quantized ComfyUI models with errors like:

`AttributeError: 'Linear' object has no attribute 'weight_scale'`

### Cause
`ModelPatcher.get_key_patches('diffusion_model.')` walks the entire model state dict. Quantized models expose auxiliary entries such as `*.weight_scale` / `*.input_scale`, but those entries are not always live module attributes. `get_key_weight()` therefore attempts to resolve a non-existent attribute and aborts extraction before any LoRA layer is processed.

### Fix
- enumerate only real `diffusion_model.*.weight` LoRA targets
- reproduce `get_key_patches()` one actual weight at a time, preserving regular patches, backups, hook backups, and conversion functions
- ignore quantization metadata tensors as LoRA targets
- honor Comfy quantized `convert_weight()` / `dequantize()` before float32 SVD extraction
- retain Donut Experimental-bypass adapter recovery
- skip an individually unresolved exotic weight instead of aborting the entire extraction

### Regression coverage
Adds a fake quantized state dict containing `layer.weight_scale` and `layer.input_scale` while the live Linear only owns `weight`, reproducing the reported failure. Also covers dequantization before float32 extraction.

This is a post-merge follow-up to #36.