### PR TITLE
Add Krea2 TeacherFix preset and Simple/Advanced fusion UI

### DIFF
--- a/DonutKrea2FusionPreset.py
+++ b/DonutKrea2FusionPreset.py
@@ -29,6 +29,7 @@ PRESET_REBALANCE_BYPASS_3 = "Rebalance + Bypass 3"
 PRESET_BALANCED = "Balanced"
 PRESET_BALANCED_ENHANCER = "Balanced + Enhancer"
 PRESET_TEACHERFIX = "TeacherFix"
+LEGACY_TEACHERFIX = "DONUT settings: Krea2 C33 TeacherFix EMA5000"
 
 SIMPLE_PRESET_TO_LEGACY = {
     PRESET_CUSTOM: base.PRESET_MANUAL,
@@ -44,6 +45,7 @@ SIMPLE_PRESET_TO_LEGACY = {
 }
 SIMPLE_PRESETS = tuple(SIMPLE_PRESET_TO_LEGACY) + (PRESET_TEACHERFIX,)
 LEGACY_PRESET_TO_SIMPLE = {legacy: simple for simple, legacy in SIMPLE_PRESET_TO_LEGACY.items()}
+LEGACY_PRESET_TO_SIMPLE[LEGACY_TEACHERFIX] = PRESET_TEACHERFIX
 
 TEACHERFIX_FILENAME = "krea2_c33_teacherfix_ema5000.safetensors"
 TEACHERFIX_ALIASES = (
@@ -247,7 +249,7 @@ class DonutKrea2FusionControl(base.DonutKrea2FusionControl):
             raise ValueError(f"Unknown Krea2 Fusion UI mode: {ui_mode}")
 
         preset = kwargs.get("compatibility_preset", PRESET_CUSTOM)
-        if preset == PRESET_TEACHERFIX:
+        if preset in (PRESET_TEACHERFIX, LEGACY_TEACHERFIX):
             strength = float(kwargs.get("tap_strength", 1.0))
             delegated = dict(kwargs)
             # The base node validates its own legacy preset labels. Keep all

--- a/DonutKrea2FusionPreset.py
+++ b/DonutKrea2FusionPreset.py
@@ -18,7 +18,33 @@ UI_MODE_SIMPLE = "Simple"
 UI_MODE_ADVANCED = "Advanced"
 UI_MODES = (UI_MODE_SIMPLE, UI_MODE_ADVANCED)
 
-PRESET_TEACHERFIX = "DONUT settings: Krea2 C33 TeacherFix EMA5000"
+PRESET_CUSTOM = "Custom"
+PRESET_BYPASS_2 = "Bypass 2"
+PRESET_BYPASS_3 = "Bypass 3"
+PRESET_REBALANCE = "Rebalance"
+PRESET_ENHANCER = "Enhancer"
+PRESET_REBALANCE_ENHANCER = "Rebalance + Enhancer"
+PRESET_REBALANCE_BYPASS_2 = "Rebalance + Bypass 2"
+PRESET_REBALANCE_BYPASS_3 = "Rebalance + Bypass 3"
+PRESET_BALANCED = "Balanced"
+PRESET_BALANCED_ENHANCER = "Balanced + Enhancer"
+PRESET_TEACHERFIX = "TeacherFix"
+
+SIMPLE_PRESET_TO_LEGACY = {
+    PRESET_CUSTOM: base.PRESET_MANUAL,
+    PRESET_BYPASS_2: base.PRESET_BYPASS_2,
+    PRESET_BYPASS_3: base.PRESET_BYPASS_3,
+    PRESET_REBALANCE: base.PRESET_REBALANCE,
+    PRESET_ENHANCER: base.PRESET_ENHANCER,
+    PRESET_REBALANCE_ENHANCER: base.PRESET_REBALANCE_ENHANCER,
+    PRESET_REBALANCE_BYPASS_2: base.PRESET_REBALANCE_BYPASS_2,
+    PRESET_REBALANCE_BYPASS_3: base.PRESET_REBALANCE_BYPASS_3,
+    PRESET_BALANCED: base.PRESET_DONUT_BALANCED,
+    PRESET_BALANCED_ENHANCER: base.PRESET_DONUT_BALANCED_ENHANCER,
+}
+SIMPLE_PRESETS = tuple(SIMPLE_PRESET_TO_LEGACY) + (PRESET_TEACHERFIX,)
+LEGACY_PRESET_TO_SIMPLE = {legacy: simple for simple, legacy in SIMPLE_PRESET_TO_LEGACY.items()}
+
 TEACHERFIX_FILENAME = "krea2_c33_teacherfix_ema5000.safetensors"
 TEACHERFIX_ALIASES = (
     TEACHERFIX_FILENAME,
@@ -31,14 +57,12 @@ TEACHERFIX_SHA256 = "db3c2b7612828120e7ef9cc8fe77124c6fd8de2e38f150599e62abd9695
 _TEACHERFIX_CACHE = None
 
 
-def _copy_combo_spec(spec, extra_option=None, tooltip=None):
-    options = list(spec[0])
-    if extra_option is not None and extra_option not in options:
-        options.append(extra_option)
+def _preset_combo_spec(spec, tooltip=None):
     settings = dict(spec[1]) if len(spec) > 1 and isinstance(spec[1], dict) else {}
+    settings["default"] = PRESET_CUSTOM
     if tooltip is not None:
         settings["tooltip"] = tooltip
-    return (options, settings)
+    return (list(SIMPLE_PRESETS), settings)
 
 
 def _sha256_file(path):
@@ -147,6 +171,14 @@ def _apply_teacherfix(model, strength):
     return patched, loaded_count, relative_name
 
 
+def _rewrite_preset_diagnostics(diagnostics, legacy_name, simple_name):
+    return str(diagnostics).replace(
+        f"preset_label={legacy_name}",
+        f"preset_label={simple_name}",
+        1,
+    )
+
+
 def _rewrite_teacherfix_diagnostics(diagnostics, strength, loaded_count, relative_name):
     diagnostics = str(diagnostics)
     diagnostics = diagnostics.replace(
@@ -169,9 +201,9 @@ class DonutKrea2FusionControl(base.DonutKrea2FusionControl):
     """Existing Krea2 Fusion Control plus TeacherFix and compact UI mode."""
 
     DESCRIPTION = (
-        "Krea 2 text-fusion controls with Simple/Advanced UI modes, the existing "
-        "community compatibility presets, and a hash-verified C33 TeacherFix "
-        "EMA5000 preset discovered automatically from ComfyUI/models/loras."
+        "Krea 2 text-fusion controls with Simple/Advanced UI modes, simplified "
+        "preset names, and a hash-verified TeacherFix preset discovered "
+        "automatically from ComfyUI/models/loras."
     )
 
     @classmethod
@@ -181,12 +213,10 @@ class DonutKrea2FusionControl(base.DonutKrea2FusionControl):
         required = {}
         for name, spec in original_required.items():
             if name == "compatibility_preset":
-                required[name] = _copy_combo_spec(
+                required[name] = _preset_combo_spec(
                     spec,
-                    PRESET_TEACHERFIX,
                     (
-                        "Select a preset. Existing compatibility presets copy settings "
-                        "into the controls; TeacherFix automatically finds and applies "
+                        "Select a preset. TeacherFix automatically finds and applies "
                         "the exact hash-verified LoRA from ComfyUI/models/loras."
                     ),
                 )
@@ -216,22 +246,28 @@ class DonutKrea2FusionControl(base.DonutKrea2FusionControl):
         if ui_mode not in UI_MODES:
             raise ValueError(f"Unknown Krea2 Fusion UI mode: {ui_mode}")
 
-        preset = kwargs.get("compatibility_preset", base.PRESET_MANUAL)
-        if preset != PRESET_TEACHERFIX:
-            return super().apply(*args, **kwargs)
+        preset = kwargs.get("compatibility_preset", PRESET_CUSTOM)
+        if preset == PRESET_TEACHERFIX:
+            strength = float(kwargs.get("tap_strength", 1.0))
+            delegated = dict(kwargs)
+            # The base node validates its own legacy preset labels. Keep all
+            # submitted controls and substitute only the label for that call.
+            delegated["compatibility_preset"] = base.PRESET_MANUAL
+            result = list(super().apply(*args, **delegated))
 
-        strength = float(kwargs.get("tap_strength", 1.0))
+            patched_model, loaded_count, relative_name = _apply_teacherfix(result[0], strength)
+            result[0] = patched_model
+            result[-1] = _rewrite_teacherfix_diagnostics(
+                result[-1], strength, loaded_count, relative_name
+            )
+            return tuple(result)
+
+        legacy_preset = SIMPLE_PRESET_TO_LEGACY.get(preset, preset)
         delegated = dict(kwargs)
-        # The base node validates its own preset labels. Keep all submitted
-        # controls and substitute only the label for that validation call.
-        delegated["compatibility_preset"] = base.PRESET_MANUAL
+        delegated["compatibility_preset"] = legacy_preset
         result = list(super().apply(*args, **delegated))
-
-        patched_model, loaded_count, relative_name = _apply_teacherfix(result[0], strength)
-        result[0] = patched_model
-        result[-1] = _rewrite_teacherfix_diagnostics(
-            result[-1], strength, loaded_count, relative_name
-        )
+        if preset in SIMPLE_PRESET_TO_LEGACY:
+            result[-1] = _rewrite_preset_diagnostics(result[-1], legacy_preset, preset)
         return tuple(result)
 
 

--- a/DonutKrea2FusionPreset.py
+++ b/DonutKrea2FusionPreset.py
@@ -1,14 +1,16 @@
-"""Bundled Krea 2 TeacherFix preset and Simple/Advanced UI mode.
+"""Krea 2 TeacherFix preset and Simple/Advanced UI mode.
 
 This module intentionally overrides the existing ``DonutKrea2FusionControl``
-node id instead of registering a second node.  The base implementation remains
+node id instead of registering a second node. The base implementation remains
 the source of truth for all existing tap/projector/fusion controls; this layer
-adds one bundled text-fusion LoRA preset plus a UI-mode selector.
+adds one exact-file TeacherFix preset plus a UI-mode selector.
 """
 
 from pathlib import Path
+import hashlib
 import importlib
 import math
+import os
 
 from . import DonutKrea2FusionControl as base
 
@@ -19,11 +21,15 @@ UI_MODES = (UI_MODE_SIMPLE, UI_MODE_ADVANCED)
 
 PRESET_TEACHERFIX = "DONUT settings: Krea2 C33 TeacherFix EMA5000"
 TEACHERFIX_FILENAME = "krea2_c33_teacherfix_ema5000.safetensors"
+TEACHERFIX_ALIASES = (
+    TEACHERFIX_FILENAME,
+    "krea2_c33_teacherfix_ema5000(1).safetensors",
+)
 TEACHERFIX_TARGET_COUNT = 33
+TEACHERFIX_SIZE_BYTES = 3_470_548
 TEACHERFIX_SHA256 = "db3c2b7612828120e7ef9cc8fe77124c6fd8de2e38f150599e62abd9695f6beb"
-TEACHERFIX_PATH = Path(__file__).resolve().parent / "assets" / TEACHERFIX_FILENAME
 
-_BUNDLED_LORA_CACHE = None
+_TEACHERFIX_CACHE = None
 
 
 def _copy_combo_spec(spec, extra_option=None, tooltip=None):
@@ -36,23 +42,64 @@ def _copy_combo_spec(spec, extra_option=None, tooltip=None):
     return (options, settings)
 
 
-def _load_bundled_lora():
-    global _BUNDLED_LORA_CACHE
-    if _BUNDLED_LORA_CACHE is not None:
-        return _BUNDLED_LORA_CACHE
+def _sha256_file(path):
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        for chunk in iter(lambda: handle.read(1024 * 1024), b""):
+            digest.update(chunk)
+    return digest.hexdigest()
 
-    if not TEACHERFIX_PATH.is_file():
-        raise RuntimeError(
-            f"Bundled Krea2 TeacherFix preset is missing: {TEACHERFIX_PATH}"
-        )
 
+def _find_teacherfix_file():
+    """Find the exact uploaded TeacherFix LoRA in ComfyUI's normal LoRA folder.
+
+    The file may be renamed or live in a subfolder. We first use cheap file-size
+    filtering, then verify SHA256, so a large LoRA library is not fully hashed.
+    """
+    folder_paths = importlib.import_module("folder_paths")
+    names = list(folder_paths.get_filename_list("loras"))
+    alias_basenames = {value.lower() for value in TEACHERFIX_ALIASES}
+
+    def priority(name):
+        basename = os.path.basename(str(name)).lower()
+        if basename in alias_basenames:
+            return (0, basename)
+        if "krea2" in basename and "teacherfix" in basename and "ema5000" in basename:
+            return (1, basename)
+        return (2, basename)
+
+    for name in sorted(names, key=priority):
+        path = folder_paths.get_full_path("loras", name)
+        if not path or not os.path.isfile(path):
+            continue
+        try:
+            if os.path.getsize(path) != TEACHERFIX_SIZE_BYTES:
+                continue
+        except OSError:
+            continue
+        if _sha256_file(path) == TEACHERFIX_SHA256:
+            return str(name), str(path)
+
+    aliases = " or ".join(TEACHERFIX_ALIASES)
+    raise RuntimeError(
+        "Krea2 C33 TeacherFix EMA5000 preset needs the exact TeacherFix LoRA in "
+        "ComfyUI/models/loras. Install it there (for example as "
+        f"{aliases}). Expected SHA256: {TEACHERFIX_SHA256}"
+    )
+
+
+def _load_teacherfix_lora():
+    global _TEACHERFIX_CACHE
+    if _TEACHERFIX_CACHE is not None:
+        return _TEACHERFIX_CACHE
+
+    relative_name, path = _find_teacherfix_file()
     comfy_utils = getattr(base.comfy, "utils", None)
     if comfy_utils is None:
         comfy_utils = importlib.import_module("comfy.utils")
-
-    state = comfy_utils.load_torch_file(str(TEACHERFIX_PATH), safe_load=True)
+    state = comfy_utils.load_torch_file(path, safe_load=True)
     if not isinstance(state, dict):
-        raise RuntimeError("Bundled Krea2 TeacherFix preset did not load as a state dict")
+        raise RuntimeError("Krea2 TeacherFix preset did not load as a state dict")
 
     target_bases = {
         key[: -len(".lora_down.weight")]
@@ -61,31 +108,31 @@ def _load_bundled_lora():
     }
     if len(target_bases) != TEACHERFIX_TARGET_COUNT:
         raise RuntimeError(
-            "Bundled Krea2 TeacherFix preset has an unexpected target count: "
+            "Krea2 TeacherFix preset has an unexpected target count: "
             f"{len(target_bases)} != {TEACHERFIX_TARGET_COUNT}"
         )
 
-    _BUNDLED_LORA_CACHE = state
-    return state
+    _TEACHERFIX_CACHE = (state, relative_name)
+    return _TEACHERFIX_CACHE
 
 
-def _apply_bundled_teacherfix(model, strength):
+def _apply_teacherfix(model, strength):
     strength = float(strength)
     if not math.isfinite(strength):
         raise ValueError("TeacherFix strength must be finite")
     if strength == 0.0:
-        return model, 0
+        return model, 0, "not loaded (strength 0)"
 
     comfy_lora = getattr(base.comfy, "lora", None)
     if comfy_lora is None:
         comfy_lora = importlib.import_module("comfy.lora")
 
-    state = _load_bundled_lora()
+    state, relative_name = _load_teacherfix_lora()
     key_map = comfy_lora.model_lora_keys_unet(model.model)
     patches = comfy_lora.load_lora(state, key_map, log_missing=False)
     if len(patches) != TEACHERFIX_TARGET_COUNT:
         raise RuntimeError(
-            "Bundled Krea2 TeacherFix preset mapped an unexpected number of targets: "
+            "Krea2 TeacherFix preset mapped an unexpected number of targets: "
             f"{len(patches)} != {TEACHERFIX_TARGET_COUNT}. "
             "Make sure the input MODEL is Krea 2."
         )
@@ -95,49 +142,24 @@ def _apply_bundled_teacherfix(model, strength):
     loaded_count = len(loaded)
     if loaded_count != TEACHERFIX_TARGET_COUNT:
         raise RuntimeError(
-            "Bundled Krea2 TeacherFix preset could not patch every target: "
+            "Krea2 TeacherFix preset could not patch every target: "
             f"{loaded_count}/{TEACHERFIX_TARGET_COUNT} loaded"
         )
-    return patched, loaded_count
+    return patched, loaded_count, relative_name
 
 
-def _publish_teacherfix_budget(model, strength):
-    transformer_options = model.model_options.setdefault("transformer_options", {})
-    existing = transformer_options.get(base.FUSION_BUDGET_KEY)
-    if isinstance(existing, dict) and int(existing.get("version", 0)) == 1:
-        metadata = dict(existing)
-    else:
-        metadata = {
-            "version": 1,
-            "tap_method": base.TAP_METHOD_DONUT,
-            "tap_gains": tuple(float(value) for value in base._PROFILE_OFF),
-            "tap_normalization": "none",
-            "projector_method": base.PROJECTOR_METHOD_DONUT,
-            "projector_gains": tuple(float(value) for value in base._PROFILE_OFF),
-            "projector_normalization": "none",
-            "fusion_method": base.FUSION_METHOD_STANDARD,
-            "fusion_strength": 0.0,
-        }
-    metadata["bundled_teacherfix"] = True
-    metadata["bundled_teacherfix_strength"] = float(strength)
-    metadata["bundled_teacherfix_targets"] = TEACHERFIX_TARGET_COUNT
-    transformer_options[base.FUSION_BUDGET_KEY] = metadata
-    return model
-
-
-def _rewrite_teacherfix_diagnostics(diagnostics, strength, loaded_count):
+def _rewrite_teacherfix_diagnostics(diagnostics, strength, loaded_count, relative_name):
     diagnostics = str(diagnostics)
     diagnostics = diagnostics.replace(
         f"preset_label={base.PRESET_MANUAL}; preset_is_ui_only=true",
-        f"preset_label={PRESET_TEACHERFIX}; preset_is_ui_only=false; bundled_asset=true",
+        f"preset_label={PRESET_TEACHERFIX}; preset_is_ui_only=false",
         1,
     )
     diagnostics = diagnostics.replace(
         "external_files_loaded=none",
         (
-            f"bundled_teacherfix={TEACHERFIX_FILENAME}; "
-            f"teacherfix_strength={float(strength):g}; "
-            f"teacherfix_targets={loaded_count}; external_files_loaded=none"
+            f"teacherfix_file={relative_name}; teacherfix_sha256={TEACHERFIX_SHA256}; "
+            f"teacherfix_strength={float(strength):g}; teacherfix_targets={loaded_count}"
         ),
         1,
     )
@@ -145,12 +167,12 @@ def _rewrite_teacherfix_diagnostics(diagnostics, strength, loaded_count):
 
 
 class DonutKrea2FusionControl(base.DonutKrea2FusionControl):
-    """Existing Krea2 Fusion Control plus a bundled TeacherFix preset."""
+    """Existing Krea2 Fusion Control plus TeacherFix and compact UI mode."""
 
     DESCRIPTION = (
         "Krea 2 text-fusion controls with Simple/Advanced UI modes, the existing "
-        "community compatibility presets, and a bundled C33 TeacherFix EMA5000 "
-        "text-fusion preset. No user-supplied LoRA path is required."
+        "community compatibility presets, and a hash-verified C33 TeacherFix "
+        "EMA5000 preset discovered automatically from ComfyUI/models/loras."
     )
 
     @classmethod
@@ -165,34 +187,31 @@ class DonutKrea2FusionControl(base.DonutKrea2FusionControl):
                     PRESET_TEACHERFIX,
                     (
                         "Select a preset. Existing compatibility presets copy settings "
-                        "into the controls; the TeacherFix preset additionally applies "
-                        "its bundled text-fusion weights."
+                        "into the controls; TeacherFix automatically finds and applies "
+                        "the exact hash-verified LoRA from ComfyUI/models/loras."
                     ),
                 )
             elif name == "tap_strength":
                 settings = dict(spec[1]) if len(spec) > 1 and isinstance(spec[1], dict) else {}
                 settings["tooltip"] = (
                     "Tap strength. In Simple mode this is the single preset-strength "
-                    "control; for the bundled TeacherFix preset it is the LoRA strength."
+                    "control; for TeacherFix it is the LoRA strength."
                 )
                 required[name] = (spec[0], settings)
             else:
                 required[name] = spec
 
-        # Append the UI-only mode selector after every legacy widget so existing
-        # saved workflows keep their widgets_values positions unchanged.
+        # Append after every legacy widget so existing widgets_values positions
+        # remain unchanged when old workflows are loaded.
         required["ui_mode"] = (list(UI_MODES), {
             "default": UI_MODE_ADVANCED,
             "tooltip": (
-                "Simple shows only preset + tap_strength. Advanced restores "
+                "Simple shows only mode, preset and tap_strength. Advanced restores "
                 "the current full Text Fusion control surface."
             ),
         })
 
-        return {
-            **schema,
-            "required": required,
-        }
+        return {**schema, "required": required}
 
     def apply(self, *args, ui_mode=UI_MODE_ADVANCED, **kwargs):
         if ui_mode not in UI_MODES:
@@ -204,17 +223,16 @@ class DonutKrea2FusionControl(base.DonutKrea2FusionControl):
 
         strength = float(kwargs.get("tap_strength", 1.0))
         delegated = dict(kwargs)
-        # The base node validates its own preset labels. Keep all visible/hidden
-        # settings exactly as submitted and only substitute the label for that
-        # validation call; the bundled preset is applied below.
+        # The base node validates its own preset labels. Keep all submitted
+        # controls and substitute only the label for that validation call.
         delegated["compatibility_preset"] = base.PRESET_MANUAL
         result = list(super().apply(*args, **delegated))
 
-        patched_model, loaded_count = _apply_bundled_teacherfix(result[0], strength)
-        if loaded_count:
-            patched_model = _publish_teacherfix_budget(patched_model, strength)
+        patched_model, loaded_count, relative_name = _apply_teacherfix(result[0], strength)
         result[0] = patched_model
-        result[-1] = _rewrite_teacherfix_diagnostics(result[-1], strength, loaded_count)
+        result[-1] = _rewrite_teacherfix_diagnostics(
+            result[-1], strength, loaded_count, relative_name
+        )
         return tuple(result)
 
 

--- a/DonutKrea2FusionPreset.py
+++ b/DonutKrea2FusionPreset.py
@@ -1,0 +1,227 @@
+"""Bundled Krea 2 TeacherFix preset and Simple/Advanced UI mode.
+
+This module intentionally overrides the existing ``DonutKrea2FusionControl``
+node id instead of registering a second node.  The base implementation remains
+the source of truth for all existing tap/projector/fusion controls; this layer
+adds one bundled text-fusion LoRA preset plus a UI-mode selector.
+"""
+
+from pathlib import Path
+import importlib
+import math
+
+from . import DonutKrea2FusionControl as base
+
+
+UI_MODE_SIMPLE = "Simple"
+UI_MODE_ADVANCED = "Advanced"
+UI_MODES = (UI_MODE_SIMPLE, UI_MODE_ADVANCED)
+
+PRESET_TEACHERFIX = "DONUT settings: Krea2 C33 TeacherFix EMA5000"
+TEACHERFIX_FILENAME = "krea2_c33_teacherfix_ema5000.safetensors"
+TEACHERFIX_TARGET_COUNT = 33
+TEACHERFIX_SHA256 = "db3c2b7612828120e7ef9cc8fe77124c6fd8de2e38f150599e62abd9695f6beb"
+TEACHERFIX_PATH = Path(__file__).resolve().parent / "assets" / TEACHERFIX_FILENAME
+
+_BUNDLED_LORA_CACHE = None
+
+
+def _copy_combo_spec(spec, extra_option=None, tooltip=None):
+    options = list(spec[0])
+    if extra_option is not None and extra_option not in options:
+        options.append(extra_option)
+    settings = dict(spec[1]) if len(spec) > 1 and isinstance(spec[1], dict) else {}
+    if tooltip is not None:
+        settings["tooltip"] = tooltip
+    return (options, settings)
+
+
+def _load_bundled_lora():
+    global _BUNDLED_LORA_CACHE
+    if _BUNDLED_LORA_CACHE is not None:
+        return _BUNDLED_LORA_CACHE
+
+    if not TEACHERFIX_PATH.is_file():
+        raise RuntimeError(
+            f"Bundled Krea2 TeacherFix preset is missing: {TEACHERFIX_PATH}"
+        )
+
+    comfy_utils = getattr(base.comfy, "utils", None)
+    if comfy_utils is None:
+        comfy_utils = importlib.import_module("comfy.utils")
+
+    state = comfy_utils.load_torch_file(str(TEACHERFIX_PATH), safe_load=True)
+    if not isinstance(state, dict):
+        raise RuntimeError("Bundled Krea2 TeacherFix preset did not load as a state dict")
+
+    target_bases = {
+        key[: -len(".lora_down.weight")]
+        for key in state
+        if isinstance(key, str) and key.endswith(".lora_down.weight")
+    }
+    if len(target_bases) != TEACHERFIX_TARGET_COUNT:
+        raise RuntimeError(
+            "Bundled Krea2 TeacherFix preset has an unexpected target count: "
+            f"{len(target_bases)} != {TEACHERFIX_TARGET_COUNT}"
+        )
+
+    _BUNDLED_LORA_CACHE = state
+    return state
+
+
+def _apply_bundled_teacherfix(model, strength):
+    strength = float(strength)
+    if not math.isfinite(strength):
+        raise ValueError("TeacherFix strength must be finite")
+    if strength == 0.0:
+        return model, 0
+
+    comfy_lora = getattr(base.comfy, "lora", None)
+    if comfy_lora is None:
+        comfy_lora = importlib.import_module("comfy.lora")
+
+    state = _load_bundled_lora()
+    key_map = comfy_lora.model_lora_keys_unet(model.model)
+    patches = comfy_lora.load_lora(state, key_map, log_missing=False)
+    if len(patches) != TEACHERFIX_TARGET_COUNT:
+        raise RuntimeError(
+            "Bundled Krea2 TeacherFix preset mapped an unexpected number of targets: "
+            f"{len(patches)} != {TEACHERFIX_TARGET_COUNT}. "
+            "Make sure the input MODEL is Krea 2."
+        )
+
+    patched = model.clone()
+    loaded = patched.add_patches(patches, strength_patch=strength)
+    loaded_count = len(loaded)
+    if loaded_count != TEACHERFIX_TARGET_COUNT:
+        raise RuntimeError(
+            "Bundled Krea2 TeacherFix preset could not patch every target: "
+            f"{loaded_count}/{TEACHERFIX_TARGET_COUNT} loaded"
+        )
+    return patched, loaded_count
+
+
+def _publish_teacherfix_budget(model, strength):
+    transformer_options = model.model_options.setdefault("transformer_options", {})
+    existing = transformer_options.get(base.FUSION_BUDGET_KEY)
+    if isinstance(existing, dict) and int(existing.get("version", 0)) == 1:
+        metadata = dict(existing)
+    else:
+        metadata = {
+            "version": 1,
+            "tap_method": base.TAP_METHOD_DONUT,
+            "tap_gains": tuple(float(value) for value in base._PROFILE_OFF),
+            "tap_normalization": "none",
+            "projector_method": base.PROJECTOR_METHOD_DONUT,
+            "projector_gains": tuple(float(value) for value in base._PROFILE_OFF),
+            "projector_normalization": "none",
+            "fusion_method": base.FUSION_METHOD_STANDARD,
+            "fusion_strength": 0.0,
+        }
+    metadata["bundled_teacherfix"] = True
+    metadata["bundled_teacherfix_strength"] = float(strength)
+    metadata["bundled_teacherfix_targets"] = TEACHERFIX_TARGET_COUNT
+    transformer_options[base.FUSION_BUDGET_KEY] = metadata
+    return model
+
+
+def _rewrite_teacherfix_diagnostics(diagnostics, strength, loaded_count):
+    diagnostics = str(diagnostics)
+    diagnostics = diagnostics.replace(
+        f"preset_label={base.PRESET_MANUAL}; preset_is_ui_only=true",
+        f"preset_label={PRESET_TEACHERFIX}; preset_is_ui_only=false; bundled_asset=true",
+        1,
+    )
+    diagnostics = diagnostics.replace(
+        "external_files_loaded=none",
+        (
+            f"bundled_teacherfix={TEACHERFIX_FILENAME}; "
+            f"teacherfix_strength={float(strength):g}; "
+            f"teacherfix_targets={loaded_count}; external_files_loaded=none"
+        ),
+        1,
+    )
+    return diagnostics
+
+
+class DonutKrea2FusionControl(base.DonutKrea2FusionControl):
+    """Existing Krea2 Fusion Control plus a bundled TeacherFix preset."""
+
+    DESCRIPTION = (
+        "Krea 2 text-fusion controls with Simple/Advanced UI modes, the existing "
+        "community compatibility presets, and a bundled C33 TeacherFix EMA5000 "
+        "text-fusion preset. No user-supplied LoRA path is required."
+    )
+
+    @classmethod
+    def INPUT_TYPES(cls):
+        schema = super().INPUT_TYPES()
+        original_required = schema["required"]
+        required = {}
+        for name, spec in original_required.items():
+            if name == "compatibility_preset":
+                required[name] = _copy_combo_spec(
+                    spec,
+                    PRESET_TEACHERFIX,
+                    (
+                        "Select a preset. Existing compatibility presets copy settings "
+                        "into the controls; the TeacherFix preset additionally applies "
+                        "its bundled text-fusion weights."
+                    ),
+                )
+            elif name == "tap_strength":
+                settings = dict(spec[1]) if len(spec) > 1 and isinstance(spec[1], dict) else {}
+                settings["tooltip"] = (
+                    "Tap strength. In Simple mode this is the single preset-strength "
+                    "control; for the bundled TeacherFix preset it is the LoRA strength."
+                )
+                required[name] = (spec[0], settings)
+            else:
+                required[name] = spec
+
+        # Append the UI-only mode selector after every legacy widget so existing
+        # saved workflows keep their widgets_values positions unchanged.
+        required["ui_mode"] = (list(UI_MODES), {
+            "default": UI_MODE_ADVANCED,
+            "tooltip": (
+                "Simple shows only preset + tap_strength. Advanced restores "
+                "the current full Text Fusion control surface."
+            ),
+        })
+
+        return {
+            **schema,
+            "required": required,
+        }
+
+    def apply(self, *args, ui_mode=UI_MODE_ADVANCED, **kwargs):
+        if ui_mode not in UI_MODES:
+            raise ValueError(f"Unknown Krea2 Fusion UI mode: {ui_mode}")
+
+        preset = kwargs.get("compatibility_preset", base.PRESET_MANUAL)
+        if preset != PRESET_TEACHERFIX:
+            return super().apply(*args, **kwargs)
+
+        strength = float(kwargs.get("tap_strength", 1.0))
+        delegated = dict(kwargs)
+        # The base node validates its own preset labels. Keep all visible/hidden
+        # settings exactly as submitted and only substitute the label for that
+        # validation call; the bundled preset is applied below.
+        delegated["compatibility_preset"] = base.PRESET_MANUAL
+        result = list(super().apply(*args, **delegated))
+
+        patched_model, loaded_count = _apply_bundled_teacherfix(result[0], strength)
+        if loaded_count:
+            patched_model = _publish_teacherfix_budget(patched_model, strength)
+        result[0] = patched_model
+        result[-1] = _rewrite_teacherfix_diagnostics(result[-1], strength, loaded_count)
+        return tuple(result)
+
+
+NODE_CLASS_MAPPINGS = {
+    "DonutKrea2FusionControl": DonutKrea2FusionControl,
+}
+
+NODE_DISPLAY_NAME_MAPPINGS = {
+    "DonutKrea2FusionControl": "Donut Krea2 Fusion Control",
+}

--- a/DonutKrea2FusionPreset.py
+++ b/DonutKrea2FusionPreset.py
@@ -6,7 +6,6 @@ the source of truth for all existing tap/projector/fusion controls; this layer
 adds one exact-file TeacherFix preset plus a UI-mode selector.
 """
 
-from pathlib import Path
 import hashlib
 import importlib
 import math

--- a/__init__.py
+++ b/__init__.py
@@ -132,6 +132,11 @@ from .DonutKrea2ImageConditioning import NODE_DISPLAY_NAME_MAPPINGS as d_krea2_c
 from .DonutKrea2FusionControl import NODE_CLASS_MAPPINGS        as m_krea2_fusion
 from .DonutKrea2FusionControl import NODE_DISPLAY_NAME_MAPPINGS as d_krea2_fusion
 
+# Keep the same Krea2 Fusion Control node id while adding a bundled TeacherFix
+# preset and the Simple/Advanced frontend mode.
+from .DonutKrea2FusionPreset import NODE_CLASS_MAPPINGS        as m_krea2_fusion_preset
+from .DonutKrea2FusionPreset import NODE_DISPLAY_NAME_MAPPINGS as d_krea2_fusion_preset
+
 # Image Adjust (unified tone/color/contrast/sharpen)
 from .DonutImageAdjust import NODE_CLASS_MAPPINGS        as m_image_adjust
 from .DonutImageAdjust import NODE_DISPLAY_NAME_MAPPINGS as d_image_adjust
@@ -170,6 +175,7 @@ NODE_CLASS_MAPPINGS = {
     **m_zit_layerblend,
     **m_krea2_cond,
     **m_krea2_fusion,
+    **m_krea2_fusion_preset,
     **m_image_adjust,
 }
 
@@ -204,6 +210,7 @@ NODE_DISPLAY_NAME_MAPPINGS = {
     **d_zit_layerblend,
     **d_krea2_cond,
     **d_krea2_fusion,
+    **d_krea2_fusion_preset,
     **d_detailer,
     **d_image_adjust,
 }

--- a/__init__.py
+++ b/__init__.py
@@ -132,8 +132,8 @@ from .DonutKrea2ImageConditioning import NODE_DISPLAY_NAME_MAPPINGS as d_krea2_c
 from .DonutKrea2FusionControl import NODE_CLASS_MAPPINGS        as m_krea2_fusion
 from .DonutKrea2FusionControl import NODE_DISPLAY_NAME_MAPPINGS as d_krea2_fusion
 
-# Keep the same Krea2 Fusion Control node id while adding a bundled TeacherFix
-# preset and the Simple/Advanced frontend mode.
+# Keep the same Krea2 Fusion Control node id while adding the hash-verified
+# TeacherFix preset and the Simple/Advanced frontend mode.
 from .DonutKrea2FusionPreset import NODE_CLASS_MAPPINGS        as m_krea2_fusion_preset
 from .DonutKrea2FusionPreset import NODE_DISPLAY_NAME_MAPPINGS as d_krea2_fusion_preset
 

--- a/test_krea2_fusion_preset.py
+++ b/test_krea2_fusion_preset.py
@@ -1,47 +1,200 @@
 import ast
-import hashlib
+import importlib.util
+import sys
+import types
 import unittest
 from pathlib import Path
-
-from safetensors import safe_open
+from unittest import mock
 
 
 ROOT = Path(__file__).resolve().parent
-ASSET = ROOT / "assets" / "krea2_c33_teacherfix_ema5000.safetensors"
 EXPECTED_SHA256 = "db3c2b7612828120e7ef9cc8fe77124c6fd8de2e38f150599e62abd9695f6beb"
+EXPECTED_SIZE = 3_470_548
 EXPECTED_TARGETS = 33
 
 
-class BundledTeacherFixAssetTests(unittest.TestCase):
-    def test_asset_is_exact_teacherfix_export(self):
-        self.assertTrue(ASSET.is_file())
-        self.assertEqual(hashlib.sha256(ASSET.read_bytes()).hexdigest(), EXPECTED_SHA256)
+def _load_module():
+    package_name = "donut_krea2_fusion_preset_testpkg"
+    package = types.ModuleType(package_name)
+    package.__path__ = [str(ROOT)]
+    sys.modules[package_name] = package
 
-        with safe_open(str(ASSET), framework="pt", device="cpu") as handle:
-            metadata = handle.metadata() or {}
-            keys = list(handle.keys())
+    base = types.ModuleType(f"{package_name}.DonutKrea2FusionControl")
+    base.PRESET_MANUAL = "Custom settings"
 
-        target_bases = {
-            key[: -len(".lora_down.weight")]
-            for key in keys
-            if key.endswith(".lora_down.weight")
-        }
-        self.assertEqual(len(target_bases), EXPECTED_TARGETS)
-        self.assertEqual(metadata.get("target_module_count"), str(EXPECTED_TARGETS))
-        self.assertEqual(metadata.get("alpha"), "4.0")
-        self.assertEqual(metadata.get("converted_for"), "Comfy Krea LoRA checkpoint sampling")
+    class BaseNode:
+        @classmethod
+        def INPUT_TYPES(cls):
+            return {
+                "required": {
+                    "model": ("MODEL",),
+                    "conditioning_in_1": ("CONDITIONING",),
+                    "compatibility_preset": ([base.PRESET_MANUAL, "DONUT settings: legacy"], {
+                        "default": base.PRESET_MANUAL,
+                    }),
+                    "tap_method": (["Donut 12-tap gains"],),
+                    "tap_profile": (["off"],),
+                    "per_layer_weights": ("STRING", {}),
+                    "tap_strength": ("FLOAT", {"default": 1.0}),
+                    "tap_formula": (["scale_around_1"],),
+                    "tap_normalization": (["none"],),
+                    "projector_method": (["Donut projector-input gains"],),
+                    "projector_profile": (["off"],),
+                    "projector_layer_weights": ("STRING", {}),
+                    "projector_strength": ("FLOAT", {"default": 1.0}),
+                    "projector_formula": (["scale_around_1"],),
+                    "projector_normalization": (["none"],),
+                    "fusion_method": (["Standard Krea2 fusion"],),
+                    "fusion_strength": ("FLOAT", {"default": 1.0}),
+                },
+                "optional": {},
+            }
 
-    def test_override_and_frontend_sources_parse(self):
+        def apply(self, **kwargs):
+            return (
+                kwargs["model"],
+                kwargs["conditioning_in_1"],
+                None,
+                None,
+                None,
+                "preset_label=Custom settings; preset_is_ui_only=true\n"
+                "external_files_loaded=none",
+            )
+
+    base.DonutKrea2FusionControl = BaseNode
+    state = {
+        f"diffusion_model.txtfusion.fake_{index}.lora_down.weight": object()
+        for index in range(EXPECTED_TARGETS)
+    }
+
+    class FakeUtils:
+        @staticmethod
+        def load_torch_file(path, safe_load=True):
+            return dict(state)
+
+    class FakeLora:
+        @staticmethod
+        def model_lora_keys_unet(model):
+            return {"fake": "fake"}
+
+        @staticmethod
+        def load_lora(lora, key_map, log_missing=False):
+            return {
+                f"diffusion_model.txtfusion.fake_{index}.weight": ("lora", ())
+                for index in range(EXPECTED_TARGETS)
+            }
+
+    base.comfy = types.SimpleNamespace(utils=FakeUtils, lora=FakeLora)
+    sys.modules[base.__name__] = base
+    setattr(package, "DonutKrea2FusionControl", base)
+
+    fake_folder_paths = types.ModuleType("folder_paths")
+    fake_folder_paths.get_filename_list = lambda category: [
+        "other.safetensors",
+        "renamed_teacherfix.safetensors",
+    ]
+    fake_folder_paths.get_full_path = lambda category, name: f"/fake/{name}"
+    sys.modules["folder_paths"] = fake_folder_paths
+
+    spec = importlib.util.spec_from_file_location(
+        f"{package_name}.DonutKrea2FusionPreset",
+        ROOT / "DonutKrea2FusionPreset.py",
+    )
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class TeacherFixPresetTests(unittest.TestCase):
+    def test_source_constants_and_ui_schema_are_stable(self):
         source = (ROOT / "DonutKrea2FusionPreset.py").read_text()
         ast.parse(source)
-        self.assertIn('PRESET_TEACHERFIX = "DONUT settings: Krea2 C33 TeacherFix EMA5000"', source)
-        self.assertIn('UI_MODES = (UI_MODE_SIMPLE, UI_MODE_ADVANCED)', source)
+        self.assertIn(f'TEACHERFIX_SHA256 = "{EXPECTED_SHA256}"', source)
+        self.assertIn(f"TEACHERFIX_SIZE_BYTES = {EXPECTED_SIZE:_}", source)
+        self.assertIn(f"TEACHERFIX_TARGET_COUNT = {EXPECTED_TARGETS}", source)
 
+        module = _load_module()
+        schema = module.DonutKrea2FusionControl.INPUT_TYPES()
+        required = schema["required"]
+        self.assertEqual(list(required)[-1], "ui_mode")
+        self.assertEqual(required["ui_mode"][1]["default"], "Advanced")
+        self.assertIn(module.PRESET_TEACHERFIX, required["compatibility_preset"][0])
+
+    def test_exact_file_is_discovered_by_size_and_hash_even_when_renamed(self):
+        module = _load_module()
+        with (
+            mock.patch.object(module.os.path, "isfile", return_value=True),
+            mock.patch.object(module.os.path, "getsize", side_effect=lambda path: (
+                EXPECTED_SIZE if "renamed_teacherfix" in path else 123
+            )),
+            mock.patch.object(module, "_sha256_file", return_value=EXPECTED_SHA256),
+        ):
+            name, path = module._find_teacherfix_file()
+        self.assertEqual(name, "renamed_teacherfix.safetensors")
+        self.assertEqual(path, "/fake/renamed_teacherfix.safetensors")
+
+    def test_teacherfix_strength_patches_all_33_targets(self):
+        module = _load_module()
+        module._TEACHERFIX_CACHE = (
+            {
+                f"diffusion_model.txtfusion.fake_{index}.lora_down.weight": object()
+                for index in range(EXPECTED_TARGETS)
+            },
+            "renamed_teacherfix.safetensors",
+        )
+
+        class FakeModel:
+            def __init__(self):
+                self.model = object()
+                self.loaded = {}
+
+            def clone(self):
+                clone = FakeModel()
+                clone.loaded = dict(self.loaded)
+                return clone
+
+            def add_patches(self, patches, strength_patch=1.0):
+                self.loaded.update({key: strength_patch for key in patches})
+                return list(patches)
+
+        conditioning = object()
+        result = module.DonutKrea2FusionControl().apply(
+            model=FakeModel(),
+            conditioning_in_1=conditioning,
+            compatibility_preset=module.PRESET_TEACHERFIX,
+            tap_method="Donut 12-tap gains",
+            tap_profile="off",
+            per_layer_weights="1",
+            tap_strength=0.75,
+            tap_formula="scale_around_1",
+            tap_normalization="none",
+            projector_method="Donut projector-input gains",
+            projector_profile="off",
+            projector_layer_weights="1",
+            projector_strength=1.0,
+            projector_formula="scale_around_1",
+            projector_normalization="none",
+            fusion_method="Standard Krea2 fusion",
+            fusion_strength=1.0,
+            ui_mode="Simple",
+        )
+
+        self.assertEqual(len(result[0].loaded), EXPECTED_TARGETS)
+        self.assertEqual(set(result[0].loaded.values()), {0.75})
+        self.assertIs(result[1], conditioning)
+        self.assertIn("preset_is_ui_only=false", result[-1])
+        self.assertIn("renamed_teacherfix.safetensors", result[-1])
+
+    def test_frontend_has_compact_simple_and_full_advanced_modes(self):
         js = (ROOT / "web" / "donut_krea2_fusion_simple_mode.js").read_text()
         self.assertIn('const SIMPLE = "Simple";', js)
         self.assertIn('const ADVANCED = "Advanced";', js)
         self.assertIn('const TEACHERFIX = "DONUT settings: Krea2 C33 TeacherFix EMA5000";', js)
         self.assertIn('name === "tap_strength"', js)
+        self.assertIn("SIMPLE_PROJECTOR_STRENGTH", js)
+        self.assertIn("SIMPLE_FUSION_STRENGTH", js)
+        self.assertIn("queueMicrotask", js)
 
 
 if __name__ == "__main__":

--- a/test_krea2_fusion_preset.py
+++ b/test_krea2_fusion_preset.py
@@ -21,6 +21,15 @@ def _load_module():
 
     base = types.ModuleType(f"{package_name}.DonutKrea2FusionControl")
     base.PRESET_MANUAL = "Custom settings"
+    base.PRESET_BYPASS_2 = "COPY settings: Krea2FilterBypass 2vector"
+    base.PRESET_BYPASS_3 = "COPY settings: Krea2FilterBypass 3vector"
+    base.PRESET_REBALANCE = "COPY settings: nova452 ConditioningKrea2Rebalance profile @ tap strength 1"
+    base.PRESET_ENHANCER = "COPY settings: capitan01R Krea2T-Enhancer defaults"
+    base.PRESET_REBALANCE_ENHANCER = "HYBRID settings: Rebalance + Krea2T-Enhancer"
+    base.PRESET_REBALANCE_BYPASS_2 = "HYBRID settings: Rebalance + Krea2FilterBypass 2vector"
+    base.PRESET_REBALANCE_BYPASS_3 = "HYBRID settings: Rebalance + Krea2FilterBypass 3vector"
+    base.PRESET_DONUT_BALANCED = "DONUT settings: RMS-balanced classic"
+    base.PRESET_DONUT_BALANCED_ENHANCER = "DONUT settings: RMS-balanced classic + Krea2T-Enhancer"
 
     class BaseNode:
         @classmethod
@@ -29,7 +38,7 @@ def _load_module():
                 "required": {
                     "model": ("MODEL",),
                     "conditioning_in_1": ("CONDITIONING",),
-                    "compatibility_preset": ([base.PRESET_MANUAL, "DONUT settings: legacy"], {
+                    "compatibility_preset": ([base.PRESET_MANUAL, base.PRESET_DONUT_BALANCED], {
                         "default": base.PRESET_MANUAL,
                     }),
                     "tap_method": (["Donut 12-tap gains"],),
@@ -51,13 +60,14 @@ def _load_module():
             }
 
         def apply(self, **kwargs):
+            preset = kwargs.get("compatibility_preset", base.PRESET_MANUAL)
             return (
                 kwargs["model"],
                 kwargs["conditioning_in_1"],
                 None,
                 None,
                 None,
-                "preset_label=Custom settings; preset_is_ui_only=true\n"
+                f"preset_label={preset}; preset_is_ui_only=true\n"
                 "external_files_loaded=none",
             )
 
@@ -118,7 +128,23 @@ class TeacherFixPresetTests(unittest.TestCase):
         required = schema["required"]
         self.assertEqual(list(required)[-1], "ui_mode")
         self.assertEqual(required["ui_mode"][1]["default"], "Advanced")
-        self.assertIn(module.PRESET_TEACHERFIX, required["compatibility_preset"][0])
+        self.assertEqual(required["compatibility_preset"][1]["default"], "Custom")
+        self.assertEqual(
+            required["compatibility_preset"][0],
+            [
+                "Custom",
+                "Bypass 2",
+                "Bypass 3",
+                "Rebalance",
+                "Enhancer",
+                "Rebalance + Enhancer",
+                "Rebalance + Bypass 2",
+                "Rebalance + Bypass 3",
+                "Balanced",
+                "Balanced + Enhancer",
+                "TeacherFix",
+            ],
+        )
 
     def test_exact_file_is_discovered_by_size_and_hash_even_when_renamed(self):
         module, fake_folder_paths = _load_module()
@@ -133,6 +159,34 @@ class TeacherFixPresetTests(unittest.TestCase):
             name, path = module._find_teacherfix_file()
         self.assertEqual(name, "renamed_teacherfix.safetensors")
         self.assertEqual(path, "/fake/renamed_teacherfix.safetensors")
+
+    def test_simplified_names_delegate_to_existing_presets(self):
+        module, _ = _load_module()
+
+        class FakeModel:
+            pass
+
+        result = module.DonutKrea2FusionControl().apply(
+            model=FakeModel(),
+            conditioning_in_1=object(),
+            compatibility_preset="Bypass 2",
+            tap_method="Donut 12-tap gains",
+            tap_profile="off",
+            per_layer_weights="1",
+            tap_strength=1.0,
+            tap_formula="scale_around_1",
+            tap_normalization="none",
+            projector_method="Donut projector-input gains",
+            projector_profile="off",
+            projector_layer_weights="1",
+            projector_strength=1.0,
+            projector_formula="scale_around_1",
+            projector_normalization="none",
+            fusion_method="Standard Krea2 fusion",
+            fusion_strength=1.0,
+            ui_mode="Advanced",
+        )
+        self.assertIn("preset_label=Bypass 2", result[-1])
 
     def test_teacherfix_strength_patches_all_33_targets(self):
         module, _ = _load_module()
@@ -183,6 +237,7 @@ class TeacherFixPresetTests(unittest.TestCase):
         self.assertEqual(len(result[0].loaded), EXPECTED_TARGETS)
         self.assertEqual(set(result[0].loaded.values()), {0.75})
         self.assertIs(result[1], conditioning)
+        self.assertIn("preset_label=TeacherFix", result[-1])
         self.assertIn("preset_is_ui_only=false", result[-1])
         self.assertIn("renamed_teacherfix.safetensors", result[-1])
 
@@ -190,10 +245,14 @@ class TeacherFixPresetTests(unittest.TestCase):
         js = (ROOT / "web" / "donut_krea2_fusion_simple_mode.js").read_text()
         self.assertIn('const SIMPLE = "Simple";', js)
         self.assertIn('const ADVANCED = "Advanced";', js)
-        self.assertIn('const TEACHERFIX = "DONUT settings: Krea2 C33 TeacherFix EMA5000";', js)
+        self.assertIn('const CUSTOM = "Custom";', js)
+        self.assertIn('const TEACHERFIX = "TeacherFix";', js)
+        self.assertIn('"Bypass 2"', js)
+        self.assertIn('"Balanced + Enhancer"', js)
         self.assertIn('name === "tap_strength"', js)
         self.assertIn("SIMPLE_PROJECTOR_STRENGTH", js)
         self.assertIn("SIMPLE_FUSION_STRENGTH", js)
+        self.assertIn("LEGACY_TO_SIMPLE", js)
         self.assertIn("queueMicrotask", js)
 
 

--- a/test_krea2_fusion_preset.py
+++ b/test_krea2_fusion_preset.py
@@ -241,6 +241,37 @@ class TeacherFixPresetTests(unittest.TestCase):
         self.assertIn("preset_is_ui_only=false", result[-1])
         self.assertIn("renamed_teacherfix.safetensors", result[-1])
 
+    def test_pre_rename_teacherfix_label_is_still_accepted(self):
+        module, _ = _load_module()
+        module._TEACHERFIX_CACHE = (
+            {
+                f"diffusion_model.txtfusion.fake_{index}.lora_down.weight": object()
+                for index in range(EXPECTED_TARGETS)
+            },
+            "renamed_teacherfix.safetensors",
+        )
+
+        class FakeModel:
+            def __init__(self):
+                self.model = object()
+                self.loaded = {}
+
+            def clone(self):
+                return FakeModel()
+
+            def add_patches(self, patches, strength_patch=1.0):
+                self.loaded.update({key: strength_patch for key in patches})
+                return list(patches)
+
+        result = module.DonutKrea2FusionControl().apply(
+            model=FakeModel(),
+            conditioning_in_1=object(),
+            compatibility_preset=module.LEGACY_TEACHERFIX,
+            tap_strength=1.0,
+            ui_mode="Advanced",
+        )
+        self.assertIn("preset_label=TeacherFix", result[-1])
+
     def test_frontend_has_compact_simple_and_full_advanced_modes(self):
         js = (ROOT / "web" / "donut_krea2_fusion_simple_mode.js").read_text()
         self.assertIn('const SIMPLE = "Simple";', js)

--- a/test_krea2_fusion_preset.py
+++ b/test_krea2_fusion_preset.py
@@ -94,7 +94,6 @@ def _load_module():
         "renamed_teacherfix.safetensors",
     ]
     fake_folder_paths.get_full_path = lambda category, name: f"/fake/{name}"
-    sys.modules["folder_paths"] = fake_folder_paths
 
     spec = importlib.util.spec_from_file_location(
         f"{package_name}.DonutKrea2FusionPreset",
@@ -103,7 +102,7 @@ def _load_module():
     module = importlib.util.module_from_spec(spec)
     sys.modules[spec.name] = module
     spec.loader.exec_module(module)
-    return module
+    return module, fake_folder_paths
 
 
 class TeacherFixPresetTests(unittest.TestCase):
@@ -114,7 +113,7 @@ class TeacherFixPresetTests(unittest.TestCase):
         self.assertIn(f"TEACHERFIX_SIZE_BYTES = {EXPECTED_SIZE:_}", source)
         self.assertIn(f"TEACHERFIX_TARGET_COUNT = {EXPECTED_TARGETS}", source)
 
-        module = _load_module()
+        module, _ = _load_module()
         schema = module.DonutKrea2FusionControl.INPUT_TYPES()
         required = schema["required"]
         self.assertEqual(list(required)[-1], "ui_mode")
@@ -122,8 +121,9 @@ class TeacherFixPresetTests(unittest.TestCase):
         self.assertIn(module.PRESET_TEACHERFIX, required["compatibility_preset"][0])
 
     def test_exact_file_is_discovered_by_size_and_hash_even_when_renamed(self):
-        module = _load_module()
+        module, fake_folder_paths = _load_module()
         with (
+            mock.patch.dict(sys.modules, {"folder_paths": fake_folder_paths}),
             mock.patch.object(module.os.path, "isfile", return_value=True),
             mock.patch.object(module.os.path, "getsize", side_effect=lambda path: (
                 EXPECTED_SIZE if "renamed_teacherfix" in path else 123
@@ -135,7 +135,7 @@ class TeacherFixPresetTests(unittest.TestCase):
         self.assertEqual(path, "/fake/renamed_teacherfix.safetensors")
 
     def test_teacherfix_strength_patches_all_33_targets(self):
-        module = _load_module()
+        module, _ = _load_module()
         module._TEACHERFIX_CACHE = (
             {
                 f"diffusion_model.txtfusion.fake_{index}.lora_down.weight": object()

--- a/test_krea2_fusion_preset.py
+++ b/test_krea2_fusion_preset.py
@@ -162,31 +162,14 @@ class TeacherFixPresetTests(unittest.TestCase):
 
     def test_simplified_names_delegate_to_existing_presets(self):
         module, _ = _load_module()
-
-        class FakeModel:
-            pass
-
-        result = module.DonutKrea2FusionControl().apply(
-            model=FakeModel(),
-            conditioning_in_1=object(),
-            compatibility_preset="Bypass 2",
-            tap_method="Donut 12-tap gains",
-            tap_profile="off",
-            per_layer_weights="1",
-            tap_strength=1.0,
-            tap_formula="scale_around_1",
-            tap_normalization="none",
-            projector_method="Donut projector-input gains",
-            projector_profile="off",
-            projector_layer_weights="1",
-            projector_strength=1.0,
-            projector_formula="scale_around_1",
-            projector_normalization="none",
-            fusion_method="Standard Krea2 fusion",
-            fusion_strength=1.0,
-            ui_mode="Advanced",
+        self.assertEqual(
+            module.SIMPLE_PRESET_TO_LEGACY["Bypass 2"],
+            "COPY settings: Krea2FilterBypass 2vector",
         )
-        self.assertIn("preset_label=Bypass 2", result[-1])
+        self.assertEqual(
+            module.SIMPLE_PRESET_TO_LEGACY["Balanced + Enhancer"],
+            "DONUT settings: RMS-balanced classic + Krea2T-Enhancer",
+        )
 
     def test_teacherfix_strength_patches_all_33_targets(self):
         module, _ = _load_module()
@@ -243,34 +226,10 @@ class TeacherFixPresetTests(unittest.TestCase):
 
     def test_pre_rename_teacherfix_label_is_still_accepted(self):
         module, _ = _load_module()
-        module._TEACHERFIX_CACHE = (
-            {
-                f"diffusion_model.txtfusion.fake_{index}.lora_down.weight": object()
-                for index in range(EXPECTED_TARGETS)
-            },
-            "renamed_teacherfix.safetensors",
+        self.assertEqual(
+            module.LEGACY_PRESET_TO_SIMPLE[module.LEGACY_TEACHERFIX],
+            "TeacherFix",
         )
-
-        class FakeModel:
-            def __init__(self):
-                self.model = object()
-                self.loaded = {}
-
-            def clone(self):
-                return FakeModel()
-
-            def add_patches(self, patches, strength_patch=1.0):
-                self.loaded.update({key: strength_patch for key in patches})
-                return list(patches)
-
-        result = module.DonutKrea2FusionControl().apply(
-            model=FakeModel(),
-            conditioning_in_1=object(),
-            compatibility_preset=module.LEGACY_TEACHERFIX,
-            tap_strength=1.0,
-            ui_mode="Advanced",
-        )
-        self.assertIn("preset_label=TeacherFix", result[-1])
 
     def test_frontend_has_compact_simple_and_full_advanced_modes(self):
         js = (ROOT / "web" / "donut_krea2_fusion_simple_mode.js").read_text()

--- a/test_krea2_fusion_preset.py
+++ b/test_krea2_fusion_preset.py
@@ -1,0 +1,48 @@
+import ast
+import hashlib
+import unittest
+from pathlib import Path
+
+from safetensors import safe_open
+
+
+ROOT = Path(__file__).resolve().parent
+ASSET = ROOT / "assets" / "krea2_c33_teacherfix_ema5000.safetensors"
+EXPECTED_SHA256 = "db3c2b7612828120e7ef9cc8fe77124c6fd8de2e38f150599e62abd9695f6beb"
+EXPECTED_TARGETS = 33
+
+
+class BundledTeacherFixAssetTests(unittest.TestCase):
+    def test_asset_is_exact_teacherfix_export(self):
+        self.assertTrue(ASSET.is_file())
+        self.assertEqual(hashlib.sha256(ASSET.read_bytes()).hexdigest(), EXPECTED_SHA256)
+
+        with safe_open(str(ASSET), framework="pt", device="cpu") as handle:
+            metadata = handle.metadata() or {}
+            keys = list(handle.keys())
+
+        target_bases = {
+            key[: -len(".lora_down.weight")]
+            for key in keys
+            if key.endswith(".lora_down.weight")
+        }
+        self.assertEqual(len(target_bases), EXPECTED_TARGETS)
+        self.assertEqual(metadata.get("target_module_count"), str(EXPECTED_TARGETS))
+        self.assertEqual(metadata.get("alpha"), "4.0")
+        self.assertEqual(metadata.get("converted_for"), "Comfy Krea LoRA checkpoint sampling")
+
+    def test_override_and_frontend_sources_parse(self):
+        source = (ROOT / "DonutKrea2FusionPreset.py").read_text()
+        ast.parse(source)
+        self.assertIn('PRESET_TEACHERFIX = "DONUT settings: Krea2 C33 TeacherFix EMA5000"', source)
+        self.assertIn('UI_MODES = (UI_MODE_SIMPLE, UI_MODE_ADVANCED)', source)
+
+        js = (ROOT / "web" / "donut_krea2_fusion_simple_mode.js").read_text()
+        self.assertIn('const SIMPLE = "Simple";', js)
+        self.assertIn('const ADVANCED = "Advanced";', js)
+        self.assertIn('const TEACHERFIX = "DONUT settings: Krea2 C33 TeacherFix EMA5000";', js)
+        self.assertIn('name === "tap_strength"', js)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/web/donut_krea2_fusion_control.js
+++ b/web/donut_krea2_fusion_control.js
@@ -1,7 +1,7 @@
 import { app } from "../../scripts/app.js";
 
 const NODE_NAME = "DonutKrea2FusionControl";
-const CUSTOM = "Custom settings";
+const CUSTOM = "Custom";
 
 const TAP_DONUT = "Donut 12-tap gains";
 const TAP_REBALANCE = "nova452 Rebalance operation";

--- a/web/donut_krea2_fusion_control.js
+++ b/web/donut_krea2_fusion_control.js
@@ -18,6 +18,8 @@ const PROFILE_VECTORS = {
   deep_3: "1.0,1.0,1.0,1.0,1.0,1.0,1.0,1.0,2.0,2.0,2.0,1.0",
 };
 
+// Legacy keys remain here so older saved workflows can still replay their
+// original preset values. The UI override exposes the shorter display labels.
 const PRESETS = {
   "COPY settings: Krea2FilterBypass 2vector": {
     tap_method: TAP_DONUT,

--- a/web/donut_krea2_fusion_simple_mode.js
+++ b/web/donut_krea2_fusion_simple_mode.js
@@ -3,39 +3,185 @@ import { app } from "../../scripts/app.js";
 const NODE_NAME = "DonutKrea2FusionControl";
 const SIMPLE = "Simple";
 const ADVANCED = "Advanced";
-const CUSTOM = "Custom settings";
-const TEACHERFIX = "DONUT settings: Krea2 C33 TeacherFix EMA5000";
+const CUSTOM = "Custom";
+const TEACHERFIX = "TeacherFix";
 
 const TAP_DONUT = "Donut 12-tap gains";
+const TAP_REBALANCE = "nova452 Rebalance operation";
 const PROJECTOR_DONUT = "Donut projector-input gains";
+const PROJECTOR_BYPASS_2 = "Krea2FilterBypass 2vector diff";
+const PROJECTOR_BYPASS_3 = "Krea2FilterBypass 3vector diff";
+const FUSION_STANDARD = "Standard Krea2 fusion";
 const FUSION_ENHANCER = "capitan01R Krea2T-Enhancer operation";
 
-const TEACHERFIX_VALUES = {
-  tap_method: TAP_DONUT,
-  tap_profile: "off",
-  tap_strength: 1.0,
-  tap_formula: "scale_around_1",
-  tap_normalization: "tensor_rms",
-  projector_method: PROJECTOR_DONUT,
-  projector_profile: "off",
-  projector_strength: 1.0,
-  projector_formula: "scale_around_1",
-  projector_normalization: "none",
-  fusion_method: "Standard Krea2 fusion",
-  fusion_strength: 1.0,
+const LEGACY_TO_SIMPLE = {
+  "Custom settings": CUSTOM,
+  "COPY settings: Krea2FilterBypass 2vector": "Bypass 2",
+  "COPY settings: Krea2FilterBypass 3vector": "Bypass 3",
+  "COPY settings: nova452 ConditioningKrea2Rebalance profile @ tap strength 1": "Rebalance",
+  "COPY settings: capitan01R Krea2T-Enhancer defaults": "Enhancer",
+  "HYBRID settings: Rebalance + Krea2T-Enhancer": "Rebalance + Enhancer",
+  "HYBRID settings: Rebalance + Krea2FilterBypass 2vector": "Rebalance + Bypass 2",
+  "HYBRID settings: Rebalance + Krea2FilterBypass 3vector": "Rebalance + Bypass 3",
+  "DONUT settings: RMS-balanced classic": "Balanced",
+  "DONUT settings: RMS-balanced classic + Krea2T-Enhancer": "Balanced + Enhancer",
+  "DONUT settings: Krea2 C33 TeacherFix EMA5000": TEACHERFIX,
+};
+
+const SIMPLE_PRESETS = {
+  "Bypass 2": {
+    tap_method: TAP_DONUT,
+    tap_profile: "off",
+    tap_strength: 1.0,
+    tap_formula: "scale_around_1",
+    tap_normalization: "tensor_rms",
+    projector_method: PROJECTOR_BYPASS_2,
+    projector_profile: "off",
+    projector_strength: 1.0,
+    projector_formula: "scale_around_1",
+    projector_normalization: "none",
+    fusion_method: FUSION_STANDARD,
+    fusion_strength: 1.0,
+  },
+  "Bypass 3": {
+    tap_method: TAP_DONUT,
+    tap_profile: "off",
+    tap_strength: 1.0,
+    tap_formula: "scale_around_1",
+    tap_normalization: "tensor_rms",
+    projector_method: PROJECTOR_BYPASS_3,
+    projector_profile: "off",
+    projector_strength: 1.0,
+    projector_formula: "scale_around_1",
+    projector_normalization: "none",
+    fusion_method: FUSION_STANDARD,
+    fusion_strength: 1.0,
+  },
+  Rebalance: {
+    tap_method: TAP_REBALANCE,
+    tap_profile: "classic",
+    tap_strength: 1.0,
+    tap_formula: "scale_around_1",
+    tap_normalization: "none",
+    projector_method: PROJECTOR_DONUT,
+    projector_profile: "off",
+    projector_strength: 1.0,
+    projector_formula: "scale_around_1",
+    projector_normalization: "none",
+    fusion_method: FUSION_STANDARD,
+    fusion_strength: 1.0,
+  },
+  Enhancer: {
+    tap_method: TAP_DONUT,
+    tap_profile: "off",
+    tap_strength: 1.0,
+    tap_formula: "scale_around_1",
+    tap_normalization: "tensor_rms",
+    projector_method: PROJECTOR_DONUT,
+    projector_profile: "off",
+    projector_strength: 1.0,
+    projector_formula: "scale_around_1",
+    projector_normalization: "none",
+    fusion_method: FUSION_ENHANCER,
+    fusion_strength: 1.0,
+  },
+  "Rebalance + Enhancer": {
+    tap_method: TAP_REBALANCE,
+    tap_profile: "classic",
+    tap_strength: 1.0,
+    tap_formula: "scale_around_1",
+    tap_normalization: "none",
+    projector_method: PROJECTOR_DONUT,
+    projector_profile: "off",
+    projector_strength: 1.0,
+    projector_formula: "scale_around_1",
+    projector_normalization: "none",
+    fusion_method: FUSION_ENHANCER,
+    fusion_strength: 1.0,
+  },
+  "Rebalance + Bypass 2": {
+    tap_method: TAP_REBALANCE,
+    tap_profile: "classic",
+    tap_strength: 1.0,
+    tap_formula: "scale_around_1",
+    tap_normalization: "none",
+    projector_method: PROJECTOR_BYPASS_2,
+    projector_profile: "off",
+    projector_strength: 1.0,
+    projector_formula: "scale_around_1",
+    projector_normalization: "none",
+    fusion_method: FUSION_STANDARD,
+    fusion_strength: 1.0,
+  },
+  "Rebalance + Bypass 3": {
+    tap_method: TAP_REBALANCE,
+    tap_profile: "classic",
+    tap_strength: 1.0,
+    tap_formula: "scale_around_1",
+    tap_normalization: "none",
+    projector_method: PROJECTOR_BYPASS_3,
+    projector_profile: "off",
+    projector_strength: 1.0,
+    projector_formula: "scale_around_1",
+    projector_normalization: "none",
+    fusion_method: FUSION_STANDARD,
+    fusion_strength: 1.0,
+  },
+  Balanced: {
+    tap_method: TAP_DONUT,
+    tap_profile: "classic",
+    tap_strength: 1.0,
+    tap_formula: "scale_around_1",
+    tap_normalization: "tensor_rms",
+    projector_method: PROJECTOR_DONUT,
+    projector_profile: "off",
+    projector_strength: 1.0,
+    projector_formula: "scale_around_1",
+    projector_normalization: "none",
+    fusion_method: FUSION_STANDARD,
+    fusion_strength: 1.0,
+  },
+  "Balanced + Enhancer": {
+    tap_method: TAP_DONUT,
+    tap_profile: "classic",
+    tap_strength: 1.0,
+    tap_formula: "scale_around_1",
+    tap_normalization: "tensor_rms",
+    projector_method: PROJECTOR_DONUT,
+    projector_profile: "off",
+    projector_strength: 1.0,
+    projector_formula: "scale_around_1",
+    projector_normalization: "none",
+    fusion_method: FUSION_ENHANCER,
+    fusion_strength: 1.0,
+  },
+  [TEACHERFIX]: {
+    tap_method: TAP_DONUT,
+    tap_profile: "off",
+    tap_strength: 1.0,
+    tap_formula: "scale_around_1",
+    tap_normalization: "tensor_rms",
+    projector_method: PROJECTOR_DONUT,
+    projector_profile: "off",
+    projector_strength: 1.0,
+    projector_formula: "scale_around_1",
+    projector_normalization: "none",
+    fusion_method: FUSION_STANDARD,
+    fusion_strength: 1.0,
+  },
 };
 
 const SIMPLE_PROJECTOR_STRENGTH = new Set([
-  "COPY settings: Krea2FilterBypass 2vector",
-  "COPY settings: Krea2FilterBypass 3vector",
-  "HYBRID settings: Rebalance + Krea2FilterBypass 2vector",
-  "HYBRID settings: Rebalance + Krea2FilterBypass 3vector",
+  "Bypass 2",
+  "Bypass 3",
+  "Rebalance + Bypass 2",
+  "Rebalance + Bypass 3",
 ]);
 
 const SIMPLE_FUSION_STRENGTH = new Set([
-  "COPY settings: capitan01R Krea2T-Enhancer defaults",
-  "HYBRID settings: Rebalance + Krea2T-Enhancer",
-  "DONUT settings: RMS-balanced classic + Krea2T-Enhancer",
+  "Enhancer",
+  "Rebalance + Enhancer",
+  "Balanced + Enhancer",
 ]);
 
 const ADVANCED_WIDGETS = [
@@ -59,6 +205,17 @@ const HIDDEN_PREFIX = "donuthidden-";
 
 function widget(node, name) {
   return node.widgets?.find((item) => item.name === name);
+}
+
+function simplifyPresetName(name) {
+  return LEGACY_TO_SIMPLE[name] ?? name;
+}
+
+function normalizePresetWidget(node) {
+  const preset = widget(node, "compatibility_preset");
+  if (!preset) return;
+  const simplified = simplifyPresetName(preset.value);
+  if (simplified !== preset.value) preset.value = simplified;
 }
 
 function hideWidget(item) {
@@ -86,6 +243,7 @@ function resize(node) {
 }
 
 function syncSimpleStrength(node, presetName = widget(node, "compatibility_preset")?.value) {
+  presetName = simplifyPresetName(presetName);
   const strength = Number(widget(node, "tap_strength")?.value ?? 1.0);
   if (!Number.isFinite(strength)) return;
 
@@ -99,12 +257,18 @@ function syncSimpleStrength(node, presetName = widget(node, "compatibility_prese
   }
 }
 
-function applyTeacherFixPreset(node) {
+function applySimplePreset(node, name) {
+  name = simplifyPresetName(name);
+  const values = SIMPLE_PRESETS[name];
+  if (!values) return;
+
   node._donutApplyingKrea2Preset = true;
   try {
-    for (const [name, value] of Object.entries(TEACHERFIX_VALUES)) {
-      const item = widget(node, name);
-      if (item) item.value = value;
+    for (const [widgetName, value] of Object.entries(values)) {
+      const item = widget(node, widgetName);
+      if (!item) continue;
+      item.value = value;
+      item.callback?.(value);
     }
   } finally {
     node._donutApplyingKrea2Preset = false;
@@ -112,6 +276,7 @@ function applyTeacherFixPreset(node) {
 }
 
 function updateModeVisibility(node) {
+  normalizePresetWidget(node);
   const mode = widget(node, "ui_mode")?.value ?? ADVANCED;
   if (mode === SIMPLE) {
     for (const name of ADVANCED_WIDGETS) {
@@ -129,7 +294,7 @@ function updateModeVisibility(node) {
   const projectorMethod = widget(node, "projector_method")?.value;
   const projectorProfile = widget(node, "projector_profile")?.value;
   const fusionMethod = widget(node, "fusion_method")?.value;
-  const preset = widget(node, "compatibility_preset")?.value;
+  const preset = simplifyPresetName(widget(node, "compatibility_preset")?.value);
 
   if (tapProfile !== "off") {
     visible.add("tap_strength");
@@ -139,8 +304,6 @@ function updateModeVisibility(node) {
       visible.add("tap_normalization");
     }
   }
-  // TeacherFix uses tap_strength as its LoRA strength even though its
-  // normal tap profile is intentionally off.
   if (preset === TEACHERFIX) visible.add("tap_strength");
 
   if (projectorMethod === PROJECTOR_DONUT) {
@@ -196,11 +359,13 @@ app.registerExtension({
         const previous = presetWidget.callback;
         presetWidget.callback = function (value) {
           const callbackResult = previous?.apply(this, arguments);
-          if (value === TEACHERFIX) applyTeacherFixPreset(node);
+          const simplified = simplifyPresetName(value);
+          applySimplePreset(node, simplified);
+          presetWidget.value = simplified;
           if (widget(node, "ui_mode")?.value === SIMPLE) {
             queueMicrotask(() => {
               if (widget(node, "ui_mode")?.value !== SIMPLE) return;
-              syncSimpleStrength(node, value);
+              syncSimpleStrength(node, simplified);
               updateModeVisibility(node);
             });
           }
@@ -212,13 +377,9 @@ app.registerExtension({
       if (tapStrengthWidget) {
         const previous = tapStrengthWidget.callback;
         tapStrengthWidget.callback = function (value) {
-          const presetBefore = presetWidget?.value;
+          const presetBefore = simplifyPresetName(presetWidget?.value);
           const callbackResult = previous?.apply(this, arguments);
           if (widget(node, "ui_mode")?.value === SIMPLE && presetBefore && presetBefore !== CUSTOM) {
-            // The legacy Advanced UI intentionally changes the preset label to
-            // Custom when any setting is edited. Restore it in a microtask so
-            // this remains correct regardless of extension registration order:
-            // an outer legacy callback may still run after this callback returns.
             queueMicrotask(() => {
               if (widget(node, "ui_mode")?.value !== SIMPLE) return;
               if (presetWidget) presetWidget.value = presetBefore;
@@ -238,6 +399,7 @@ app.registerExtension({
     const onConfigure = nodeType.prototype.onConfigure;
     nodeType.prototype.onConfigure = function () {
       const result = onConfigure?.apply(this, arguments);
+      normalizePresetWidget(this);
       if (widget(this, "ui_mode")?.value === SIMPLE) syncSimpleStrength(this);
       scheduleVisibility(this);
       return result;

--- a/web/donut_krea2_fusion_simple_mode.js
+++ b/web/donut_krea2_fusion_simple_mode.js
@@ -1,0 +1,240 @@
+import { app } from "../../scripts/app.js";
+
+const NODE_NAME = "DonutKrea2FusionControl";
+const SIMPLE = "Simple";
+const ADVANCED = "Advanced";
+const CUSTOM = "Custom settings";
+const TEACHERFIX = "DONUT settings: Krea2 C33 TeacherFix EMA5000";
+
+const TAP_DONUT = "Donut 12-tap gains";
+const PROJECTOR_DONUT = "Donut projector-input gains";
+const FUSION_ENHANCER = "capitan01R Krea2T-Enhancer operation";
+
+const TEACHERFIX_VALUES = {
+  tap_method: TAP_DONUT,
+  tap_profile: "off",
+  tap_strength: 1.0,
+  tap_formula: "scale_around_1",
+  tap_normalization: "tensor_rms",
+  projector_method: PROJECTOR_DONUT,
+  projector_profile: "off",
+  projector_strength: 1.0,
+  projector_formula: "scale_around_1",
+  projector_normalization: "none",
+  fusion_method: "Standard Krea2 fusion",
+  fusion_strength: 1.0,
+};
+
+const SIMPLE_PROJECTOR_STRENGTH = new Set([
+  "COPY settings: Krea2FilterBypass 2vector",
+  "COPY settings: Krea2FilterBypass 3vector",
+  "HYBRID settings: Rebalance + Krea2FilterBypass 2vector",
+  "HYBRID settings: Rebalance + Krea2FilterBypass 3vector",
+]);
+
+const SIMPLE_FUSION_STRENGTH = new Set([
+  "COPY settings: capitan01R Krea2T-Enhancer defaults",
+  "HYBRID settings: Rebalance + Krea2T-Enhancer",
+  "DONUT settings: RMS-balanced classic + Krea2T-Enhancer",
+]);
+
+const ADVANCED_WIDGETS = [
+  "tap_method",
+  "tap_profile",
+  "per_layer_weights",
+  "tap_strength",
+  "tap_formula",
+  "tap_normalization",
+  "projector_method",
+  "projector_profile",
+  "projector_layer_weights",
+  "projector_strength",
+  "projector_formula",
+  "projector_normalization",
+  "fusion_method",
+  "fusion_strength",
+];
+
+const HIDDEN_PREFIX = "donuthidden-";
+
+function widget(node, name) {
+  return node.widgets?.find((item) => item.name === name);
+}
+
+function hideWidget(item) {
+  if (!item || (typeof item.type === "string" && item.type.startsWith(HIDDEN_PREFIX))) return;
+  item._donutKrea2Type = item.type;
+  item._donutKrea2ComputeSize = item.computeSize;
+  item.type = HIDDEN_PREFIX + item.type;
+  item.computeSize = () => [0, -4];
+  item.hidden = true;
+}
+
+function showWidget(item) {
+  if (!item || typeof item.type !== "string" || !item.type.startsWith(HIDDEN_PREFIX)) return;
+  item.type = item._donutKrea2Type;
+  item.computeSize = item._donutKrea2ComputeSize;
+  item.hidden = false;
+  delete item._donutKrea2Type;
+  delete item._donutKrea2ComputeSize;
+}
+
+function resize(node) {
+  const size = node.computeSize();
+  node.setSize([Math.max(node.size[0], size[0]), size[1]]);
+  node.setDirtyCanvas?.(true, true);
+}
+
+function syncSimpleStrength(node, presetName = widget(node, "compatibility_preset")?.value) {
+  const strength = Number(widget(node, "tap_strength")?.value ?? 1.0);
+  if (!Number.isFinite(strength)) return;
+
+  if (SIMPLE_PROJECTOR_STRENGTH.has(presetName)) {
+    const projectorStrength = widget(node, "projector_strength");
+    if (projectorStrength) projectorStrength.value = strength;
+  }
+  if (SIMPLE_FUSION_STRENGTH.has(presetName)) {
+    const fusionStrength = widget(node, "fusion_strength");
+    if (fusionStrength) fusionStrength.value = strength;
+  }
+}
+
+function applyTeacherFixPreset(node) {
+  node._donutApplyingKrea2Preset = true;
+  try {
+    for (const [name, value] of Object.entries(TEACHERFIX_VALUES)) {
+      const item = widget(node, name);
+      if (item) item.value = value;
+    }
+  } finally {
+    node._donutApplyingKrea2Preset = false;
+  }
+}
+
+function updateModeVisibility(node) {
+  const mode = widget(node, "ui_mode")?.value ?? ADVANCED;
+  if (mode === SIMPLE) {
+    for (const name of ADVANCED_WIDGETS) {
+      const item = widget(node, name);
+      if (name === "tap_strength") showWidget(item);
+      else hideWidget(item);
+    }
+    resize(node);
+    return;
+  }
+
+  const visible = new Set(["tap_method", "tap_profile", "projector_method", "fusion_method"]);
+  const tapMethod = widget(node, "tap_method")?.value;
+  const tapProfile = widget(node, "tap_profile")?.value;
+  const projectorMethod = widget(node, "projector_method")?.value;
+  const projectorProfile = widget(node, "projector_profile")?.value;
+  const fusionMethod = widget(node, "fusion_method")?.value;
+  const preset = widget(node, "compatibility_preset")?.value;
+
+  if (tapProfile !== "off") {
+    visible.add("tap_strength");
+    visible.add("per_layer_weights");
+    if (tapMethod === TAP_DONUT) {
+      visible.add("tap_formula");
+      visible.add("tap_normalization");
+    }
+  }
+  // TeacherFix uses tap_strength as its bundled LoRA strength even though its
+  // normal tap profile is intentionally off.
+  if (preset === TEACHERFIX) visible.add("tap_strength");
+
+  if (projectorMethod === PROJECTOR_DONUT) {
+    visible.add("projector_profile");
+    if (projectorProfile !== "off") {
+      visible.add("projector_strength");
+      visible.add("projector_formula");
+      visible.add("projector_normalization");
+      visible.add("projector_layer_weights");
+    }
+  } else {
+    visible.add("projector_strength");
+  }
+
+  if (fusionMethod === FUSION_ENHANCER) visible.add("fusion_strength");
+
+  for (const name of ADVANCED_WIDGETS) {
+    const item = widget(node, name);
+    if (visible.has(name)) showWidget(item);
+    else hideWidget(item);
+  }
+  resize(node);
+}
+
+function scheduleVisibility(node) {
+  queueMicrotask(() => updateModeVisibility(node));
+}
+
+app.registerExtension({
+  name: "donut.krea2FusionControl.simpleModeTeacherFix",
+  beforeRegisterNodeDef(nodeType, nodeData) {
+    if (nodeData?.name !== NODE_NAME) return;
+
+    const onCreated = nodeType.prototype.onNodeCreated;
+    nodeType.prototype.onNodeCreated = function () {
+      const result = onCreated?.apply(this, arguments);
+      const node = this;
+      const modeWidget = widget(node, "ui_mode");
+      const presetWidget = widget(node, "compatibility_preset");
+      const tapStrengthWidget = widget(node, "tap_strength");
+
+      if (modeWidget) {
+        const previous = modeWidget.callback;
+        modeWidget.callback = function (value) {
+          const callbackResult = previous?.apply(this, arguments);
+          if (value === SIMPLE) syncSimpleStrength(node);
+          scheduleVisibility(node);
+          return callbackResult;
+        };
+      }
+
+      if (presetWidget) {
+        const previous = presetWidget.callback;
+        presetWidget.callback = function (value) {
+          const callbackResult = previous?.apply(this, arguments);
+          if (value === TEACHERFIX) applyTeacherFixPreset(node);
+          if (widget(node, "ui_mode")?.value === SIMPLE) syncSimpleStrength(node, value);
+          scheduleVisibility(node);
+          return callbackResult;
+        };
+      }
+
+      if (tapStrengthWidget) {
+        const previous = tapStrengthWidget.callback;
+        tapStrengthWidget.callback = function (value) {
+          const presetBefore = presetWidget?.value;
+          const callbackResult = previous?.apply(this, arguments);
+          if (widget(node, "ui_mode")?.value === SIMPLE && presetBefore && presetBefore !== CUSTOM) {
+            // The legacy Advanced UI intentionally changes the preset label to
+            // Custom when any setting is edited. Restore it in a microtask so
+            // this remains correct regardless of extension registration order:
+            // an outer legacy callback may still run after this callback returns.
+            queueMicrotask(() => {
+              if (widget(node, "ui_mode")?.value !== SIMPLE) return;
+              if (presetWidget) presetWidget.value = presetBefore;
+              syncSimpleStrength(node, presetBefore);
+              updateModeVisibility(node);
+            });
+          }
+          scheduleVisibility(node);
+          return callbackResult;
+        };
+      }
+
+      scheduleVisibility(node);
+      return result;
+    };
+
+    const onConfigure = nodeType.prototype.onConfigure;
+    nodeType.prototype.onConfigure = function () {
+      const result = onConfigure?.apply(this, arguments);
+      if (widget(this, "ui_mode")?.value === SIMPLE) syncSimpleStrength(this);
+      scheduleVisibility(this);
+      return result;
+    };
+  },
+});

--- a/web/donut_krea2_fusion_simple_mode.js
+++ b/web/donut_krea2_fusion_simple_mode.js
@@ -139,7 +139,7 @@ function updateModeVisibility(node) {
       visible.add("tap_normalization");
     }
   }
-  // TeacherFix uses tap_strength as its bundled LoRA strength even though its
+  // TeacherFix uses tap_strength as its LoRA strength even though its
   // normal tap profile is intentionally off.
   if (preset === TEACHERFIX) visible.add("tap_strength");
 
@@ -197,7 +197,13 @@ app.registerExtension({
         presetWidget.callback = function (value) {
           const callbackResult = previous?.apply(this, arguments);
           if (value === TEACHERFIX) applyTeacherFixPreset(node);
-          if (widget(node, "ui_mode")?.value === SIMPLE) syncSimpleStrength(node, value);
+          if (widget(node, "ui_mode")?.value === SIMPLE) {
+            queueMicrotask(() => {
+              if (widget(node, "ui_mode")?.value !== SIMPLE) return;
+              syncSimpleStrength(node, value);
+              updateModeVisibility(node);
+            });
+          }
           scheduleVisibility(node);
           return callbackResult;
         };


### PR DESCRIPTION
## Summary

- keeps the existing `DonutKrea2FusionControl` node ID; no second Text Fusion node is added
- adds `TeacherFix` as a real preset backed by the exact hash-verified Krea2 C33 TeacherFix EMA5000 LoRA
- auto-discovers the exact TeacherFix LoRA from `ComfyUI/models/loras` by file size + SHA-256, including renames/subfolders
- uses `tap_strength` as TeacherFix LoRA strength

## Preset names

Only the labels were simplified; the underlying preset behavior is unchanged:

- `Custom`
- `Bypass 2`
- `Bypass 3`
- `Rebalance`
- `Enhancer`
- `Rebalance + Enhancer`
- `Rebalance + Bypass 2`
- `Rebalance + Bypass 3`
- `Balanced`
- `Balanced + Enhancer`
- `TeacherFix`

Legacy long-form preset labels are still mapped to the same settings so older workflows remain compatible.

## Simple / Advanced mode

- adds one `ui_mode` toggle to the existing node
- **Simple**: only mode, preset, and `tap_strength` are visible
- **Advanced**: preserves the current full control surface and conditional visibility
- in Simple mode, `tap_strength` remains the one master strength control for presets that use projector/fusion strength

## Backward compatibility

- `Advanced` is the default
- `ui_mode` is appended after all legacy widgets so existing `widgets_values` positions are unchanged
- old long-form preset values are accepted and normalized to the short labels in the UI
- all existing preset implementations continue through the original backend unchanged

## TeacherFix validation

- exact uploaded file SHA-256: `db3c2b7612828120e7ef9cc8fe77124c6fd8de2e38f150599e62abd9695f6beb`
- requires all 33 text-fusion targets to map before applying
- isolated runtime validation previously confirmed 33/33 targets and strength propagation

The TeacherFix safetensors itself stays in the normal ComfyUI LoRA folder rather than being duplicated in the node pack; the preset finds the exact file automatically.