### PR TITLE
Make DonutExtractLoRA include Krea2 bypass model merges

### DIFF
--- a/DonutExtractLoRA.py
+++ b/DonutExtractLoRA.py
@@ -1,19 +1,24 @@
 """Donut Extract LoRA - raw MODEL + patched MODEL -> low-rank LoRA safetensors.
 
-Unlike ComfyUI's ModelSubtract-based extractor, this node compares ModelPatcher
-weights in float32 directly and explicitly includes Donut Experimental-bypass
-LoRA adapters. Bypass adapters normally exist only as forward hooks, so ordinary
-state-dict subtraction cannot see them.
+Unlike ComfyUI's ModelSubtract-based extractor, this node compares effective
+ModelPatcher tensors in float32 and explicitly includes Donut runtime-only
+features. Donut Experimental-bypass LoRA adapters normally exist only as forward
+hooks, and Donut Model Merge Krea2 Experimental bypass keeps exact model2 swaps
+as source-model forwards rather than model1 weight patches. Ordinary state-dict
+subtraction cannot see either behavior.
 
-The extractor processes one model weight at a time on CPU. It does not need the
-full patched model or a dense full-model difference resident in VRAM, making it
-more practical on lower-VRAM GPUs. Large matrices use randomized low-rank SVD;
-small matrices use exact SVD.
+The extractor processes one model parameter at a time on CPU. It does not need
+the full patched model or a dense full-model difference resident in VRAM, making
+it more practical on lower-VRAM GPUs. Large matrices use randomized low-rank
+SVD; small matrices use exact SVD. Bias and one-dimensional weight differences
+are stored as Comfy-compatible direct-diff entries so model merges are not
+silently reduced to matrix-only changes.
 
 Quantized ComfyUI models may expose auxiliary state-dict entries such as
 ``weight_scale``/``input_scale`` that are not real module attributes. We never
 feed those entries through ModelPatcher.get_key_patches(); instead we enumerate
-only actual ``*.weight`` targets and reproduce get_key_patches for those keys.
+only actual ``*.weight``/``*.bias`` targets and reproduce get_key_patches for
+those keys.
 """
 
 import logging
@@ -31,10 +36,18 @@ try:
         BYPASS_INJECTION_KEY,
         get_bypass_components,
     )
+    from .donut_krea2_merge_serialization import (
+        KREA2_MERGE_INJECTION_KEY,
+        get_krea2_merge_bypass_info,
+    )
 except ImportError:
     from donut_bypass_materialization import (
         BYPASS_INJECTION_KEY,
         get_bypass_components,
+    )
+    from donut_krea2_merge_serialization import (
+        KREA2_MERGE_INJECTION_KEY,
+        get_krea2_merge_bypass_info,
     )
 
 
@@ -50,56 +63,59 @@ def _runtime_injection_keys(model):
     injections = getattr(model, "injections", None)
     if not isinstance(injections, dict):
         return set()
-    return {key for key, value in injections.items() if value}
+
+    # Krea2's composable injection list is intentionally falsey so the Donut
+    # bypass-LoRA compatibility guard can wrap it. Presence of the key still
+    # means runtime behavior exists and must not be ignored by extraction.
+    return {
+        key
+        for key, value in injections.items()
+        if value or key == KREA2_MERGE_INJECTION_KEY
+    }
 
 
 def _identity(value, **kwargs):
     return value
 
 
-def _weight_target_keys(model, bypass_components=None):
-    """Return real diffusion-model weight targets, excluding quant metadata.
+def _parameter_target_keys(model, bypass_components=None):
+    """Return real diffusion parameters a Comfy LoRA can target.
 
     Quantized state dicts can contain entries such as ``*.weight_scale`` and
