### PR TITLE
Bake Krea2 bypass merges and support output symlink model saves

### DIFF
--- a/DonutModelSave.py
+++ b/DonutModelSave.py
@@ -9,11 +9,11 @@ ComfyUI loaded a model in fp8 but the desired baked LoRA/merge output should be
 saved as bf16/fp16/fp32 instead.
 
 The state-dict construction path follows comfy.sd.save_checkpoint:
-load_models_gpu(...) -> ModelPatcher.state_dict_for_saving(...). This routes
-through ComfyUI's LazyCastingParam machinery, so ordinary patches are materialized
-one weight at a time. Donut Experimental-bypass LoRAs are first converted on a
-temporary clone to equivalent ordinary adapter patches, so bypass inference is
-also baked into saved weights without densifying the whole model in VRAM.
+load_models_gpu(...) -> ModelPatcher state_dict_for_saving machinery. Ordinary
+patches are materialized one weight at a time. Donut Experimental-bypass LoRAs
+are converted on a temporary clone to equivalent ordinary adapter patches.
+Donut Model Merge Krea2 Experimental-bypass hard swaps are composed from the
+retained model2 source state so those runtime-only swaps are also baked.
 """
 
 from contextlib import nullcontext
@@ -35,12 +35,24 @@ try:
         clone_with_bypass_as_regular_patches,
         get_bypass_components,
     )
+    from .donut_krea2_merge_serialization import (
+        clone_with_regular_components,
+        clone_without_krea2_merge_runtime,
+        compose_krea2_merge_unet_state_dict,
+        get_krea2_merge_bypass_info,
+    )
     from .DonutExtractLoRA import DonutExtractLoRA
 except ImportError:
     from model_lifecycle import offload_models
     from donut_bypass_materialization import (
         clone_with_bypass_as_regular_patches,
         get_bypass_components,
+    )
+    from donut_krea2_merge_serialization import (
+        clone_with_regular_components,
+        clone_without_krea2_merge_runtime,
+        compose_krea2_merge_unet_state_dict,
+        get_krea2_merge_bypass_info,
     )
     from DonutExtractLoRA import DonutExtractLoRA
 
@@ -132,18 +144,40 @@ def _materialize_and_cast(sd, dtype):
 
 
 def _save_via_comfy(model, clip, vae, output_path, filename, counter, dtype):
-    """
-    Faithful reproduction of comfy.sd.save_checkpoint with:
-      - workflow metadata stripped
-      - optional dtype conversion
-      - Donut Experimental-bypass adapters serialized as ordinary patches
-    """
-    bypass_components = get_bypass_components(model)
+    """Save a model/checkpoint while materializing Donut runtime-only bypasses."""
+    lora_bypass_components = get_bypass_components(model)
+    krea2_merge_info = get_krea2_merge_bypass_info(model)
+
+    has_runtime_serialization = bool(lora_bypass_components) or krea2_merge_info is not None
     use_ejected = getattr(model, "use_ejected", None)
-    context = use_ejected() if bypass_components and callable(use_ejected) else nullcontext()
+    context = (
+        use_ejected()
+        if has_runtime_serialization and callable(use_ejected)
+        else nullcontext()
+    )
 
     with context:
+        # Convert final-model bypass LoRAs to ordinary patches for every normal
+        # model1/partial-blend key. The Krea2 exact-swap keys are replaced from
+        # model2 below, so their final bypass-LoRA components are also applied to
+        # a source-model clone before composing the state dict.
         save_model = clone_with_bypass_as_regular_patches(model)
+        source_for_save = None
+        krea2_plans = None
+
+        if krea2_merge_info is not None:
+            source_model, krea2_plans, _attachment_keys = krea2_merge_info
+            save_model = clone_without_krea2_merge_runtime(
+                save_model,
+                krea2_merge_info,
+            )
+
+            swapped_weight_keys = {plan[1] for plan in krea2_plans}
+            source_for_save = clone_with_regular_components(
+                source_model,
+                lora_bypass_components,
+                allowed_keys=swapped_weight_keys,
+            )
 
         metadata, extra_keys = _build_modelspec_metadata(save_model, filename, counter)
         if args.disable_metadata:
@@ -151,6 +185,11 @@ def _save_via_comfy(model, clip, vae, output_path, filename, counter, dtype):
 
         clip_sd = None
         load_models = [save_model]
+        if source_for_save is not None:
+            # Keeping source model2 explicit here preserves ComfyUI's normal
+            # partial-loading behavior on low-VRAM systems instead of forcing a
+            # dense merged model into VRAM.
+            load_models.append(source_for_save)
         if clip is not None:
             load_models.append(clip.load_model())
             clip_sd = clip.get_sd()
@@ -159,12 +198,36 @@ def _save_via_comfy(model, clip, vae, output_path, filename, counter, dtype):
             vae_sd = vae.get_sd()
 
         # Do not force_patch_weights. Normal partial loading is important on
-        # low-VRAM systems; LazyCastingParam applies regular and converted-bypass
-        # patches as each saved tensor is moved to CPU.
+        # low-VRAM systems; lazy state-dict tensors apply regular patches as each
+        # tensor is materialized on CPU.
         comfy.model_management.load_models_gpu(load_models)
 
         clip_vision_sd = None
-        sd = save_model.state_dict_for_saving(clip_sd, vae_sd, clip_vision_sd)
+        if source_for_save is not None:
+            unet_sd, swapped_modules, swapped_state_keys = \
+                compose_krea2_merge_unet_state_dict(
+                    save_model,
+                    source_for_save,
+                    krea2_plans,
+                )
+            sd = save_model.model.state_dict_for_saving(
+                unet_sd,
+                clip_state_dict=clip_sd,
+                vae_state_dict=vae_sd,
+                clip_vision_state_dict=clip_vision_sd,
+            )
+            print(
+                "[DonutSave] Materializing Krea2 Experimental-bypass merge: "
+                f"{swapped_modules} model2 module swap(s), "
+                f"{swapped_state_keys} direct state key(s)"
+            )
+        else:
+            sd = save_model.state_dict_for_saving(
+                clip_sd,
+                vae_sd,
+                clip_vision_sd,
+            )
+
         for k in extra_keys:
             sd[k] = extra_keys[k]
 
@@ -261,9 +324,10 @@ class DonutDiffusionModelSave(DonutModelSave):
     DEPRECATED = False
     DESCRIPTION = (
         "Saves only the diffusion MODEL as safetensors with no workflow metadata. "
-        "Ordinary ModelPatcher changes and Donut Experimental-bypass LoRAs are baked "
-        "into the saved weights. BF16 is the default so a model loaded in fp8 is "
-        "not silently re-saved as fp8."
+        "Ordinary ModelPatcher changes, Donut Experimental-bypass LoRAs, and "
+        "Donut Model Merge Krea2 Experimental-bypass hard swaps are baked into "
+        "the saved weights. BF16 is the default so a model loaded in fp8 is not "
+        "silently re-saved as fp8."
     )
 
 

--- a/donut_krea2_merge_serialization.py
+++ b/donut_krea2_merge_serialization.py
@@ -1,0 +1,219 @@
+"""Serialization helpers for Donut Model Merge Krea2 Experimental bypass.
+
+The Krea2 merge node keeps exact ratio=0 model2 swaps as runtime forward hooks.
+Those hooks intentionally do not modify model1's stored weights, so a normal
+state-dict save would silently serialize model1 for every bypassed component.
+
+This module reconstructs the effective save state without materializing a dense
+merged model in VRAM:
+
+* normal and partial-blend keys stay on the final model1 patcher
+* exact bypassed modules are taken from the retained model2 source patcher
+* all direct module state (weight, bias, quant scales/buffers) is swapped
+* later Donut bypass-LoRA adapters can be applied to model2's swapped weights
+  before the final state dict is produced
+
+The final composed UNet state dict still uses ComfyUI LazyCastingParam wrappers,
+so tensors are materialized one at a time during saving.
+"""
+
+KREA2_MERGE_INJECTION_KEY = "donut_krea2_model_merge_bypass"
+KREA2_MERGE_SOURCE_KEY = "donut_krea2_model_merge_sources"
+KREA2_MERGE_PLAN_PREFIX = "donut_krea2_model_merge_identity:"
+
+
+def _get_injections(model):
+    injections = getattr(model, "injections", None)
+    return injections if isinstance(injections, dict) else {}
+
+
+def _get_additional_models(model, key):
+    getter = getattr(model, "get_additional_models_with_key", None)
+    if callable(getter):
+        return list(getter(key) or [])
+    additional = getattr(model, "additional_models", None)
+    if isinstance(additional, dict):
+        return list(additional.get(key, []) or [])
+    return []
+
+
+def _get_attachments(model):
+    attachments = getattr(model, "attachments", None)
+    return attachments if isinstance(attachments, dict) else {}
+
+
+def get_krea2_merge_bypass_info(model):
+    """Return ``(source_model, plans, attachment_keys)`` or ``None``.
+
+    A plan item is ``(module_path, weight_key, model1_ratio)``. Experimental
+    bypass currently emits only ratio 0.0 plans. If runtime merge hooks exist
+    but the source/plan metadata is missing, raise instead of allowing a silent
+    model1-only save.
+    """
+    injections = _get_injections(model)
+    has_runtime = KREA2_MERGE_INJECTION_KEY in injections
+
+    plans = []
+    attachment_keys = []
+    for key, value in _get_attachments(model).items():
+        if not isinstance(key, str) or not key.startswith(KREA2_MERGE_PLAN_PREFIX):
+            continue
+        attachment_keys.append(key)
+        if not isinstance(value, (list, tuple)):
+            continue
+        for item in value:
+            if not isinstance(item, (list, tuple)) or len(item) != 3:
+                continue
+            module_path, weight_key, ratio = item
+            if not isinstance(module_path, str) or not isinstance(weight_key, str):
+                continue
+            plans.append((module_path, weight_key, float(ratio)))
+
+    if not has_runtime and not plans:
+        return None
+    if not plans:
+        raise RuntimeError(
+            "Donut Krea2 Experimental-bypass merge is active, but its save plan "
+            "metadata is missing. Refusing to save model1 without the bypassed model2 blocks."
+        )
+
+    # Preserve order while removing duplicate plan tuples inherited through clones.
+    unique_plans = []
+    seen = set()
+    for plan in plans:
+        if plan in seen:
+            continue
+        seen.add(plan)
+        unique_plans.append(plan)
+
+    for module_path, weight_key, ratio in unique_plans:
+        if ratio != 0.0:
+            raise RuntimeError(
+                "Donut Krea2 save encountered a non-zero runtime bypass ratio for "
+                f"{weight_key}: {ratio}. Partial blends must be regular Comfy patches."
+            )
+        if not weight_key.endswith(".weight"):
+            raise RuntimeError(f"Invalid Krea2 bypass weight key: {weight_key}")
+        if weight_key[:-7] != module_path:
+            raise RuntimeError(
+                f"Krea2 bypass plan mismatch: module '{module_path}' vs '{weight_key}'"
+            )
+
+    sources = _get_additional_models(model, KREA2_MERGE_SOURCE_KEY)
+    if len(sources) != 1:
+        raise RuntimeError(
+            "Donut Krea2 Experimental-bypass save expected exactly one retained "
+            f"model2 source, found {len(sources)}. Refusing a lossy save."
+        )
+
+    return sources[0], tuple(unique_plans), tuple(attachment_keys)
+
+
+def clone_without_krea2_merge_runtime(model, info=None):
+    """Clone the final model and remove only Krea2 merge runtime plumbing."""
+    if info is None:
+        info = get_krea2_merge_bypass_info(model)
+    if info is None:
+        return model
+
+    _source, _plans, attachment_keys = info
+    converted = model.clone()
+
+    remove_injections = getattr(converted, "remove_injections", None)
+    if callable(remove_injections):
+        remove_injections(KREA2_MERGE_INJECTION_KEY)
+    elif isinstance(getattr(converted, "injections", None), dict):
+        converted.injections.pop(KREA2_MERGE_INJECTION_KEY, None)
+
+    remove_additional = getattr(converted, "remove_additional_models", None)
+    if callable(remove_additional):
+        remove_additional(KREA2_MERGE_SOURCE_KEY)
+    elif callable(getattr(converted, "set_additional_models", None)):
+        converted.set_additional_models(KREA2_MERGE_SOURCE_KEY, [])
+    elif isinstance(getattr(converted, "additional_models", None), dict):
+        converted.additional_models.pop(KREA2_MERGE_SOURCE_KEY, None)
+
+    remove_attachment = getattr(converted, "remove_attachments", None)
+    for key in attachment_keys:
+        if callable(remove_attachment):
+            remove_attachment(key)
+        elif isinstance(getattr(converted, "attachments", None), dict):
+            converted.attachments.pop(key, None)
+
+    return converted
+
+
+def clone_with_regular_components(model, components_by_key, allowed_keys=None):
+    """Clone ``model`` and register selected bypass adapters as normal patches."""
+    if not components_by_key:
+        return model.clone()
+
+    allowed = None if allowed_keys is None else set(allowed_keys)
+    converted = model.clone()
+    for key, components in components_by_key.items():
+        if allowed is not None and key not in allowed:
+            continue
+        for adapter, strength in components:
+            strength = float(strength)
+            if strength == 0.0:
+                continue
+            converted.add_patches({key: adapter}, strength)
+    return converted
+
+
+def _direct_module_state_keys(state_dict, module_path):
+    prefix = f"{module_path}."
+    direct = set()
+    for key in state_dict.keys():
+        if not isinstance(key, str) or not key.startswith(prefix):
+            continue
+        suffix = key[len(prefix):]
+        if suffix and "." not in suffix:
+            direct.add(key)
+    return direct
+
+
+def compose_krea2_merge_unet_state_dict(base_model, source_model, plans):
+    """Compose the lazy UNet state dict matching Experimental-bypass inference.
+
+    ``base_model`` is the final model with runtime merge plumbing removed and all
+    normal patches preserved. ``source_model`` is the retained model2 patcher,
+    optionally with later bypass-LoRA adapters registered as ordinary patches.
+    """
+    base_sd = base_model.model_state_dict_for_saving(
+        base_model.model.diffusion_model,
+        "diffusion_model.",
+    )
+    source_sd = source_model.model_state_dict_for_saving(
+        source_model.model.diffusion_model,
+        "diffusion_model.",
+    )
+
+    swapped_modules = 0
+    swapped_keys = 0
+    for module_path, weight_key, _ratio in plans:
+        base_keys = _direct_module_state_keys(base_sd, module_path)
+        source_keys = _direct_module_state_keys(source_sd, module_path)
+
+        if weight_key not in source_keys:
+            raise RuntimeError(
+                "Donut Krea2 save could not find the model2 source weight for "
+                f"bypassed module '{module_path}'."
+            )
+        if not source_keys:
+            raise RuntimeError(
+                f"Donut Krea2 save found no model2 state for '{module_path}'."
+            )
+
+        # Runtime bypass calls the complete source module, not merely its weight.
+        # Remove every direct model1 state entry and replace it with model2's set,
+        # preserving quant metadata such as weight_scale/input_scale as well as bias.
+        for key in base_keys:
+            base_sd.pop(key, None)
+        for key in source_keys:
+            base_sd[key] = source_sd[key]
+
+        swapped_modules += 1
+        swapped_keys += len(source_keys)
+
+    return base_sd, swapped_modules, swapped_keys

--- a/test_krea2_merge_serialization.py
+++ b/test_krea2_merge_serialization.py
@@ -1,0 +1,168 @@
+import unittest
+
+import donut_krea2_merge_serialization as serialization
+
+
+class FalseyInjectionList(list):
+    def __bool__(self):
+        return False
+
+
+class FakeRoot:
+    def __init__(self):
+        self.diffusion_model = object()
+
+
+class FakePatcher:
+    def __init__(self, state_dict=None):
+        self.model = FakeRoot()
+        self.state_dict = dict(state_dict or {})
+        self.injections = {}
+        self.additional_models = {}
+        self.attachments = {}
+        self.added = []
+
+    def clone(self):
+        clone = FakePatcher(self.state_dict)
+        clone.injections = {key: list(value) for key, value in self.injections.items()}
+        clone.additional_models = {
+            key: [item.clone() for item in values]
+            for key, values in self.additional_models.items()
+        }
+        clone.attachments = dict(self.attachments)
+        clone.added = list(self.added)
+        return clone
+
+    def get_additional_models_with_key(self, key):
+        return self.additional_models.get(key, [])
+
+    def remove_injections(self, key):
+        self.injections.pop(key, None)
+
+    def remove_additional_models(self, key):
+        self.additional_models.pop(key, None)
+
+    def remove_attachments(self, key):
+        self.attachments.pop(key, None)
+
+    def add_patches(self, patches, strength_patch=1.0, strength_model=1.0):
+        self.added.append((dict(patches), strength_patch, strength_model))
+
+    def model_state_dict_for_saving(self, model, prefix):
+        self.assert_prefix = prefix
+        return dict(self.state_dict)
+
+
+def make_merge(base_state=None, source_state=None):
+    base = FakePatcher(base_state)
+    source = FakePatcher(source_state)
+    plan = (
+        "diffusion_model.first",
+        "diffusion_model.first.weight",
+        0.0,
+    )
+    base.injections[serialization.KREA2_MERGE_INJECTION_KEY] = FalseyInjectionList([object()])
+    base.additional_models[serialization.KREA2_MERGE_SOURCE_KEY] = [source]
+    identity = serialization.KREA2_MERGE_PLAN_PREFIX + "abc"
+    base.attachments[identity] = (plan,)
+    return base, source, plan, identity
+
+
+class Krea2MergeSerializationTests(unittest.TestCase):
+    def test_falsey_runtime_injection_is_still_detected(self):
+        base, source, plan, identity = make_merge()
+
+        info = serialization.get_krea2_merge_bypass_info(base)
+
+        self.assertIs(info[0], source)
+        self.assertEqual(info[1], (plan,))
+        self.assertEqual(info[2], (identity,))
+
+    def test_runtime_without_plan_refuses_lossy_save(self):
+        model = FakePatcher()
+        model.injections[serialization.KREA2_MERGE_INJECTION_KEY] = FalseyInjectionList([object()])
+
+        with self.assertRaisesRegex(RuntimeError, "save plan metadata is missing"):
+            serialization.get_krea2_merge_bypass_info(model)
+
+    def test_runtime_without_source_refuses_lossy_save(self):
+        model, _source, _plan, _identity = make_merge()
+        model.additional_models.clear()
+
+        with self.assertRaisesRegex(RuntimeError, "exactly one retained model2 source"):
+            serialization.get_krea2_merge_bypass_info(model)
+
+    def test_clone_removes_only_merge_runtime_plumbing(self):
+        model, _source, _plan, identity = make_merge()
+        model.injections["other_runtime"] = [object()]
+        model.additional_models["other_source"] = [FakePatcher()]
+        model.attachments["other_attachment"] = 7
+
+        converted = serialization.clone_without_krea2_merge_runtime(model)
+
+        self.assertNotIn(serialization.KREA2_MERGE_INJECTION_KEY, converted.injections)
+        self.assertNotIn(serialization.KREA2_MERGE_SOURCE_KEY, converted.additional_models)
+        self.assertNotIn(identity, converted.attachments)
+        self.assertIn("other_runtime", converted.injections)
+        self.assertIn("other_source", converted.additional_models)
+        self.assertEqual(converted.attachments["other_attachment"], 7)
+
+    def test_composition_replaces_complete_direct_module_state(self):
+        base_state = {
+            "diffusion_model.first.weight": "base-weight",
+            "diffusion_model.first.bias": "base-bias",
+            "diffusion_model.first.weight_scale": "base-scale",
+            "diffusion_model.first.child.weight": "base-child",
+            "diffusion_model.other.weight": "base-other",
+        }
+        source_state = {
+            "diffusion_model.first.weight": "source-weight",
+            "diffusion_model.first.bias": "source-bias",
+            "diffusion_model.first.weight_scale": "source-scale",
+            "diffusion_model.first.input_scale": "source-input-scale",
+            "diffusion_model.first.child.weight": "source-child",
+            "diffusion_model.other.weight": "source-other",
+        }
+        base, source, plan, _identity = make_merge(base_state, source_state)
+
+        composed, module_count, key_count = serialization.compose_krea2_merge_unet_state_dict(
+            base,
+            source,
+            (plan,),
+        )
+
+        self.assertEqual(composed["diffusion_model.first.weight"], "source-weight")
+        self.assertEqual(composed["diffusion_model.first.bias"], "source-bias")
+        self.assertEqual(composed["diffusion_model.first.weight_scale"], "source-scale")
+        self.assertEqual(composed["diffusion_model.first.input_scale"], "source-input-scale")
+        # Child modules are not direct state of the swapped Linear and therefore
+        # remain on the normal model1/partial-patch path.
+        self.assertEqual(composed["diffusion_model.first.child.weight"], "base-child")
+        self.assertEqual(composed["diffusion_model.other.weight"], "base-other")
+        self.assertEqual(module_count, 1)
+        self.assertEqual(key_count, 4)
+
+    def test_later_bypass_lora_components_can_be_applied_only_to_swapped_weights(self):
+        source = FakePatcher()
+        adapter_swapped = object()
+        adapter_other = object()
+        components = {
+            "diffusion_model.first.weight": [(adapter_swapped, 0.75)],
+            "diffusion_model.other.weight": [(adapter_other, 1.0)],
+        }
+
+        converted = serialization.clone_with_regular_components(
+            source,
+            components,
+            allowed_keys={"diffusion_model.first.weight"},
+        )
+
+        self.assertEqual(len(converted.added), 1)
+        patches, strength_patch, strength_model = converted.added[0]
+        self.assertIs(patches["diffusion_model.first.weight"], adapter_swapped)
+        self.assertEqual(strength_patch, 0.75)
+        self.assertEqual(strength_model, 1.0)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes two model-save failures in `Donut Diffusion Model Save (No Workflow)`.

### 1. Krea2 Experimental-bypass merges were silently omitted
Exact ratio-0 Krea2 component swaps are runtime forward hooks that call the retained model2 module directly. They intentionally do not alter model1's stored weights, so the old saver could write model1 + LoRAs while dropping all hard-swapped model2 blocks.

The save path now:
- detects Krea2 merge-bypass source/plan metadata
- refuses to save silently if runtime merge metadata is incomplete
- keeps model1 and partial blends on ComfyUI's normal lazy patch path
- replaces exact-swapped modules from retained model2 before final serialization
- replaces complete direct module state, including bias and quantization metadata (`weight_scale`, `input_scale`, `pre_quant_scale`, etc.)
- applies later Donut Experimental-bypass LoRAs on top of model2 for swapped weights, matching inference order
- keeps model2 as a separate partially-loadable source patcher instead of constructing a dense merged model in VRAM

### 2. Intentional `output/` symlinks were rejected by newer ComfyUI
Newer `folder_paths.get_save_image_path()` resolves symlinks before containment checks. A local setup such as:

`ComfyUI/output/diffusion_models -> /fast-ssd/comfy-model-output`

therefore triggers `Saving image outside the output folder is not allowed`.

Donut now delegates to ComfyUI first and only falls back when:
- the requested filename prefix is lexically inside the configured output directory
- it is not absolute and contains no parent traversal
- an already-existing symlink component under `output/` explains the realpath escape

This supports intentional SSD symlinks without changing ComfyUI's global path validation or allowing arbitrary absolute/`..` destinations.

### Regression coverage
Tests cover:
- Krea2 falsey/composable merge injections
- missing source/plan refusal
- direct model2-state replacement including quant metadata and bias
- later bypass-LoRA application to swapped model2 weights
- normal ComfyUI save-path behavior staying unchanged
- output symlink to an external SSD
- counter detection through the symlink
- rejection of absolute paths and `..` traversal
- no fallback when there is no symlink

This fixes the reported workflow where the live graph used Krea2 model2 blocks but the saved file behaved like model1 with LoRAs attached, and also allows the user's intentional SSD symlink destination.