### PR TITLE
Fix Krea2 bypass save key namespace mismatch

### DIFF
--- a/donut_krea2_merge_serialization.py
+++ b/donut_krea2_merge_serialization.py
@@ -20,6 +20,7 @@ so tensors are materialized one at a time during saving.
 KREA2_MERGE_INJECTION_KEY = "donut_krea2_model_merge_bypass"
 KREA2_MERGE_SOURCE_KEY = "donut_krea2_model_merge_sources"
 KREA2_MERGE_PLAN_PREFIX = "donut_krea2_model_merge_identity:"
+_DIFFUSION_PREFIX = "diffusion_model."
 
 
 def _get_injections(model):
@@ -40,6 +41,23 @@ def _get_additional_models(model, key):
 def _get_attachments(model):
     attachments = getattr(model, "attachments", None)
     return attachments if isinstance(attachments, dict) else {}
+
+
+def _relative_unet_key(key):
+    """Translate a full ModelPatcher key to the UNet save-dict key namespace.
+
+    ComfyUI's ``model_state_dict_for_saving(model.diffusion_model,
+    prefix="diffusion_model.")`` uses the prefix only to resolve ModelPatcher
+    patches. The dictionary it returns keeps the diffusion-model-local state
+    keys (for example ``blocks.0.attn.wq.weight``), not the full
+    ``diffusion_model.blocks.0.attn.wq.weight`` key. Merge plans, on the other
+    hand, intentionally store the full ModelPatcher key. Keep that distinction
+    explicit here instead of depending on test doubles to happen to use the
+    same namespace.
+    """
+    if isinstance(key, str) and key.startswith(_DIFFUSION_PREFIX):
+        return key[len(_DIFFUSION_PREFIX):]
+    return key
 
 
 def get_krea2_merge_bypass_info(model):
@@ -179,26 +197,35 @@ def compose_krea2_merge_unet_state_dict(base_model, source_model, plans):
     ``base_model`` is the final model with runtime merge plumbing removed and all
     normal patches preserved. ``source_model`` is the retained model2 patcher,
     optionally with later bypass-LoRA adapters registered as ordinary patches.