-    ``*.input_scale``. Those are serialization metadata, not LoRA targets, and
-    calling ModelPatcher.get_key_patches() on the full state dict can try to
-    resolve them as normal module attributes. Restricting the scan to the
-    canonical ``*.weight`` keys avoids that failure and is also exactly what a
-    standard LoRA can represent.
+    ``*.input_scale``. Those are serialization metadata, not normal LoRA target
+    parameters, and asking ModelPatcher.get_key_patches() to resolve the entire
+    state dict can fail when they are not live module attributes. Restricting the
+    scan to canonical ``*.weight`` and ``*.bias`` keys avoids that failure.
     """
     keys = set()
 
+    def accepted(key):
+        return (
+            isinstance(key, str)
+            and key.startswith("diffusion_model.")
+            and (key.endswith(".weight") or key.endswith(".bias"))
+        )
+
     try:
         state_dict = model.model.state_dict()
-        keys.update(
-            key for key in state_dict.keys()
-            if key.startswith("diffusion_model.") and key.endswith(".weight")
-        )
+        keys.update(key for key in state_dict.keys() if accepted(key))
     except Exception:
         logging.exception("[DonutExtractLoRA] Could not enumerate model state dict")
 
     patches = getattr(model, "patches", {})
     if isinstance(patches, dict):
-        keys.update(
-            key for key in patches.keys()
-            if isinstance(key, str)
-            and key.startswith("diffusion_model.")
-            and key.endswith(".weight")
-        )
+        keys.update(key for key in patches.keys() if accepted(key))
 
     if isinstance(bypass_components, dict):
-        keys.update(
-            key for key in bypass_components.keys()
-            if isinstance(key, str)
-            and key.startswith("diffusion_model.")
-            and key.endswith(".weight")
-        )
+        # Donut bypass adapters are currently weight-only, but keep this generic
+        # in case Comfy gains additive bias adapters later.
+        keys.update(key for key in bypass_components.keys() if accepted(key))
 
     return keys
 
 
 def _single_key_patches(model, key):
-    """Reproduce ModelPatcher.get_key_patches() for one real weight key.
+    """Reproduce ModelPatcher.get_key_patches() for one real parameter key.
 
     Doing this one key at a time avoids ComfyUI's quantization bookkeeping keys
     while preserving physically patched backups, hook backups, conversion
@@ -110,7 +126,7 @@ def _single_key_patches(model, key):
             model.model, key
         )
     except (AttributeError, IndexError, KeyError, TypeError) as exc:
-        raise RuntimeError(f"Could not resolve model weight {key}: {exc}") from exc
+        raise RuntimeError(f"Could not resolve model parameter {key}: {exc}") from exc
 
     backup = getattr(model, "backup", {}).get(key)
     if backup is not None:
@@ -131,21 +147,25 @@ def _single_key_patches(model, key):
 
 
 def _get_extractable_key_patches(model, bypass_components=None):
-    """Return get_key_patches-style entries for only actual LoRA weight targets."""
+    """Return get_key_patches-style entries for actual LoRA target parameters."""
     output = {}
-    for key in sorted(_weight_target_keys(model, bypass_components)):
+    for key in sorted(_parameter_target_keys(model, bypass_components)):
         try:
             output[key] = _single_key_patches(model, key)
         except Exception as exc:
-            # A model may expose a serialization-only weight-like key without a
-            # resolvable live module. Do not let one exotic layer abort every
+            # A model may expose a serialization-only parameter-like key without
+            # a resolvable live module. Do not let one exotic layer abort every
             # otherwise extractable LoRA layer.
-            logging.warning("[DonutExtractLoRA] Skipping unresolved weight %s: %s", key, exc)
+            logging.warning(
+                "[DonutExtractLoRA] Skipping unresolved parameter %s: %s",
+                key,
+                exc,
+            )
     return output
 
 
 def _convert_base_weight(base_weight, convert_func):
-    """Convert a normal or quantized model weight to CPU float32."""
+    """Convert a normal or quantized model parameter to CPU float32."""
     value = base_weight
 
     # Comfy quantized modules commonly provide convert_weight(), which
@@ -165,13 +185,75 @@ def _convert_base_weight(base_weight, convert_func):
         value = dequantize()
 
     if not torch.is_tensor(value):
-        raise TypeError(f"Unsupported base weight type: {type(value).__name__}")
+        raise TypeError(f"Unsupported base parameter type: {type(value).__name__}")
 
     return value.detach().to(device="cpu", dtype=torch.float32).clone()
 
 
+def _zero_parameter_patches(key_patches):
+    """Build an effective zero parameter matching an existing parameter shape."""
+    if not key_patches:
+        return None
+    first = key_patches[0]
+    if not isinstance(first, (tuple, list)) or len(first) < 2:
+        return None
+    value = _convert_base_weight(first[0], first[1])
+    return [(torch.zeros_like(value), _identity)]
+
+
+def _get_effective_key_patches(model, bypass_components=None):
+    """Resolve the parameter sources that actually execute at inference time.
+
+    Normal and partial Krea2 merge components stay on ``model`` and therefore
+    use its ordinary patch stack. Exact ratio-0 Krea2 Experimental-bypass plans
+    execute the retained model2 source module instead. Replace those parameter
+    sources with model2 here before subtraction so extraction represents the
+    live merged model, not model1-with-LoRAs.
+
+    Returns ``(key_patches, swapped_keys, swap_count)``.
+    """
+    output = _get_extractable_key_patches(model, bypass_components)
+    merge_info = get_krea2_merge_bypass_info(model)
+    if merge_info is None:
+        return output, set(), 0
+
+    source_model, plans, _attachment_keys = merge_info
+    source_keys = _get_extractable_key_patches(source_model)
+    swapped_keys = set()
+
+    for module_path, weight_key, _ratio in plans:
+        source_weight = source_keys.get(weight_key)
+        if source_weight is None:
+            raise RuntimeError(
+                "Donut Extract LoRA could not resolve the model2 source weight "
+                f"for Krea2 bypassed module '{module_path}' ({weight_key})."
+            )
+
+        # The runtime hook calls model2's complete Linear module, so its weight
+        # and bias (if present) replace model1. Later Donut bypass LoRAs are not
+        # added here; _effective_weight applies the final model's bypass adapter
+        # on top of this model2 weight, matching inference order.
+        output[weight_key] = source_weight
+        swapped_keys.add(weight_key)
+
+        bias_key = f"{module_path}.bias"
+        if bias_key in source_keys:
+            output[bias_key] = source_keys[bias_key]
+            swapped_keys.add(bias_key)
+        elif bias_key in output:
+            # A source Linear with bias=None executes with zero bias. If model1
+            # has a bias, represent that effective zero so the emitted diff_b can
+            # cancel the raw bias instead of silently keeping it.
+            zero_patches = _zero_parameter_patches(output[bias_key])
+            if zero_patches is not None:
+                output[bias_key] = zero_patches
+                swapped_keys.add(bias_key)
+
+    return output, swapped_keys, len(plans)
+
+
 def _effective_weight(key, key_patches, bypass_components):
-    """Materialize one effective model weight in float32 without final fp8 rounding."""
+    """Materialize one effective parameter in float32 without final fp8 rounding."""
     if not key_patches:
         return None
 
@@ -186,8 +268,8 @@ def _effective_weight(key, key_patches, bypass_components):
     # Donut's experimental bypass is activation-side at inference time, but for
     # the bypass-compatible additive adapters Donut permits, its exact
     # serialization equivalent is an ordinary weight-adapter patch at the same
-    # strength. Append those adapters before computing the effective weight so
-    # extraction sees what inference actually used.
+    # strength. For Krea2 exact swaps, key_patches above already points at the
+    # model2 source weight, so this correctly produces model2 + later bypass LoRA.
     for adapter, strength in bypass_components or ():
         strength = float(strength)
         if strength != 0.0:
@@ -253,15 +335,19 @@ def _factorize_delta(delta, rank):
     return up.contiguous(), down.contiguous(), effective_rank
 
 
+def _is_zero_delta(delta):
+    return delta.numel() == 0 or float(delta.abs().max()) <= 1e-12
+
+
 class DonutExtractLoRA:
     """Extract a diffusion-model LoRA from RAW MODEL and PATCHED MODEL."""
 
     DESCRIPTION = (
-        "Extracts a standard low-rank LoRA representing PATCHED MODEL - RAW MODEL. "
-        "Understands Donut Experimental bypass, whose adapter effect is invisible "
-        "to ordinary ModelSubtract/state-dict LoRA extractors. Quantization metadata "
-        "is ignored safely, and large SVDs run in CPU memory so the full merged "
-        "model does not need to fit in VRAM."
+        "Extracts a LoRA representing PATCHED MODEL - RAW MODEL. Understands "
+        "Donut Experimental-bypass LoRAs and Donut Model Merge Krea2 Experimental "
+        "bypass, including model2 hard-swapped weights. Matrix differences are "
+        "rank-limited by SVD; bias/1D weight differences are stored as exact "
+        "Comfy-compatible direct diffs. Quantization metadata is ignored safely."
     )
 
     @classmethod
@@ -272,21 +358,21 @@ class DonutExtractLoRA:
                     "tooltip": "The unmodified/base diffusion model before LoRAs or merges are applied.",
                 }),
                 "patched_model": ("MODEL", {
-                    "tooltip": "The model after LoRAs/patches. Donut Experimental bypass adapters are included.",
+                    "tooltip": "The effective target model after LoRAs/patches/Krea2 merge bypasses.",
                 }),
                 "rank": ("INT", {
                     "default": 32,
                     "min": 1,
                     "max": 4096,
                     "step": 1,
-                    "tooltip": "Maximum SVD rank per weight. Higher ranks preserve more of the model difference and create larger LoRAs.",
+                    "tooltip": "Maximum SVD rank per matrix weight. Higher ranks preserve more model-merge detail and create larger LoRAs.",
                 }),
                 "filename_prefix": ("STRING", {
                     "default": "loras/Donut_extracted_lora",
                 }),
                 "dtype": (OUTPUT_DTYPES, {
                     "default": "fp16",
-                    "tooltip": "Storage dtype for the extracted LoRA factors. Computation is float32.",
+                    "tooltip": "Storage dtype for extracted factors/direct diffs. Computation is float32.",
                 }),
             }
         }
@@ -303,8 +389,14 @@ class DonutExtractLoRA:
 
         raw_bypass = get_bypass_components(raw_model)
         patched_bypass = get_bypass_components(patched_model)
-        raw_keys = _get_extractable_key_patches(raw_model, raw_bypass)
-        patched_keys = _get_extractable_key_patches(patched_model, patched_bypass)
+        raw_keys, raw_swapped_keys, raw_swap_count = _get_effective_key_patches(
+            raw_model,
+            raw_bypass,
+        )
+        patched_keys, patched_swapped_keys, patched_swap_count = _get_effective_key_patches(
+            patched_model,
+            patched_bypass,
+        )
 
         raw_injections = _runtime_injection_keys(raw_model)
         patched_injections = _runtime_injection_keys(patched_model)
@@ -319,11 +411,18 @@ class DonutExtractLoRA:
                 "could not be recovered. Restart ComfyUI with the updated DonutNodes and retry."
             )
 
-        unsupported_injections = (raw_injections | patched_injections) - {BYPASS_INJECTION_KEY}
+        supported_injections = {
+            BYPASS_INJECTION_KEY,
+            KREA2_MERGE_INJECTION_KEY,
+        }
+        unsupported_injections = (
+            raw_injections | patched_injections
+        ) - supported_injections
 
         common_keys = sorted(set(raw_keys).intersection(patched_keys))
         output_sd = {}
-        extracted_layers = 0
+        low_rank_layers = 0
+        direct_diff_layers = 0
         skipped_zero = 0
         failed_layers = []
 
@@ -333,34 +432,72 @@ class DonutExtractLoRA:
 
         for key in common_keys:
             try:
-                raw_weight = _effective_weight(key, raw_keys[key], raw_bypass.get(key))
-                patched_weight = _effective_weight(key, patched_keys[key], patched_bypass.get(key))
+                raw_weight = _effective_weight(
+                    key,
+                    raw_keys[key],
+                    raw_bypass.get(key),
+                )
+                patched_weight = _effective_weight(
+                    key,
+                    patched_keys[key],
+                    patched_bypass.get(key),
+                )
                 if raw_weight is None or patched_weight is None:
                     continue
                 if raw_weight.shape != patched_weight.shape:
-                    failed_layers.append(f"{key}: shape {tuple(raw_weight.shape)} != {tuple(patched_weight.shape)}")
+                    failed_layers.append(
+                        f"{key}: shape {tuple(raw_weight.shape)} != {tuple(patched_weight.shape)}"
+                    )
                     continue
 
                 delta = patched_weight - raw_weight
+                del raw_weight, patched_weight
+
+                if _is_zero_delta(delta):
+                    skipped_zero += 1
+                    del delta
+                    continue
+
+                if key.endswith(".bias"):
+                    base = key[:-len(".bias")]
+                    output_sd[f"{base}.diff_b"] = delta.to(output_dtype).contiguous().cpu()
+                    direct_diff_layers += 1
+                    del delta
+                    continue
+
+                if not key.endswith(".weight"):
+                    del delta
+                    continue
+
+                base = key[:-len(".weight")]
+                if delta.ndim < 2:
+                    output_sd[f"{base}.diff"] = delta.to(output_dtype).contiguous().cpu()
+                    direct_diff_layers += 1
+                    del delta
+                    continue
+
                 factors = _factorize_delta(delta, rank)
-                del raw_weight, patched_weight, delta
+                del delta
                 if factors is None:
                     skipped_zero += 1
                     continue
 
                 up, down, actual_rank = factors
-                base = key[:-len(".weight")]
                 output_sd[f"{base}.lora_up.weight"] = up.to(output_dtype).cpu()
                 output_sd[f"{base}.lora_down.weight"] = down.to(output_dtype).cpu()
                 # alpha/rank = 1, so applying the extracted LoRA at strength 1
                 # reconstructs the truncated SVD delta directly.
-                output_sd[f"{base}.alpha"] = torch.tensor(float(actual_rank), dtype=torch.float32)
-                extracted_layers += 1
+                output_sd[f"{base}.alpha"] = torch.tensor(
+                    float(actual_rank),
+                    dtype=torch.float32,
+                )
+                low_rank_layers += 1
                 del up, down
             except Exception as exc:
                 logging.exception("[DonutExtractLoRA] Failed extracting %s", key)
                 failed_layers.append(f"{key}: {exc}")
 
+        extracted_layers = low_rank_layers + direct_diff_layers
         if extracted_layers == 0:
             detail = ""
             if failed_layers:
@@ -371,10 +508,12 @@ class DonutExtractLoRA:
 
         full_output_folder, filename, counter, subfolder, filename_prefix = \
             folder_paths.get_save_image_path(
-                filename_prefix, folder_paths.get_output_directory()
+                filename_prefix,
+                folder_paths.get_output_directory(),
             )
         output_path = os.path.join(
-            full_output_folder, f"{filename}_{counter:05}_.safetensors"
+            full_output_folder,
+            f"{filename}_{counter:05}_.safetensors",
         )
 
         metadata = {
@@ -382,14 +521,27 @@ class DonutExtractLoRA:
             "donut.rank": str(rank),
             "donut.dtype": dtype,
             "donut.bypass_aware": "true",
+            "donut.krea2_merge_aware": "true",
             "donut.quant_metadata_safe": "true",
+            "donut.low_rank_layers": str(low_rank_layers),
+            "donut.direct_diff_layers": str(direct_diff_layers),
         }
         comfy.utils.save_torch_file(output_sd, output_path, metadata=metadata)
 
         report_parts = [
-            f"Extracted {extracted_layers} layer(s) at rank <= {rank}",
-            f"skipped {skipped_zero} zero/non-matrix layer(s)",
+            f"Extracted {low_rank_layers} low-rank matrix layer(s) at rank <= {rank}",
+            f"{direct_diff_layers} exact bias/1D diff layer(s)",
+            f"skipped {skipped_zero} zero layer(s)",
         ]
+        if patched_swap_count:
+            report_parts.append(
+                f"included {patched_swap_count} Krea2 model2 hard swap(s) "
+                f"covering {len(patched_swapped_keys)} extractable parameter(s)"
+            )
+        if raw_swap_count:
+            report_parts.append(
+                f"RAW MODEL also contains {raw_swap_count} Krea2 hard swap(s)"
+            )
         if patched_bypass:
             report_parts.append(
                 f"included Donut Experimental bypass on {len(patched_bypass)} weight(s)"
@@ -408,6 +560,11 @@ class DonutExtractLoRA:
 
         report = "; ".join(report_parts)
         print(f"[DonutExtractLoRA] {report}")
+        if patched_swap_count:
+            print(
+                "[DonutExtractLoRA] Krea2 Experimental-bypass source weights "
+                "were included before SVD."
+            )
         print(f"[DonutExtractLoRA] Saved to {output_path}")
         return output_path, report
 

--- a/test_donut_extract_lora.py
+++ b/test_donut_extract_lora.py
@@ -19,6 +19,9 @@ fake_comfy.utils = fake_utils
 fake_comfy.model_patcher = fake_model_patcher
 
 
+SAVED_FILES = []
+
+
 def fake_calculate_weight(patches, weight, key, **kwargs):
     out = weight.clone()
     for patch in patches:
@@ -38,9 +41,13 @@ def fake_get_key_weight(model, key):
     return getattr(obj, parts[-1]), None, None
 
 
+def fake_save_torch_file(sd, path, metadata=None):
+    SAVED_FILES.append((dict(sd), path, dict(metadata or {})))
+
+
 fake_lora.calculate_weight = fake_calculate_weight
 fake_model_patcher.get_key_weight = fake_get_key_weight
-fake_utils.save_torch_file = lambda *args, **kwargs: None
+fake_utils.save_torch_file = fake_save_torch_file
 
 fake_folder_paths = types.ModuleType("folder_paths")
 fake_folder_paths.get_output_directory = lambda: "/tmp"
@@ -56,6 +63,8 @@ _previous = {
         "comfy.model_patcher",
         "comfy.utils",
         "folder_paths",
+        "donut_bypass_materialization",
+        "donut_krea2_merge_serialization",
     )
 }
 sys.modules["comfy"] = fake_comfy
@@ -72,6 +81,14 @@ try:
     helper = importlib.util.module_from_spec(helper_spec)
     helper_spec.loader.exec_module(helper)
     sys.modules["donut_bypass_materialization"] = helper
+
+    krea_spec = importlib.util.spec_from_file_location(
+        "donut_krea2_merge_serialization",
+        Path(__file__).with_name("donut_krea2_merge_serialization.py"),
+    )
+    krea = importlib.util.module_from_spec(krea_spec)
+    krea_spec.loader.exec_module(krea)
+    sys.modules["donut_krea2_merge_serialization"] = krea
 
     extract_spec = importlib.util.spec_from_file_location(
         "donut_extract_lora_tested",
@@ -95,6 +112,11 @@ class Adapter:
 class CompositeAdapter:
     def __init__(self, components):
         self.components = components
+
+
+class FalseyInjectionList(list):
+    def __bool__(self):
+        return False
 
 
 class FakeInjectionModel:
@@ -162,7 +184,69 @@ class FakeQuantizedValue:
         return self.tensor
 
 
+class FakeModelTree:
+    def __init__(self, layer_weight, layer_bias, other_weight=None):
+        self.diffusion_model = types.SimpleNamespace(
+            layer=types.SimpleNamespace(
+                weight=layer_weight.clone(),
+                bias=None if layer_bias is None else layer_bias.clone(),
+            ),
+            other=types.SimpleNamespace(
+                weight=(
+                    torch.eye(layer_weight.shape[0])
+                    if other_weight is None
+                    else other_weight.clone()
+                ),
+            ),
+        )
+
+    def state_dict(self):
+        state = {
+            "diffusion_model.layer.weight": self.diffusion_model.layer.weight,
+            "diffusion_model.other.weight": self.diffusion_model.other.weight,
+        }
+        if self.diffusion_model.layer.bias is not None:
+            state["diffusion_model.layer.bias"] = self.diffusion_model.layer.bias
+        return state
+
+
+class FakeMergePatcher:
+    def __init__(self, layer_weight, layer_bias, other_weight=None, clone_id="base"):
+        self.model = FakeModelTree(layer_weight, layer_bias, other_weight)
+        self.patches = {}
+        self.backup = {}
+        self.hook_backup = {}
+        self.injections = {}
+        self.attachments = {}
+        self.additional_models = {}
+        self.clone_base_uuid = clone_id
+
+    def get_attachment(self, key):
+        return self.attachments.get(key)
+
+    def get_injections(self, key):
+        return self.injections.get(key, [])
+
+    def get_additional_models_with_key(self, key):
+        return self.additional_models.get(key, [])
+
+
+def attach_krea2_swap(patched, source):
+    plan = (
+        "diffusion_model.layer",
+        "diffusion_model.layer.weight",
+        0.0,
+    )
+    patched.injections[krea.KREA2_MERGE_INJECTION_KEY] = FalseyInjectionList([object()])
+    patched.additional_models[krea.KREA2_MERGE_SOURCE_KEY] = [source]
+    patched.attachments[krea.KREA2_MERGE_PLAN_PREFIX + "test"] = (plan,)
+    return plan
+
+
 class DonutExtractLoRATests(unittest.TestCase):
+    def setUp(self):
+        SAVED_FILES.clear()
+
     def test_rank_factorization_reconstructs_low_rank_matrix(self):
         left = torch.tensor([[1.0, 2.0], [3.0, -1.0], [0.5, 4.0]])
         right = torch.tensor([[2.0, 0.0, 1.0, -1.0], [1.0, 3.0, -2.0, 0.5]])
@@ -211,7 +295,10 @@ class DonutExtractLoRATests(unittest.TestCase):
         patches = extract._get_extractable_key_patches(model)
 
         self.assertEqual(list(patches), ["diffusion_model.layer.weight"])
-        self.assertTrue(torch.equal(patches["diffusion_model.layer.weight"][0][0], model.model.diffusion_model.layer.weight))
+        self.assertTrue(torch.equal(
+            patches["diffusion_model.layer.weight"][0][0],
+            model.model.diffusion_model.layer.weight,
+        ))
 
     def test_quantized_value_is_dequantized_before_float32_extraction(self):
         expected = torch.tensor([[1.25, -2.5], [3.75, 4.0]], dtype=torch.float16)
@@ -249,6 +336,127 @@ class DonutExtractLoRATests(unittest.TestCase):
         patches, strength = converted.added[0]
         self.assertIs(patches["diffusion_model.layer.weight"], adapter)
         self.assertEqual(strength, 0.75)
+
+    def test_falsey_krea2_runtime_is_not_treated_as_invisible(self):
+        model = FakeMergePatcher(torch.eye(2), torch.zeros(2))
+        model.injections[krea.KREA2_MERGE_INJECTION_KEY] = FalseyInjectionList([object()])
+
+        self.assertIn(
+            krea.KREA2_MERGE_INJECTION_KEY,
+            extract._runtime_injection_keys(model),
+        )
+
+    def test_effective_sources_use_model2_for_hard_swap_and_model1_elsewhere(self):
+        raw = FakeMergePatcher(
+            torch.eye(2),
+            torch.zeros(2),
+            other_weight=torch.eye(2),
+        )
+        source = FakeMergePatcher(
+            4.0 * torch.eye(2),
+            torch.tensor([2.0, -1.0]),
+            other_weight=99.0 * torch.eye(2),
+        )
+        patched = FakeMergePatcher(
+            torch.eye(2),
+            torch.zeros(2),
+            other_weight=torch.eye(2),
+        )
+        attach_krea2_swap(patched, source)
+        patched.patches["diffusion_model.other.weight"] = [
+            (1.0, Adapter(3.0 * torch.eye(2)), 1.0, None, None),
+        ]
+        bypass = {
+            "diffusion_model.layer.weight": [
+                (Adapter(torch.ones(2, 2)), 0.5),
+            ],
+        }
+
+        effective, swapped, swap_count = extract._get_effective_key_patches(
+            patched,
+            bypass,
+        )
+
+        swapped_weight = extract._effective_weight(
+            "diffusion_model.layer.weight",
+            effective["diffusion_model.layer.weight"],
+            bypass["diffusion_model.layer.weight"],
+        )
+        swapped_bias = extract._effective_weight(
+            "diffusion_model.layer.bias",
+            effective["diffusion_model.layer.bias"],
+            None,
+        )
+        other_weight = extract._effective_weight(
+            "diffusion_model.other.weight",
+            effective["diffusion_model.other.weight"],
+            None,
+        )
+
+        self.assertEqual(swap_count, 1)
+        self.assertIn("diffusion_model.layer.weight", swapped)
+        self.assertIn("diffusion_model.layer.bias", swapped)
+        self.assertTrue(torch.allclose(
+            swapped_weight,
+            4.0 * torch.eye(2) + 0.5 * torch.ones(2, 2),
+        ))
+        self.assertTrue(torch.equal(swapped_bias, torch.tensor([2.0, -1.0])))
+        self.assertTrue(torch.equal(other_weight, 4.0 * torch.eye(2)))
+        self.assertNotEqual(id(raw), id(patched))
+
+    def test_full_extraction_includes_krea2_swap_lora_and_bias_diff(self):
+        raw = FakeMergePatcher(
+            torch.eye(2),
+            torch.zeros(2),
+            clone_id="same-base",
+        )
+        source = FakeMergePatcher(
+            4.0 * torch.eye(2),
+            torch.tensor([2.0, -1.0]),
+            clone_id="model2",
+        )
+        patched = FakeMergePatcher(
+            torch.eye(2),
+            torch.zeros(2),
+            clone_id="same-base",
+        )
+        attach_krea2_swap(patched, source)
+        bypass_delta = torch.tensor([[1.0, -1.0], [0.5, 0.25]])
+        patched.attachments[helper.BYPASS_ATTACHMENT_KEY] = {
+            "diffusion_model.layer.weight": [
+                (Adapter(bypass_delta), 0.5),
+            ],
+        }
+
+        _path, report = extract.DonutExtractLoRA().extract(
+            raw,
+            patched,
+            rank=2,
+            filename_prefix="loras/test",
+            dtype="fp32",
+        )
+
+        self.assertEqual(len(SAVED_FILES), 1)
+        sd, _saved_path, metadata = SAVED_FILES[0]
+        up = sd["diffusion_model.layer.lora_up.weight"]
+        down = sd["diffusion_model.layer.lora_down.weight"]
+        reconstructed_delta = up @ down
+        expected_target = 4.0 * torch.eye(2) + 0.5 * bypass_delta
+        expected_delta = expected_target - torch.eye(2)
+
+        self.assertTrue(torch.allclose(
+            reconstructed_delta,
+            expected_delta,
+            atol=1e-4,
+            rtol=1e-4,
+        ))
+        self.assertTrue(torch.equal(
+            sd["diffusion_model.layer.diff_b"],
+            torch.tensor([2.0, -1.0]),
+        ))
+        self.assertEqual(metadata["donut.krea2_merge_aware"], "true")
+        self.assertIn("included 1 Krea2 model2 hard swap", report)
+        self.assertNotIn("unsupported runtime injections", report)
 
     def test_node_schema_has_raw_patched_and_rank(self):
         required = extract.DonutExtractLoRA.INPUT_TYPES()["required"]


### PR DESCRIPTION
Fixes `Donut Extract LoRA (Raw → Patched)` ignoring `Donut Model Merge Krea2` when `execution_mode = Experimental bypass`.

### Cause
The extractor only materialized ordinary ModelPatcher patches plus Donut bypass-LoRA adapters. Exact ratio-0 Krea2 model2 swaps are runtime forward hooks backed by a retained model2 patcher, so those blocks never appeared in the patched model1 weight stack. The extractor therefore effectively compared `raw model1` against `model1 + LoRAs` and omitted the model2 hard swaps.

Krea2's composable runtime injection list is intentionally falsey, so the old runtime-injection check could even fail to report it as unsupported.

### Fix
- detect Donut Krea2 merge-bypass metadata/source plans during extraction
- for each exact hard-swapped module, use the retained model2 weight as PATCHED MODEL's effective parameter source
- apply later Donut Experimental-bypass LoRA adapters on top of that model2 weight before SVD, matching live inference order
- keep non-swapped and partial-blend components on the normal model1/Comfy patch path
- support the same logic if RAW MODEL itself contains a Krea2 bypass merge
- treat Krea2's intentionally falsey injection as real runtime behavior rather than silently ignoring it
- include changed biases as Comfy-compatible `.diff_b` entries
- include one-dimensional weight changes as `.diff` entries instead of dropping them
- retain the quantized-weight-safe per-parameter materialization path
- add metadata/reporting that states how many Krea2 hard swaps were included

### Regression coverage
Adds tests that:
- verify a falsey Krea2 runtime injection is visible to extraction
- verify hard-swapped weights and biases come from model2 while unrelated layers stay on model1's regular patch path
- verify a later bypass LoRA is applied on top of the model2 hard-swap weight
- run the full extraction path and reconstruct the expected `model2 + bypass LoRA - raw model1` matrix delta
- verify the model2 bias difference is emitted as `.diff_b`

### Note on rank
A hard model1→model2 block swap can be a much larger/full-rank change than a normal LoRA. The merge is now included, but the matrix part is still compressed to the requested rank, so higher ranks preserve more of the merged model difference.