### PR TITLE
Allow Donut model saves through intentional output symlinks

### DIFF
--- a/DonutModelSave.py
+++ b/DonutModelSave.py
@@ -31,6 +31,7 @@ from comfy.cli_args import args
 
 try:
     from .model_lifecycle import offload_models
+    from .donut_save_path import get_model_save_path
     from .donut_bypass_materialization import (
         clone_with_bypass_as_regular_patches,
         get_bypass_components,
@@ -44,6 +45,7 @@ try:
     from .DonutExtractLoRA import DonutExtractLoRA
 except ImportError:
     from model_lifecycle import offload_models
+    from donut_save_path import get_model_save_path
     from donut_bypass_materialization import (
         clone_with_bypass_as_regular_patches,
         get_bypass_components,
@@ -271,7 +273,7 @@ class DonutSave:
 
     def save(self, model, filename_prefix, dtype="original", clip=None, vae=None):
         full_output_folder, filename, counter, subfolder, filename_prefix = \
-            folder_paths.get_save_image_path(filename_prefix, self.output_dir)
+            get_model_save_path(folder_paths, filename_prefix, self.output_dir)
 
         output_path = os.path.join(
             full_output_folder, f"{filename}_{counter:05}_.safetensors"
@@ -301,7 +303,7 @@ class DonutModelSave(DonutSave):
                 "model": ("MODEL",),
                 "filename_prefix": ("STRING", {
                     "default": "diffusion_models/ComfyUI",
-                    "tooltip": "Saved under ComfyUI/output by default; use diffusion_models/... for model-library style organization.",
+                    "tooltip": "Saved under ComfyUI/output by default; existing symlinks beneath output are supported for model storage.",
                 }),
                 "dtype": (DTYPE_OPTIONS, {
                     "default": "bf16",
@@ -326,7 +328,8 @@ class DonutDiffusionModelSave(DonutModelSave):
         "Saves only the diffusion MODEL as safetensors with no workflow metadata. "
         "Ordinary ModelPatcher changes, Donut Experimental-bypass LoRAs, and "
         "Donut Model Merge Krea2 Experimental-bypass hard swaps are baked into "
-        "the saved weights. BF16 is the default so a model loaded in fp8 is not "
+        "the saved weights. Existing output-directory symlinks are supported for "
+        "model storage. BF16 is the default so a model loaded in fp8 is not "
         "silently re-saved as fp8."
     )
 

--- a/donut_save_path.py
+++ b/donut_save_path.py
@@ -1,0 +1,97 @@
+"""Safe model-save path resolution with support for intentional output symlinks.
+
+ComfyUI's image-save helper resolves symlinks before checking containment. That is
+correct for browser-facing image writes, but it also rejects a common local model
+workflow where e.g. ``output/diffusion_models`` is a user-created symlink to a
+larger/faster SSD.
+
+Donut first delegates to ComfyUI unchanged. Only when that call fails do we allow
+a narrow fallback: the requested path must be lexically inside ``output_dir`` and
+an already-existing symlink component inside ``output_dir`` must explain why the
+resolved path leaves it. Absolute paths and ``..`` traversal are never accepted.
+"""
+
+from __future__ import annotations
+
+import os
+import re
+
+
+def _lexically_within(base_dir: str, target: str) -> bool:
+    base_abs = os.path.abspath(base_dir)
+    target_abs = os.path.abspath(target)
+    try:
+        return os.path.commonpath([base_abs, target_abs]) == base_abs
+    except ValueError:
+        return False
+
+
+def _first_existing_symlink(base_dir: str, target_dir: str):
+    base_abs = os.path.abspath(base_dir)
+    target_abs = os.path.abspath(target_dir)
+    if not _lexically_within(base_abs, target_abs):
+        return None
+
+    relative = os.path.relpath(target_abs, base_abs)
+    current = base_abs
+    if relative in ("", "."):
+        return None
+
+    for part in relative.split(os.sep):
+        if part in ("", "."):
+            continue
+        current = os.path.join(current, part)
+        if os.path.lexists(current) and os.path.islink(current):
+            return current
+    return None
+
+
+def _next_counter(folder: str, filename: str) -> int:
+    pattern = re.compile(rf"^{re.escape(filename)}_(\d+)_\.safetensors$")
+    highest = 0
+    try:
+        entries = os.listdir(folder)
+    except FileNotFoundError:
+        entries = []
+
+    for entry in entries:
+        match = pattern.match(entry)
+        if match:
+            highest = max(highest, int(match.group(1)))
+    return highest + 1
+
+
+def get_model_save_path(folder_paths_module, filename_prefix: str, output_dir: str):
+    """Resolve a model-save path, permitting only intentional output symlinks."""
+    try:
+        return folder_paths_module.get_save_image_path(filename_prefix, output_dir)
+    except Exception as original_error:
+        if not isinstance(filename_prefix, str) or not filename_prefix:
+            raise
+        if "\x00" in filename_prefix or os.path.isabs(filename_prefix):
+            raise
+        if "%" in filename_prefix:
+            raise
+
+        normalized = os.path.normpath(filename_prefix)
+        subfolder = os.path.dirname(normalized)
+        filename = os.path.basename(normalized)
+        if filename in ("", ".", ".."):
+            raise
+
+        output_abs = os.path.abspath(output_dir)
+        full_output_folder = os.path.abspath(os.path.join(output_abs, subfolder))
+        if not _lexically_within(output_abs, full_output_folder):
+            raise
+
+        symlink = _first_existing_symlink(output_abs, full_output_folder)
+        if symlink is None or not os.path.isdir(symlink):
+            raise original_error
+
+        os.makedirs(full_output_folder, exist_ok=True)
+        counter = _next_counter(full_output_folder, filename)
+        print(
+            "[DonutSave] ComfyUI rejected an output symlink; allowing explicit "
+            f"local symlink {symlink} -> {os.path.realpath(symlink)}"
+        )
+        return full_output_folder, filename, counter, subfolder, filename_prefix

--- a/test_donut_save_path.py
+++ b/test_donut_save_path.py
@@ -1,0 +1,105 @@
+import tempfile
+import unittest
+from pathlib import Path
+
+from donut_save_path import get_model_save_path
+
+
+class RejectingFolderPaths:
+    @staticmethod
+    def get_save_image_path(filename_prefix, output_dir):
+        raise Exception("Saving image outside the output folder is not allowed")
+
+
+class AcceptingFolderPaths:
+    @staticmethod
+    def get_save_image_path(filename_prefix, output_dir):
+        return (output_dir, filename_prefix, 7, "", filename_prefix)
+
+
+class DonutSavePathTests(unittest.TestCase):
+    def test_normal_comfy_path_is_used_unchanged(self):
+        result = get_model_save_path(AcceptingFolderPaths, "ComfyUI", "/tmp/output")
+        self.assertEqual(result, ("/tmp/output", "ComfyUI", 7, "", "ComfyUI"))
+
+    def test_existing_output_symlink_can_point_to_external_ssd(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            output = root / "output"
+            ssd = root / "external-ssd"
+            output.mkdir()
+            ssd.mkdir()
+            (output / "diffusion_models").symlink_to(ssd, target_is_directory=True)
+
+            result = get_model_save_path(
+                RejectingFolderPaths,
+                "diffusion_models/KreaMerge",
+                str(output),
+            )
+
+            folder, filename, counter, subfolder, _ = result
+            self.assertEqual(Path(folder), output / "diffusion_models")
+            self.assertEqual(Path(folder).resolve(), ssd.resolve())
+            self.assertEqual(filename, "KreaMerge")
+            self.assertEqual(counter, 1)
+            self.assertEqual(subfolder, "diffusion_models")
+
+    def test_counter_scans_existing_safetensors_through_symlink(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            output = root / "output"
+            ssd = root / "ssd"
+            output.mkdir()
+            ssd.mkdir()
+            (output / "models").symlink_to(ssd, target_is_directory=True)
+            (ssd / "Thing_00001_.safetensors").write_bytes(b"")
+            (ssd / "Thing_00009_.safetensors").write_bytes(b"")
+
+            result = get_model_save_path(
+                RejectingFolderPaths,
+                "models/Thing",
+                str(output),
+            )
+            self.assertEqual(result[2], 10)
+
+    def test_parent_traversal_is_rejected_even_with_symlink_present(self):
+        with tempfile.TemporaryDirectory() as temp:
+            root = Path(temp)
+            output = root / "output"
+            ssd = root / "ssd"
+            output.mkdir()
+            ssd.mkdir()
+            (output / "models").symlink_to(ssd, target_is_directory=True)
+
+            with self.assertRaises(Exception):
+                get_model_save_path(
+                    RejectingFolderPaths,
+                    "../escape/model",
+                    str(output),
+                )
+
+    def test_absolute_path_is_rejected(self):
+        with tempfile.TemporaryDirectory() as temp:
+            output = Path(temp) / "output"
+            output.mkdir()
+            with self.assertRaises(Exception):
+                get_model_save_path(
+                    RejectingFolderPaths,
+                    "/mnt/elsewhere/model",
+                    str(output),
+                )
+
+    def test_no_symlink_does_not_weaken_comfy_validation(self):
+        with tempfile.TemporaryDirectory() as temp:
+            output = Path(temp) / "output"
+            output.mkdir()
+            with self.assertRaisesRegex(Exception, "outside the output"):
+                get_model_save_path(
+                    RejectingFolderPaths,
+                    "ordinary/subdir/model",
+                    str(output),
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes `DonutDiffusionModelSave` failing on local setups where a model-output subfolder under ComfyUI `output/` is a symlink to another drive/SSD.

Example:

`ComfyUI/output/diffusion_models -> /fast-ssd/comfy-model-output`

Newer ComfyUI resolves symlinks during `get_save_image_path()` containment checks, so this intentional local redirection is reported as `Saving image outside the output folder is not allowed`.

### Behavior
- use ComfyUI's normal `get_save_image_path()` first
- only fall back when the requested prefix is lexically inside `output/`
- require an already-existing symlink component under `output/` to explain the realpath escape
- reject absolute paths, `..` traversal, NULs, and unsupported `%` filename-variable fallback cases
- preserve Donut's numbered `name_00001_.safetensors` behavior through the symlink
- do not modify ComfyUI's global path-security behavior

This is a follow-up to #38; `main` already contains the Krea2 Experimental-bypass merge serialization fix.

Focused tests cover normal ComfyUI behavior, external SSD symlinks, counter scanning through the symlink, absolute/parent-traversal rejection, and ensuring no fallback occurs without a symlink.