+
+    The merge plans are stored in ModelPatcher's full ``diffusion_model.*`` key
+    namespace, while these two state dicts are local to ``model.diffusion_model``.
+    Convert the plan keys to that relative namespace before selecting state.
     """
     base_sd = base_model.model_state_dict_for_saving(
         base_model.model.diffusion_model,
-        "diffusion_model.",
+        _DIFFUSION_PREFIX,
     )
     source_sd = source_model.model_state_dict_for_saving(
         source_model.model.diffusion_model,
-        "diffusion_model.",
+        _DIFFUSION_PREFIX,
     )
 
     swapped_modules = 0
     swapped_keys = 0
     for module_path, weight_key, _ratio in plans:
-        base_keys = _direct_module_state_keys(base_sd, module_path)
-        source_keys = _direct_module_state_keys(source_sd, module_path)
+        state_module_path = _relative_unet_key(module_path)
+        state_weight_key = _relative_unet_key(weight_key)
 
-        if weight_key not in source_keys:
+        base_keys = _direct_module_state_keys(base_sd, state_module_path)
+        source_keys = _direct_module_state_keys(source_sd, state_module_path)
+
+        if state_weight_key not in source_keys:
+            available = ", ".join(sorted(source_keys)) if source_keys else "none"
             raise RuntimeError(
                 "Donut Krea2 save could not find the model2 source weight for "
-                f"bypassed module '{module_path}'."
+                f"bypassed module '{module_path}'. Expected UNet state key "
+                f"'{state_weight_key}'; direct source keys: {available}."
             )
         if not source_keys:
             raise RuntimeError(

--- a/test_krea2_merge_serialization.py
+++ b/test_krea2_merge_serialization.py
@@ -49,6 +49,8 @@ class FakePatcher:
         self.added.append((dict(patches), strength_patch, strength_model))
 
     def model_state_dict_for_saving(self, model, prefix):
+        # Match ComfyUI: prefix is used internally for patch lookup, but the
+        # returned dictionary remains relative to the supplied diffusion model.
         self.assert_prefix = prefix
         return dict(self.state_dict)
 
@@ -107,21 +109,30 @@ class Krea2MergeSerializationTests(unittest.TestCase):
         self.assertIn("other_source", converted.additional_models)
         self.assertEqual(converted.attachments["other_attachment"], 7)
 
-    def test_composition_replaces_complete_direct_module_state(self):
+    def test_full_patcher_key_is_translated_to_relative_unet_key(self):
+        self.assertEqual(
+            serialization._relative_unet_key("diffusion_model.txtfusion.layerwise_blocks.0.attn.wq.weight"),
+            "txtfusion.layerwise_blocks.0.attn.wq.weight",
+        )
+        self.assertEqual(serialization._relative_unet_key("first.weight"), "first.weight")
+
+    def test_composition_replaces_complete_direct_module_state_with_relative_keys(self):
+        # model_state_dict_for_saving(model.diffusion_model, "diffusion_model.")
+        # returns these relative keys in real ComfyUI.
         base_state = {
-            "diffusion_model.first.weight": "base-weight",
-            "diffusion_model.first.bias": "base-bias",
-            "diffusion_model.first.weight_scale": "base-scale",
-            "diffusion_model.first.child.weight": "base-child",
-            "diffusion_model.other.weight": "base-other",
+            "first.weight": "base-weight",
+            "first.bias": "base-bias",
+            "first.weight_scale": "base-scale",
+            "first.child.weight": "base-child",
+            "other.weight": "base-other",
         }
         source_state = {
-            "diffusion_model.first.weight": "source-weight",
-            "diffusion_model.first.bias": "source-bias",
-            "diffusion_model.first.weight_scale": "source-scale",
-            "diffusion_model.first.input_scale": "source-input-scale",
-            "diffusion_model.first.child.weight": "source-child",
-            "diffusion_model.other.weight": "source-other",
+            "first.weight": "source-weight",
+            "first.bias": "source-bias",
+            "first.weight_scale": "source-scale",
+            "first.input_scale": "source-input-scale",
+            "first.child.weight": "source-child",
+            "other.weight": "source-other",
         }
         base, source, plan, _identity = make_merge(base_state, source_state)
 
@@ -131,16 +142,46 @@ class Krea2MergeSerializationTests(unittest.TestCase):
             (plan,),
         )
 
-        self.assertEqual(composed["diffusion_model.first.weight"], "source-weight")
-        self.assertEqual(composed["diffusion_model.first.bias"], "source-bias")
-        self.assertEqual(composed["diffusion_model.first.weight_scale"], "source-scale")
-        self.assertEqual(composed["diffusion_model.first.input_scale"], "source-input-scale")
+        self.assertEqual(base.assert_prefix, "diffusion_model.")
+        self.assertEqual(source.assert_prefix, "diffusion_model.")
+        self.assertEqual(composed["first.weight"], "source-weight")
+        self.assertEqual(composed["first.bias"], "source-bias")
+        self.assertEqual(composed["first.weight_scale"], "source-scale")
+        self.assertEqual(composed["first.input_scale"], "source-input-scale")
         # Child modules are not direct state of the swapped Linear and therefore
         # remain on the normal model1/partial-patch path.
-        self.assertEqual(composed["diffusion_model.first.child.weight"], "base-child")
-        self.assertEqual(composed["diffusion_model.other.weight"], "base-other")
+        self.assertEqual(composed["first.child.weight"], "base-child")
+        self.assertEqual(composed["other.weight"], "base-other")
         self.assertEqual(module_count, 1)
         self.assertEqual(key_count, 4)
+
+    def test_realistic_txtfusion_relative_key_is_found(self):
+        module_path = "diffusion_model.txtfusion.layerwise_blocks.0.attn.wq"
+        weight_key = module_path + ".weight"
+        plan = (module_path, weight_key, 0.0)
+        base_state = {
+            "txtfusion.layerwise_blocks.0.attn.wq.weight": "base",
+            "txtfusion.layerwise_blocks.0.attn.wq.weight_scale": "base-scale",
+        }
+        source_state = {
+            "txtfusion.layerwise_blocks.0.attn.wq.weight": "source",
+            "txtfusion.layerwise_blocks.0.attn.wq.weight_scale": "source-scale",
+        }
+        base = FakePatcher(base_state)
+        source = FakePatcher(source_state)
+
+        composed, module_count, key_count = serialization.compose_krea2_merge_unet_state_dict(
+            base,
+            source,
+            (plan,),
+        )
+
+        self.assertEqual(composed["txtfusion.layerwise_blocks.0.attn.wq.weight"], "source")
+        self.assertEqual(
+            composed["txtfusion.layerwise_blocks.0.attn.wq.weight_scale"],
+            "source-scale",
+        )
+        self.assertEqual((module_count, key_count), (1, 2))
 
     def test_later_bypass_lora_components_can_be_applied_only_to_swapped_weights(self):
         source = FakePatcher()


### PR DESCRIPTION
Fixes `DonutDiffusionModelSave` failing with errors like:

`Donut Krea2 save could not find the model2 source weight for bypassed module 'diffusion_model.txtfusion.layerwise_blocks.0.attn.wq'.`

### Cause
Krea2 merge plans store full ModelPatcher keys such as:

`diffusion_model.txtfusion.layerwise_blocks.0.attn.wq.weight`

but ComfyUI's `model_state_dict_for_saving(model.diffusion_model, prefix="diffusion_model.")` returns a UNet-local dictionary keyed like:

`txtfusion.layerwise_blocks.0.attn.wq.weight`

The `diffusion_model.` prefix is used internally for patch lookup/materialization, not retained in the returned dictionary. The serializer compared the full merge-plan key against the relative save-dict keys and incorrectly concluded model2's source weight was missing.

### Fix
- explicitly translate merge-plan module/weight keys from full `diffusion_model.*` namespace to the relative UNet save-dict namespace before selecting model2 state
- keep ModelPatcher patch keys unchanged for LoRA/merge materialization
- improve the failure message to show the expected relative key and available direct source keys
- preserve complete direct state replacement including bias and quantization metadata

### Regression coverage
- updates the serializer test doubles to match real ComfyUI relative UNet save keys
- adds a regression using the exact reported `txtfusion.layerwise_blocks.0.attn.wq` path
- verifies `weight_scale` follows model2 alongside the swapped weight

This is a follow-up to #38 and #39.