### PR TITLE
Fix UncensorFix Experimental merge bypass and add an Off preset

### DIFF
--- a/DonutKrea2FusionPreset.py
+++ b/DonutKrea2FusionPreset.py
@@ -6,6 +6,7 @@ folders, or downloads weights. All other presets delegate to the base node.
 """
 
 import math
+import uuid
 
 from . import DonutKrea2FusionControl as base
 
@@ -46,6 +47,7 @@ LEGACY_PRESET_TO_SIMPLE[LEGACY_TEACHERFIX] = PRESET_UNCENSORFIX
 LEGACY_PRESET_TO_SIMPLE[LEGACY_TEACHERFIX_SHORT] = PRESET_UNCENSORFIX
 
 UNCENSORFIX_TARGET_COUNT = 33
+_UNCENSORFIX_SOURCE_ID_PREFIX = "donut_uncensorfix_source_identity:"
 
 
 def _preset_combo_spec(spec, tooltip=None):
@@ -80,40 +82,99 @@ def _apply_uncensorfix(model, strength):
     if len(factors) != UNCENSORFIX_TARGET_COUNT or len(expected) != UNCENSORFIX_TARGET_COUNT:
         raise RuntimeError("UncensorFix requires exactly 33 unique embedded targets")
 
+    # Hard model2 swaps execute a retained source model, not the main model's
+    # patched weights. Resolve the same plan used by Donut save/extraction.
+    # In particular, do not test the truth value of the composable injection
+    # list: it deliberately reports False while containing live swap hooks.
+    from .donut_krea2_merge_serialization import (
+        KREA2_MERGE_INJECTION_KEY,
+        KREA2_MERGE_SOURCE_KEY,
+        get_krea2_merge_bypass_info,
+    )
+
+    merge_info = get_krea2_merge_bypass_info(model)
+    source_model, source_keys = None, set()
+    if merge_info is not None:
+        if KREA2_MERGE_INJECTION_KEY not in getattr(model, "injections", {}):
+            raise RuntimeError("UncensorFix found Krea2 swap plans without their runtime injection")
+        source_model, plans, _ = merge_info
+        source_keys = expected.intersection(key for _, key, _ in plans)
+
     model_state = model.model.state_dict()
+    source_state = source_model.model.state_dict() if source_keys else {}
     for key, up, down, alpha in factors:
-        weight = model_state.get(key)
+        state = source_state if key in source_keys else model_state
+        weight = state.get(key)
         if weight is None or tuple(weight.shape) != (up.shape[0], down.shape[1]):
+            owner = "merge-bypass model2" if key in source_keys else "main model"
             raise RuntimeError(
-                f"UncensorFix target missing or wrong shape: {key}. "
+                f"UncensorFix target missing or wrong shape on {owner}: {key}. "
                 "The input MODEL must be a compatible Krea 2 model."
             )
-    del model_state
+    del model_state, source_state
 
     # Fresh adapters/tensor copies isolate cached factors from other patches.
     patches = {
         key: LoRAAdapter(set(), (up.clone(), down.clone(), alpha, None, None, None))
         for key, up, down, alpha in factors
     }
+    main_patches = {key: patch for key, patch in patches.items() if key not in source_keys}
+    source_patches = {key: patches[key] for key in sorted(source_keys)}
     patched = model.clone()
-    loaded = patched.add_patches(patches, strength_patch=strength)
-    if set(loaded) != expected:
+    loaded = set()
+    if main_patches:
+        accepted = set(patched.add_patches(main_patches, strength_patch=strength))
+        if accepted != set(main_patches):
+            raise RuntimeError(
+                f"UncensorFix could not patch every target on main model: {len(accepted)}/{len(main_patches)} loaded"
+            )
+        loaded.update(accepted)
+
+    if source_patches:
+        # Never mutate model2 or replace its existing patch lists. Its cloned
+        # patch stack includes earlier LoRAs. The main model's runtime LoRA
+        # injections, merge plans, and other additional models remain intact.
+        source = source_model.clone()
+        accepted = set(source.add_patches(source_patches, strength_patch=strength))
+        if accepted != source_keys:
+            raise RuntimeError(
+                f"UncensorFix could not patch every target on merge-bypass model2: {len(accepted)}/{len(source_keys)} loaded"
+            )
+        loaded.update(accepted)
+        patched.set_additional_models(KREA2_MERGE_SOURCE_KEY, [source])
+
+        # ModelPatcher.clone_has_same_weights does not compare the contents of
+        # additional_models. It can also return True for two empty main patch
+        # stacks before checking patches_uuid. A fresh attachment KEY forces
+        # the outer swap injection to reload and resolve this cloned source.
+        patched.set_attachments(
+            _UNCENSORFIX_SOURCE_ID_PREFIX + uuid.uuid4().hex, tuple(sorted(source_keys))
+        )
+        patched.patches_uuid = uuid.uuid4()
+
+    if loaded != expected:
         raise RuntimeError(f"UncensorFix could not patch every target: {len(loaded)}/33 loaded")
-    return patched, len(loaded), "embedded"
+    source_details = "embedded"
+    if source_keys:
+        source_details += (
+            f"; uncensorfix_bypass_source_targets={len(source_keys)}"
+            f"; uncensorfix_model_targets={len(main_patches)}"
+        )
+    return patched, len(loaded), source_details
 
 
 def _rewrite_preset_diagnostics(diagnostics, legacy_name, simple_name):
     return str(diagnostics).replace(f"preset_label={legacy_name}", f"preset_label={simple_name}", 1)
 
 
-def _rewrite_uncensorfix_diagnostics(diagnostics, strength, loaded_count, relative_name):
+def _rewrite_uncensorfix_diagnostics(diagnostics, strength, loaded_count, source_details):
     diagnostics = str(diagnostics).replace(
         f"preset_label={base.PRESET_MANUAL}; preset_is_ui_only=true",
         f"preset_label={PRESET_UNCENSORFIX}; preset_is_ui_only=false", 1,
     )
     return diagnostics.replace(
         "external_files_loaded=none",
-        f"uncensorfix_source=embedded; uncensorfix_strength={float(strength):g}; "
+        f"uncensorfix_source={source_details}; uncensorfix_strength={float(strength):g}; "
         f"uncensorfix_targets={loaded_count}; external_files_loaded=none", 1,
     )
 
@@ -124,7 +185,8 @@ class DonutKrea2FusionControl(base.DonutKrea2FusionControl):
     DESCRIPTION = (
         "Krea 2 text-fusion controls with Simple/Advanced UI modes and short preset names. "
         "UncensorFix uses numerical factors embedded in Python; no external LoRA "
-        "installation, file selection or download is required."
+        "installation, file selection or download is required. Krea2 Experimental "
+        "merge-bypass targets are patched on their retained model2 source."
     )
 
     @classmethod
@@ -159,9 +221,9 @@ class DonutKrea2FusionControl(base.DonutKrea2FusionControl):
             delegated = dict(kwargs)
             delegated["compatibility_preset"] = base.PRESET_MANUAL
             result = list(super().apply(*args, **delegated))
-            patched_model, loaded_count, relative_name = _apply_uncensorfix(result[0], strength)
+            patched_model, loaded_count, source_details = _apply_uncensorfix(result[0], strength)
             result[0] = patched_model
-            result[-1] = _rewrite_uncensorfix_diagnostics(result[-1], strength, loaded_count, relative_name)
+            result[-1] = _rewrite_uncensorfix_diagnostics(result[-1], strength, loaded_count, source_details)
             return tuple(result)
 
         legacy_preset = SIMPLE_PRESET_TO_LEGACY.get(preset, preset)

--- a/DonutKrea2FusionPreset.py
+++ b/DonutKrea2FusionPreset.py
@@ -2,7 +2,8 @@
 
 The existing DonutKrea2FusionControl node ID is retained. UncensorFix uses numerical
 factors embedded in Python source. It never reads safetensors, searches LoRA
-folders, or downloads weights. All other presets delegate to the base node.
+folders, or downloads weights. Off is a pure pass-through; other presets delegate
+to the base node.
 """
 
 import math
@@ -15,6 +16,7 @@ UI_MODE_SIMPLE = "Simple"
 UI_MODE_ADVANCED = "Advanced"
 UI_MODES = (UI_MODE_SIMPLE, UI_MODE_ADVANCED)
 
+PRESET_OFF = "Off"
 PRESET_CUSTOM = "Custom"
 PRESET_BYPASS_2 = "Bypass 2"
 PRESET_BYPASS_3 = "Bypass 3"
@@ -41,7 +43,7 @@ SIMPLE_PRESET_TO_LEGACY = {
     PRESET_BALANCED: base.PRESET_DONUT_BALANCED,
     PRESET_BALANCED_ENHANCER: base.PRESET_DONUT_BALANCED_ENHANCER,
 }
-SIMPLE_PRESETS = tuple(SIMPLE_PRESET_TO_LEGACY) + (PRESET_UNCENSORFIX,)
+SIMPLE_PRESETS = (PRESET_OFF,) + tuple(SIMPLE_PRESET_TO_LEGACY) + (PRESET_UNCENSORFIX,)
 LEGACY_PRESET_TO_SIMPLE = {legacy: simple for simple, legacy in SIMPLE_PRESET_TO_LEGACY.items()}
 LEGACY_PRESET_TO_SIMPLE[LEGACY_TEACHERFIX] = PRESET_UNCENSORFIX
 LEGACY_PRESET_TO_SIMPLE[LEGACY_TEACHERFIX_SHORT] = PRESET_UNCENSORFIX
@@ -196,7 +198,8 @@ class DonutKrea2FusionControl(base.DonutKrea2FusionControl):
         required["compatibility_preset"] = _preset_combo_spec(
             required["compatibility_preset"],
             "Select a preset. UncensorFix uses embedded weights and stays selected when "
-            "its controls are edited. Select Custom or another preset to turn it off.",
+            "its controls are edited. Off passes the input model and conditioning through "
+            "unchanged, preserving upstream LoRAs and stored control values.",
         )
         spec = required["tap_strength"]
         settings = dict(spec[1]) if len(spec) > 1 and isinstance(spec[1], dict) else {}
@@ -216,6 +219,31 @@ class DonutKrea2FusionControl(base.DonutKrea2FusionControl):
         if ui_mode not in UI_MODES:
             raise ValueError(f"Unknown Krea2 Fusion UI mode: {ui_mode}")
         preset = kwargs.get("compatibility_preset", PRESET_CUSTOM)
+        if preset == PRESET_OFF:
+            # Do not call the base node: hidden tap/projector/fusion settings
+            # from the last active preset can still be non-neutral. Return the
+            # original objects, including upstream patches, injections and
+            # conditioning metadata. Off only disables this node's changes.
+            inputs = kwargs
+            if args:
+                # Preserve direct Python callers' legacy positional arguments
+                # without duplicating the base node's parameter order.
+                from inspect import signature
+                inputs = signature(super().apply).bind_partial(*args, **kwargs).arguments
+            conditionings = (
+                inputs["conditioning_in_1"],
+                inputs.get("conditioning_in_2"),
+                inputs.get("conditioning_in_3"),
+                inputs.get("conditioning_in_4"),
+            )
+            diagnostics = (
+                "preset_label=Off; preset_is_ui_only=false\n"
+                "fusion_control=off; uncensorfix_targets=0\n"
+                f"conditioning_routes={sum(value is not None for value in conditionings)}/4\n"
+                "external_files_loaded=none"
+            )
+            return (inputs["model"], *conditionings, diagnostics)
+
         if preset in (PRESET_UNCENSORFIX, LEGACY_TEACHERFIX, LEGACY_TEACHERFIX_SHORT):
             strength = float(kwargs.get("tap_strength", 1.0))
             delegated = dict(kwargs)

--- a/docs/teacherfix.md
+++ b/docs/teacherfix.md
@@ -35,7 +35,45 @@ and be accepted by `add_patches`. The input model is cloned, and fresh factor
 copies isolate the cached embedded tensors from downstream mutation.
 
 This requires the ComfyUI LoRAAdapter API used by current Krea2-capable versions.
-It is the ordinary weight-patch path, not Experimental bypass execution.
+Its factors still use ordinary weight-patch arithmetic. It now supports an
+upstream **Donut Model Merge Krea2 → Experimental bypass** automatically; it does
+not add a separate activation-side execution mode or a new node.
+
+## Experimental model-merge bypass
+
+Connect the merged MODEL (including any existing LoRA stack) to Fusion Control,
+select UncensorFix, and send Fusion Control's MODEL output to the sampler. No
+extra mode switch is needed in Fusion Control.
+
+Exact model2 swaps in the upstream merge execute retained model2 layers. For
+these targets, UncensorFix appends its adapters to a **clone of that source
+patcher**. Unswapped and partially blended targets stay on the main patcher.
+There is no patch applied to an unused model1 copy of a swapped target, and no
+extra copy of UncensorFix is added through a forward hook.
+
+Existing main/source patch stacks and runtime LoRA injections are preserved.
+Only the output model references the newly patched source. Source-only changes
+also invalidate the outer model's clone cache so a later run does not retain
+the old swap forward. The existing save/extract helpers see the same source
+patch stack, so the routed changes remain available for serialization.
+
+For a full 33-target text-fusion swap the diagnostics include:
+
+```text
+uncensorfix_source=embedded
+uncensorfix_bypass_source_targets=33
+uncensorfix_model_targets=0
+uncensorfix_targets=33
+```
+
+Mixed merges report the corresponding counts. Missing source/plan metadata or
+wrong target shapes raise an error instead of silently patching inactive
+weights. The original embedded data, strengths, and Simple/Advanced UI do not
+change. UncensorFix strength zero still performs no decoding or patching.
+
+Apply UncensorFix **after** a model merge to affect the resulting merged model.
+A later model merge can intentionally replace weights, including adapters
+applied before that merge. This fix does not override those merge semantics.
 
 ## Validation
 
@@ -43,6 +81,7 @@ Run from the node-pack root:
 
 ```sh
 python test_krea2_fusion_preset.py -v
+python test_uncensorfix_merge_bypass.py -v
 node --test tests/teacherfix_ui.test.mjs
 ```
 
@@ -71,3 +110,9 @@ The visible preset is **UncensorFix** and its data module is `uncensorfix_weight
 Saved workflows using either previous TeacherFix label are normalized to UncensorFix;
 the numerical data is unchanged. The existing documentation and test filenames are
 retained to avoid breaking links and test commands.
+
+The merge-bypass regression suite uses small CPU linear layers with the actual
+Donut merge-plan resolver and swap-injection implementation. ComfyUI's patcher,
+adapter, and injection-manager interfaces are test doubles. It checks forward
+outputs and save-state routing, not just accepted patch counts. It is not a
+full ComfyUI/GPU or quantized-checkpoint image-generation test.

--- a/docs/teacherfix.md
+++ b/docs/teacherfix.md
@@ -8,14 +8,29 @@ file picker, safetensors parser, LoRA-file loader, or runtime download.
 ## Use
 
 Select **UncensorFix**, then adjust `tap_strength`. Both Simple and Advanced mode
-keep UncensorFix selected during edits. Select Custom or another preset to turn
-it off. Strength zero skips the embedded patch and does not decode its data.
+keep UncensorFix selected during edits. Select **Off** for pass-through, or select another preset to change effects. Strength zero skips the embedded patch and does not decode its data.
 The existing short names, node ID and legacy widget order are retained.
 
 Selecting UncensorFix disables extra tap/projector profiles and selects standard
 fusion. Leave them that way for a comparison with ordinary LoRA application.
 Enabling extra Advanced controls intentionally combines their effects with the
 embedded UncensorFix patch. Do not also apply UncensorFix elsewhere in the chain.
+
+## Off preset
+
+**Off** disables this Fusion Control node's processing, independently of any
+stored tap, projector, enhancer or UncensorFix settings. The incoming MODEL and
+all four conditioning routes are returned as the exact same objects, including
+metadata and unused optional slots. No embedded weights are decoded, no model
+is cloned or patched, and no fusion wrapper or budget is added.
+
+Off does **not** remove upstream LoRAs, merges, runtime injections or UncensorFix
+applied by a different node. It only skips the changes this node would add.
+Stored control values are kept, and editing them or strength while Off is
+selected does not silently reactivate the node. Select an active preset to
+resume, or Custom to use the stored manual settings. Off is available in both
+Simple and Advanced modes; the existing Custom default and widget order stay
+unchanged. Diagnostics report `preset_label=Off` and `fusion_control=off`.
 
 ## Representation and execution
 
@@ -85,11 +100,11 @@ python test_uncensorfix_merge_bypass.py -v
 node --test tests/teacherfix_ui.test.mjs
 ```
 
-The Python suite has 20 CPU tests of the actual embedded data, including checksum,
+The preset Python suite has 26 CPU tests of the actual embedded data, including checksum,
 shape, rank/alpha, corruption handling, cloning, strength propagation, target
 validation, unchanged UI schema, and operation with safetensors, comfy.lora,
 comfy.utils and folder_paths imports blocked. ComfyUI model/base/adapter interfaces
-are test doubles. The 22 JavaScript tests execute the actual preset-label mutation
+are test doubles. The 30 JavaScript tests execute the actual preset-label mutation
 callback and both frontend extensions in both registration orders. They include
 legacy-label migration and Simple/Advanced strength edits in an isolated VM, not a full browser.
 
@@ -97,6 +112,11 @@ A separate local comparison against the private original checked all 99 tensor
 and alpha values and 66 full CPU weight/linear-output comparisons (33 targets at
 strengths 0.75 and 1.0) against the ordinary LoRA reference formula. All were
 bitwise equal. This was not a full ComfyUI/GPU image-generation A/B test.
+
+The Off regressions check exact model/conditioning identity, preservation of
+upstream patches and bypass forwards, no base fusion processing or embedded-data
+access, saved settings, switching modes/presets, and rapid selection while old
+strength callbacks are queued. The merge-bypass suite has 22 CPU tests.
 
 ## Distribution
 

--- a/test_krea2_fusion_preset.py
+++ b/test_krea2_fusion_preset.py
@@ -27,7 +27,7 @@ BASE_NAMES = {
     "PRESET_DONUT_BALANCED": "DONUT settings: RMS-balanced classic",
     "PRESET_DONUT_BALANCED_ENHANCER": "DONUT settings: RMS-balanced classic + Krea2T-Enhancer",
 }
-SHORT_NAMES = ["Custom", "Bypass 2", "Bypass 3", "Rebalance", "Enhancer",
+SHORT_NAMES = ["Off", "Custom", "Bypass 2", "Bypass 3", "Rebalance", "Enhancer",
                "Rebalance + Enhancer", "Rebalance + Bypass 2", "Rebalance + Bypass 3",
                "Balanced", "Balanced + Enhancer", "UncensorFix"]
 LEGACY_WIDGETS = ["model", "conditioning_in_1", "compatibility_preset", "tap_method",
@@ -169,6 +169,7 @@ class EmbeddedUncensorFixTests(unittest.TestCase):
         required = self.module.DonutKrea2FusionControl.INPUT_TYPES()["required"]
         self.assertEqual(list(required), LEGACY_WIDGETS + ["ui_mode"])
         self.assertEqual(required["compatibility_preset"][0], SHORT_NAMES)
+        self.assertEqual(required["compatibility_preset"][1]["default"], "Custom")
         self.assertEqual(required["ui_mode"][1]["default"], "Advanced")
         self.assertEqual(required["tap_strength"][1]["max"], 10.0)
         self.assertEqual(list(self.module.NODE_CLASS_MAPPINGS), ["DonutKrea2FusionControl"])
@@ -256,6 +257,86 @@ class EmbeddedUncensorFixTests(unittest.TestCase):
         with mock.patch.object(FakeModel, "add_patches", return_value=[f"wrong.{i}" for i in range(33)]):
             with self.assertRaisesRegex(RuntimeError, "could not patch every target"):
                 self.module._apply_uncensorfix(FakeModel(self.factors), 1.0)
+
+    def test_off_returns_all_inputs_by_identity_in_both_modes(self):
+        model = object()  # No cloning, state_dict or patch APIs required.
+        routes = ([[object(), {"nested": [1, 2]}]], [], None, [[object(), {}]])
+        for mode in ("Simple", "Advanced"):
+            with self.subTest(mode=mode):
+                result = self.module.DonutKrea2FusionControl().apply(
+                    model=model, compatibility_preset="Off", ui_mode=mode,
+                    **{f"conditioning_in_{i}": value for i, value in enumerate(routes, 1)})
+                self.assertEqual(len(result), 6)
+                for actual, expected in zip(result[:-1], (model, *routes)):
+                    self.assertIs(actual, expected)
+                self.assertIn("preset_label=Off; preset_is_ui_only=false", result[-1])
+                self.assertIn("fusion_control=off", result[-1])
+                self.assertIn("conditioning_routes=3/4", result[-1])
+                self.assertIn("uncensorfix_targets=0", result[-1])
+
+    def test_off_does_not_run_hidden_controls_or_decode_embedded_weights(self):
+        with (
+            mock.patch.object(self.module.base.DonutKrea2FusionControl, "apply",
+                              side_effect=AssertionError("base fusion executed")),
+            mock.patch.object(self.module, "_uncensorfix_factors",
+                              side_effect=AssertionError("embedded data decoded")),
+            mock.patch.object(self.module, "_apply_uncensorfix",
+                              side_effect=AssertionError("embedded patches applied")),
+        ):
+            model, conditioning = object(), object()
+            result = self.module.DonutKrea2FusionControl().apply(
+                model=model, conditioning_in_1=conditioning, compatibility_preset="Off",
+                tap_method=BASE_NAMES["PRESET_REBALANCE"], tap_profile="custom",
+                per_layer_weights="invalid dormant profile", tap_strength=3.,
+                projector_method="Krea2FilterBypass 3vector diff", projector_strength=2.,
+                fusion_method="capitan01R Krea2T-Enhancer operation", fusion_strength=2.)
+            self.assertIs(result[0], model)
+            self.assertIs(result[1], conditioning)
+            self.assertEqual(result[2:5], (None, None, None))
+
+    def test_off_is_safe_without_any_optional_conditioning(self):
+        result = self.module.DonutKrea2FusionControl().apply(
+            model=object(), conditioning_in_1=object(), compatibility_preset="Off")
+        self.assertEqual(result[2:5], (None, None, None))
+        self.assertIn("conditioning_routes=1/4", result[-1])
+
+    def test_off_preserves_upstream_model_state_without_mutation(self):
+        model = FakeModel(())
+        model.patches = {"existing": [object()]}
+        model.injections = {"runtime": [object()]}
+        model.additional_models = {"source": [object()]}
+        model.attachments = {"keep": object()}
+        model.model_options = {"transformer_options": {"upstream": object()}}
+        before = {key: value for key, value in vars(model).items()}
+        with mock.patch.object(model, "clone", side_effect=AssertionError("cloned")):
+            result = self.module.DonutKrea2FusionControl().apply(
+                model=model, conditioning_in_1=object(), compatibility_preset="Off")
+        self.assertIs(result[0], model)
+        for key, value in before.items():
+            self.assertIs(getattr(model, key), value)
+
+    def test_off_supports_legacy_positional_routes_without_running_base(self):
+        def base_apply(self, model, conditioning_in_1, ignored_control,
+                       conditioning_in_2=None, conditioning_in_3=None,
+                       conditioning_in_4=None, compatibility_preset="Custom settings"):
+            raise AssertionError("base called")
+        inputs = (object(), object(), "unused", object(), None, object())
+        with mock.patch.object(self.module.base.DonutKrea2FusionControl, "apply", base_apply):
+            result = self.module.DonutKrea2FusionControl().apply(
+                *inputs, compatibility_preset="Off")
+        for actual, expected in zip(result[:-1], (inputs[0], inputs[1], *inputs[3:])):
+            self.assertIs(actual, expected)
+
+    def test_switching_to_off_does_not_mutate_prior_uncensorfix_output(self):
+        model, cond = FakeModel(self.factors), object()
+        node = self.module.DonutKrea2FusionControl()
+        enabled = node.apply(model=model, conditioning_in_1=cond,
+                             compatibility_preset="UncensorFix", tap_strength=.75)
+        disabled = node.apply(model=model, conditioning_in_1=cond,
+                              compatibility_preset="Off", tap_strength=.75)
+        self.assertIs(disabled[0], model)
+        self.assertFalse(model.patches)
+        self.assertEqual(len(enabled[0].patches), 33)
 
     def test_invalid_ui_mode_rejected(self):
         with self.assertRaisesRegex(ValueError, "UI mode"):

--- a/test_uncensorfix_merge_bypass.py
+++ b/test_uncensorfix_merge_bypass.py
@@ -501,6 +501,17 @@ class MergeBypassTests(unittest.TestCase):
         self.assertFalse(source.patches)
         self.assertFalse(merged.patches)
 
+    def test_off_preserves_existing_merge_and_bypass_lora_forwards(self):
+        upstream = self.add_bypass(self.apply(self.merged(), .75))
+        before = self.outputs(upstream)
+        result = self.node.DonutKrea2FusionControl().apply(
+            model=upstream, conditioning_in_1=object(), compatibility_preset="Off",
+            tap_strength=3., fusion_strength=2., projector_strength=2.)
+        self.assertIs(result[0], upstream)
+        after = self.outputs(result[0])
+        for key in self.keys:
+            self.assertTrue(torch.equal(before[key], after[key]))
+
     def test_zero_strength_keeps_identity_and_does_not_inspect_bypass(self):
         merged = self.merged()
         merged.attachments.clear()  # Invalid metadata must not matter at zero.

--- a/test_uncensorfix_merge_bypass.py
+++ b/test_uncensorfix_merge_bypass.py
@@ -1,0 +1,515 @@
+"""Forward-output regressions for UncensorFix after Krea2 merge bypass.
+
+Uses the real Donut merge node, dynamic swap injection, plan resolver and save
+composition with small CPU Linear layers. ComfyUI patcher/adapter/manager APIs
+are explicit test doubles. This is not a quantized/GPU generation test.
+"""
+import contextlib
+import copy
+import importlib.util
+import io
+import sys
+import types
+import unittest
+import uuid
+from pathlib import Path
+from unittest import mock
+
+import torch
+import torch.nn.functional as F
+
+ROOT = Path(__file__).resolve().parent
+PREFIX = "diffusion_model."
+LORA_KEY = "donut_bypass_lora"
+
+
+def load_module(name, path):
+    spec = importlib.util.spec_from_file_location(name, path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+class Adapter:
+    def __init__(self, loaded_keys=(), weights=()):
+        self.loaded_keys, self.weights = set(loaded_keys), weights
+
+    def delta(self):
+        up, down, alpha, *_ = self.weights
+        return (up @ down) * (alpha / down.shape[0])
+
+    def bypass_forward(self, original, x, *args, **kwargs):
+        return original(x, *args, **kwargs) + F.linear(x, self.delta()) * self.multiplier
+
+
+class Injection:
+    def __init__(self, inject, eject):
+        self.inject, self.eject = inject, eject
+
+
+class Manager:
+    def __init__(self):
+        self.adapters, self.hooks = {}, []
+
+    def add_adapter(self, key, adapter, strength=1.0):
+        self.adapters[key.removesuffix(".weight")] = (adapter, strength)
+
+    def create_injections(self, root):
+        self.hooks = [(root.get_submodule(path), adapter, strength)
+                      for path, (adapter, strength) in self.adapters.items()]
+        originals = []
+
+        def inject(patcher):
+            for layer, adapter, strength in self.hooks:
+                original = layer.forward
+                originals.append((layer, original))
+                adapter.multiplier = strength
+                layer.forward = lambda x, *a, _p=adapter, _f=original, **kw: _p.bypass_forward(_f, x, *a, **kw)
+
+        def eject(patcher):
+            for layer, original in reversed(originals):
+                layer.forward = original
+            originals.clear()
+
+        return [Injection(inject, eject)]
+
+    def get_hook_count(self):
+        return len(self.hooks)
+
+
+class Patcher:
+    """Ordered patch lists and shared roots, rather than dict.update mocks."""
+    def __init__(self, root):
+        self.model = root
+        self.raw = {k: v.detach().clone() for k, v in root.state_dict().items()}
+        self.patches, self.injections, self.additional_models, self.attachments = {}, {}, {}, {}
+        self.model_options = {"transformer_options": {}}
+        self.patches_uuid = uuid.uuid4()
+        self.is_injected = False
+        self.load_device = torch.device("cpu")
+        self.reject = set()
+
+    def clone(self):
+        n = copy.copy(self)
+        n.patches = {k: list(v) for k, v in self.patches.items()}
+        n.injections = {k: v.copy() for k, v in self.injections.items()}
+        n.attachments = dict(self.attachments)
+        n.additional_models = {k: [p.clone() for p in v] for k, v in self.additional_models.items()}
+        n.model_options = copy.deepcopy(self.model_options)
+        n.is_injected = False
+        return n
+
+    def is_clone(self, other):
+        return self.model is other.model
+
+    def clone_has_same_weights(self, other):
+        # Cache-relevant subset of core ModelPatcher's comparison: it compares
+        # attachment/additional-model KEYS, not retained source patch contents.
+        if not self.is_clone(other) or self.attachments.keys() != other.attachments.keys():
+            return False
+        if self.additional_models.keys() != other.additional_models.keys():
+            return False
+        if self.injections.keys() != other.injections.keys():
+            return False
+        if not self.patches and not other.patches:
+            return True
+        return self.patches_uuid == other.patches_uuid and len(self.patches) == len(other.patches)
+
+    def add_patches(self, patches, strength_patch=1.0, strength_model=1.0):
+        accepted = set(patches).intersection(self.raw) - self.reject
+        for key in accepted:
+            self.patches.setdefault(key, []).append((strength_patch, patches[key], strength_model))
+        self.patches_uuid = uuid.uuid4()
+        return list(accepted)
+
+    def effective(self, key):
+        value = self.raw[key].clone()
+        for strength, patch, model_strength in self.patches.get(key, ()):
+            delta = patch.delta() if isinstance(patch, Adapter) else patch
+            value = value * model_strength + delta * strength
+        return value
+
+    def get_key_patches(self, prefix):
+        return {k: self.effective(k) for k in self.raw if k.startswith(prefix)}
+
+    def set_injections(self, key, value):
+        self.injections[key] = value
+
+    def remove_injections(self, key):
+        self.injections.pop(key, None)
+
+    def set_attachments(self, key, value):
+        self.attachments[key] = value
+
+    def remove_attachments(self, key):
+        self.attachments.pop(key, None)
+
+    def set_additional_models(self, key, value):
+        self.additional_models[key] = value
+
+    def get_additional_models_with_key(self, key):
+        return self.additional_models.get(key, [])
+
+    def remove_additional_models(self, key):
+        self.additional_models.pop(key, None)
+
+    def model_state_dict_for_saving(self, model, prefix):
+        return {k.removeprefix(prefix): self.effective(k) for k in self.raw if k.startswith(prefix)}
+
+    @contextlib.contextmanager
+    def activate(self):
+        # Minimal CPU load lifecycle: additional sources first, then ordered
+        # patches, then existing runtime injections. Always restore shared roots.
+        with contextlib.ExitStack() as stack:
+            for models in self.additional_models.values():
+                for model in models:
+                    stack.enter_context(model.activate())
+            saved = {k: v.clone() for k, v in self.model.state_dict().items()}
+            active = []
+            try:
+                with torch.no_grad():
+                    for key, value in self.model.state_dict().items():
+                        value.copy_(self.effective(key))
+                for injections in self.injections.values():
+                    for inj in injections:
+                        active.append(inj)
+                        inj.inject(self)
+                self.is_injected = bool(active)
+                yield
+            finally:
+                for inj in reversed(active):
+                    inj.eject(self)
+                self.is_injected = False
+                with torch.no_grad():
+                    for key, value in self.model.state_dict().items():
+                        value.copy_(saved[key])
+
+
+def make_root(keys, value):
+    root = torch.nn.Module()
+    for key in keys:
+        parts = key.removesuffix(".weight").split(".")
+        module = root
+        for i, part in enumerate(parts[:-1]):
+            if part.isdigit():
+                while len(module) <= int(part):
+                    module.append(torch.nn.Module())
+                module = module[int(part)]
+            else:
+                if not hasattr(module, part):
+                    child = torch.nn.ModuleList() if parts[i + 1].isdigit() else torch.nn.Module()
+                    module.add_module(part, child)
+                module = getattr(module, part)
+        layer = torch.nn.Linear(3, 2, bias=True)
+        with torch.no_grad():
+            layer.weight.fill_(value)
+            layer.bias.fill_(value / 10)
+        module.add_module(parts[-1], layer)
+    return root
+
+
+class MergeBypassTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        package_name = "_uncensorfix_merge_tests"
+        package = types.ModuleType(package_name)
+        package.__path__ = [str(ROOT)]
+        comfy = types.ModuleType("comfy")
+        comfy.__path__ = []
+        adapters = types.ModuleType("comfy.weight_adapter")
+        adapters.__path__ = []
+        adapters.WeightAdapterBase = Adapter
+        adapters.BypassInjectionManager = Manager
+        comfy.weight_adapter = adapters
+        lora = types.ModuleType("comfy.weight_adapter.lora")
+        lora.LoRAAdapter = Adapter
+        extension = types.ModuleType("comfy.patcher_extension")
+        extension.PatcherInjection = Injection
+        cls.modules = mock.patch.dict(sys.modules, {
+            package_name: package, "comfy": comfy, "comfy.weight_adapter": adapters,
+            "comfy.weight_adapter.lora": lora, "comfy.patcher_extension": extension,
+            "folder_paths": None, "comfy.lora": None, "safetensors": None,
+        })
+        cls.modules.start()
+        cls.addClassCleanup(cls.modules.stop)
+        # Reuse the original suite's tiny base-node definition only; import the
+        # real merge and serializer modules without importing pack __init__.
+        original_tests = load_module(package_name + ".original_tests", ROOT / "test_krea2_fusion_preset.py")
+        base = types.ModuleType(package_name + ".DonutKrea2FusionControl")
+        for key, value in original_tests.BASE_NAMES.items():
+            setattr(base, key, value)
+
+        class BaseNode:
+            def apply(self, **kwargs):
+                return (kwargs["model"], kwargs["conditioning_in_1"], None, None, None,
+                        "preset_label=Custom settings; preset_is_ui_only=true\nexternal_files_loaded=none")
+
+        base.DonutKrea2FusionControl = BaseNode
+        package.DonutKrea2FusionControl = base
+        sys.modules[base.__name__] = base
+        cls.node = load_module(package_name + ".DonutKrea2FusionPreset", ROOT / "DonutKrea2FusionPreset.py")
+        cls.merge = load_module(package_name + ".DonutModelMergeKrea2", ROOT / "DonutModelMergeKrea2.py")
+        cls.serialization = load_module(package_name + ".donut_krea2_merge_serialization", ROOT / "donut_krea2_merge_serialization.py")
+        weights = load_module(package_name + ".uncensorfix_weights", ROOT / "uncensorfix_weights.py")
+        cls.keys = tuple(target[0] for target in weights.TARGETS)
+        cls.factors = tuple((k, torch.full((2, 2), .02 + i / 1000),
+                            torch.full((2, 3), .1), 2.0) for i, k in enumerate(cls.keys))
+        cls.factor_patch = mock.patch.object(cls.node, "_uncensorfix_factors", return_value=cls.factors)
+        cls.factor_patch.start()
+        cls.addClassCleanup(cls.factor_patch.stop)
+        cls.x = torch.tensor([[.3, -.7, 1.1], [.4, .2, -.1]])
+
+    def models(self):
+        return Patcher(make_root(self.keys, .2)), Patcher(make_root(self.keys, .8))
+
+    def merged(self, base=None, source=None, ratios=None):
+        if base is None:
+            base, source = self.models()
+        ratios = ratios or {"first.": 1., "txtfusion.": 0.}
+        with contextlib.redirect_stdout(io.StringIO()):
+            result, = self.merge.DonutModelMergeKrea2().merge(base, source, "Experimental bypass", **ratios)
+        return result
+
+    def apply(self, model, strength=1.):
+        return self.node._apply_uncensorfix(model, strength)[0]
+
+    def outputs(self, model):
+        with model.activate():
+            return {key: model.model.get_submodule(key[:-7])(self.x).detach().clone() for key in self.keys}
+
+    def delta_outputs(self, strength=1.):
+        return {key: F.linear(self.x, up @ down * (alpha / down.shape[0])) * strength
+                for key, up, down, alpha in self.factors}
+
+    def assert_output_delta(self, before, after, strength=1.):
+        for key, delta in self.delta_outputs(strength).items():
+            torch.testing.assert_close(after[key], before[key] + delta, rtol=1e-5, atol=2e-7)
+            self.assertFalse(torch.equal(before[key], after[key]), key)
+
+    def add_bypass(self, model, strength=.35):
+        result = model.clone()
+        manager = Manager()
+        for key, up, down, alpha in self.factors:
+            manager.add_adapter(key, Adapter((), (up * 2, down, alpha, None, None, None)), strength)
+        result.set_injections(LORA_KEY, manager.create_injections(result.model))
+        return result
+
+    def test_reproduces_old_accepted_but_inactive_patches(self):
+        merged = self.merged()
+        wrong = merged.clone()
+        patches = {k: Adapter((), (up, down, a, None, None, None)) for k, up, down, a in self.factors}
+        self.assertEqual(len(wrong.add_patches(patches)), 33)
+        before, after = self.outputs(merged), self.outputs(wrong)
+        for key in self.keys:
+            self.assertTrue(torch.equal(before[key], after[key]))
+
+    def test_full_swap_routes_all_33_and_changes_real_forwards(self):
+        merged = self.merged()
+        self.assertFalse(bool(merged.injections[self.serialization.KREA2_MERGE_INJECTION_KEY]))
+        original_source = self.serialization.get_krea2_merge_bypass_info(merged)[0]
+        for strength in (.75, 1., -0.5, 2.):
+            with self.subTest(strength=strength):
+                patched, count, details = self.node._apply_uncensorfix(merged, strength)
+                source = self.serialization.get_krea2_merge_bypass_info(patched)[0]
+                self.assertEqual(count, 33)
+                self.assertEqual(set(source.patches), set(self.keys))
+                self.assertFalse(patched.patches)
+                self.assertFalse(merged.patches)
+                self.assertFalse(original_source.patches)
+                self.assertIsNot(source, original_source)
+                self.assertIn("uncensorfix_bypass_source_targets=33", details)
+                self.assert_output_delta(self.outputs(merged), self.outputs(patched), strength)
+
+    def test_partial_and_unswapped_targets_stay_on_main(self):
+        ratios = {"first.": 1., "txtfusion.layerwise_blocks.0.": 0.,
+                  "txtfusion.layerwise_blocks.1.": .4, "txtfusion.projector.": 0.}
+        merged = self.merged(ratios=ratios)
+        before = self.outputs(merged)
+        patched = self.apply(merged, .75)
+        source, plans, _ = self.serialization.get_krea2_merge_bypass_info(patched)
+        swapped = {key for _, key, _ in plans}
+        self.assertEqual(len(swapped), 9)
+        self.assertEqual(set(source.patches), swapped)
+        self.assertFalse(swapped.intersection(patched.patches))
+        self.assertEqual(set(patched.patches), set(merged.patches) | (set(self.keys) - swapped))
+        self.assert_output_delta(before, self.outputs(patched), .75)
+
+    def test_preserves_source_and_main_overlapping_regular_loras(self):
+        base, source = self.models()
+        existing = {k: Adapter((), (up * 3, down, a, None, None, None)) for k, up, down, a in self.factors}
+        base.add_patches(existing, .2)
+        source.add_patches(existing, .3)
+        merged = self.merged(base, source, {"first.": 1., "txtfusion.layerwise_blocks.0.": 0.})
+        patched = self.apply(merged)
+        routed = self.serialization.get_krea2_merge_bypass_info(patched)[0]
+        for key in self.keys:
+            self.assertEqual(len(base.patches[key]), 1)
+            self.assertEqual(len(source.patches[key]), 1)
+            self.assertGreaterEqual(len(patched.patches[key]), 1)
+            if key.startswith(PREFIX + "txtfusion.layerwise_blocks.0."):
+                self.assertEqual(len(routed.patches[key]), 2)
+                self.assertEqual(len(patched.patches[key]), 1)
+            else:
+                self.assertEqual(len(patched.patches[key]), 2)
+        self.assert_output_delta(self.outputs(merged), self.outputs(patched))
+
+    def test_prior_bypass_lora_survives_without_hook_replacement(self):
+        merged = self.merged()
+        lora_model = self.add_bypass(merged)
+        patched = self.apply(lora_model, .75)
+        self.assertEqual(patched.injections.keys(), lora_model.injections.keys())
+        self.assertIs(patched.injections[LORA_KEY][0], lora_model.injections[LORA_KEY][0])
+        self.assert_output_delta(self.outputs(lora_model), self.outputs(patched), .75)
+        self.assert_output_delta(self.outputs(merged), self.outputs(lora_model), .7)
+
+    def test_bypass_lora_added_after_uncensorfix_remains_additive(self):
+        patched = self.apply(self.merged(), .75)
+        later = self.add_bypass(patched)
+        self.assert_output_delta(self.outputs(patched), self.outputs(later), .7)
+
+    def test_bypass_lora_without_model_merge_keeps_normal_path(self):
+        base, _ = self.models()
+        lora_model = self.add_bypass(base)
+        patched = self.apply(lora_model)
+        self.assertEqual(set(patched.patches), set(self.keys))
+        self.assertEqual(patched.additional_models, {})
+        self.assert_output_delta(self.outputs(lora_model), self.outputs(patched))
+
+    def test_changed_source_invalidates_outer_empty_patch_cache(self):
+        merged = self.merged()
+        low, high = self.apply(merged, .5), self.apply(merged, 1.)
+        self.assertFalse(low.patches)
+        self.assertFalse(high.patches)
+        self.assertFalse(merged.clone_has_same_weights(low))
+        self.assertFalse(low.clone_has_same_weights(high))
+        self.assertTrue(high.clone_has_same_weights(high.clone()))
+        self.assertNotEqual(merged.patches_uuid, low.patches_uuid)
+        self.assert_output_delta(self.outputs(low), self.outputs(high), .5)
+        # Return to the old graph/source after executing both patched clones.
+        self.assert_output_delta(self.outputs(merged), self.outputs(low), .5)
+
+    def test_later_clone_resolves_its_own_source_at_injection_time(self):
+        patched = self.apply(self.merged(), .75)
+        clone = patched.clone()
+        self.assertIsNot(self.serialization.get_krea2_merge_bypass_info(patched)[0],
+                         self.serialization.get_krea2_merge_bypass_info(clone)[0])
+        a, b = self.outputs(patched), self.outputs(clone)
+        for key in self.keys:
+            self.assertTrue(torch.equal(a[key], b[key]))
+
+    def test_sequential_uncensorfix_nodes_append_once_each(self):
+        merged = self.merged()
+        first = self.apply(merged, .25)
+        second = self.apply(first, .75)
+        source = self.serialization.get_krea2_merge_bypass_info(second)[0]
+        self.assertTrue(all(len(v) == 2 for v in source.patches.values()))
+        self.assert_output_delta(self.outputs(merged), self.outputs(second))
+
+    def test_save_composition_sees_routed_weights_and_source_bias(self):
+        for ratios in ({"first.": 1., "txtfusion.": 0.},
+                       {"first.": 1., "txtfusion.layerwise_blocks.0.": 0., "txtfusion.projector.": .4}):
+            patched = self.apply(self.merged(ratios=ratios), .75)
+            info = self.serialization.get_krea2_merge_bypass_info(patched)
+            regular = self.serialization.clone_without_krea2_merge_runtime(patched, info)
+            sd, _, _ = self.serialization.compose_krea2_merge_unet_state_dict(regular, info[0], info[1])
+            live = self.outputs(patched)
+            for key in self.keys:
+                local = key.removeprefix(PREFIX)
+                expected = F.linear(self.x, sd[local], sd[local[:-6] + "bias"])
+                torch.testing.assert_close(live[key], expected)
+
+    def test_save_composition_keeps_overlapping_bypass_lora_and_uncensorfix(self):
+        merged = self.merged(ratios={"first.": 1., "txtfusion.layerwise_blocks.0.": 0.})
+        patched = self.apply(self.add_bypass(merged), .75)
+        source, plans, _ = self.serialization.get_krea2_merge_bypass_info(patched)
+        components = {key: [(Adapter((), (up * 2, down, a, None, None, None)), .35)]
+                      for key, up, down, a in self.factors}
+        # Same split as Donut's save path: main components stay on main;
+        # components on runtime-swapped targets are materialized on source.
+        regular = self.serialization.clone_without_krea2_merge_runtime(patched)
+        regular = self.serialization.clone_with_regular_components(regular, components)
+        source = self.serialization.clone_with_regular_components(
+            source, components, {key for _, key, _ in plans})
+        sd, _, _ = self.serialization.compose_krea2_merge_unet_state_dict(regular, source, plans)
+        live = self.outputs(patched)
+        for key in self.keys:
+            local = key.removeprefix(PREFIX)
+            expected = F.linear(self.x, sd[local], sd[local[:-6] + "bias"])
+            torch.testing.assert_close(live[key], expected)
+
+    def test_other_additional_models_and_attachments_are_preserved(self):
+        merged = self.merged()
+        other, _ = self.models()
+        merged.set_additional_models("other", [other])
+        merged.set_attachments("keep_me", "retained")
+        patched = self.apply(merged)
+        self.assertIs(patched.additional_models["other"][0].model, other.model)
+        self.assertEqual(patched.attachments["keep_me"], "retained")
+        self.assertEqual(merged.additional_models["other"], [other])
+
+    def test_diagnostics_report_main_and_bypass_target_counts(self):
+        result = self.node.DonutKrea2FusionControl().apply(
+            model=self.merged(), conditioning_in_1=object(),
+            compatibility_preset="UncensorFix", tap_strength=.75)
+        for text in ("uncensorfix_source=embedded", "uncensorfix_targets=33",
+                     "uncensorfix_bypass_source_targets=33", "uncensorfix_model_targets=0",
+                     "uncensorfix_strength=0.75", "external_files_loaded=none"):
+            self.assertIn(text, result[-1])
+
+    def test_missing_source_is_an_error_not_a_main_model_fallback(self):
+        merged = self.merged()
+        merged.remove_additional_models(self.serialization.KREA2_MERGE_SOURCE_KEY)
+        with self.assertRaisesRegex(RuntimeError, "source, found 0"):
+            self.apply(merged)
+
+    def test_missing_plan_is_an_error_even_with_falsey_injection_list(self):
+        merged = self.merged()
+        merged.attachments.clear()
+        with self.assertRaisesRegex(RuntimeError, "metadata is missing"):
+            self.apply(merged)
+
+    def test_orphaned_plan_is_not_routed_to_an_inactive_source(self):
+        merged = self.merged()
+        merged.injections.clear()
+        with self.assertRaisesRegex(RuntimeError, "without their runtime injection"):
+            self.apply(merged)
+
+    def test_missing_source_target_is_rejected_before_any_clone(self):
+        merged = self.merged()
+        source = self.serialization.get_krea2_merge_bypass_info(merged)[0]
+        with mock.patch.object(source.model, "state_dict", return_value={}):
+            with mock.patch.object(merged, "clone", side_effect=AssertionError("clone too soon")):
+                with self.assertRaisesRegex(RuntimeError, "merge-bypass model2"):
+                    self.apply(merged)
+
+    def test_wrong_source_shape_is_rejected(self):
+        merged = self.merged()
+        source = self.serialization.get_krea2_merge_bypass_info(merged)[0]
+        state = dict(source.model.state_dict())
+        state[self.keys[0]] = torch.zeros(1, 1)
+        with mock.patch.object(source.model, "state_dict", return_value=state):
+            with self.assertRaisesRegex(RuntimeError, "wrong shape on merge-bypass model2"):
+                self.apply(merged)
+
+    def test_partial_source_acceptance_is_rejected_and_input_is_unchanged(self):
+        merged = self.merged()
+        source = self.serialization.get_krea2_merge_bypass_info(merged)[0]
+        source.reject = {self.keys[0]}
+        with self.assertRaisesRegex(RuntimeError, "model2: 32/33"):
+            self.apply(merged)
+        self.assertFalse(source.patches)
+        self.assertFalse(merged.patches)
+
+    def test_zero_strength_keeps_identity_and_does_not_inspect_bypass(self):
+        merged = self.merged()
+        merged.attachments.clear()  # Invalid metadata must not matter at zero.
+        with mock.patch.object(self.node, "_uncensorfix_factors", side_effect=AssertionError("decoded")):
+            result, count, _ = self.node._apply_uncensorfix(merged, 0.)
+        self.assertIs(result, merged)
+        self.assertEqual(count, 0)
+
+
+if __name__ == "__main__":
+    torch.set_num_threads(1)
+    unittest.main()

--- a/tests/teacherfix_ui.test.mjs
+++ b/tests/teacherfix_ui.test.mjs
@@ -161,3 +161,57 @@ for (const reverse of [false, true]) {
     }
   }
 }
+
+// Off is a real runtime switch, not a numeric preset. Keep dormant settings
+// intact and never re-enable them as a side effect of an automatic label edit.
+for (const reverse of [false, true]) {
+  for (const mode of ["Simple", "Advanced"]) {
+    test(`Off pass-through selection: ${mode}, reverse=${reverse}`, () => {
+      const { node, flush } = makeCombinedNode("UncensorFix", mode, reverse);
+      edit(node, "compatibility_preset", "Rebalance + Enhancer");
+      flush();
+      const previousValues = settings.map(name => widget(node, name).value);
+      edit(node, "compatibility_preset", "Off");
+      flush();
+      assert.equal(widget(node, "compatibility_preset").value, "Off");
+      assert.deepEqual(settings.map(name => widget(node, name).value), previousValues);
+      for (const name of settings) {
+        edit(node, name, name.endsWith("profile") ? "classic" : 1);
+        assert.equal(widget(node, "compatibility_preset").value, "Off", name);
+        flush();
+        assert.equal(widget(node, "compatibility_preset").value, "Off", name);
+      }
+      const savedValues = settings.map(name => widget(node, name).value);
+      node.onConfigure();
+      flush();
+      assert.equal(widget(node, "compatibility_preset").value, "Off");
+      assert.deepEqual(settings.map(name => widget(node, name).value), savedValues);
+      edit(node, "compatibility_preset", "UncensorFix");
+      flush();
+      assert.equal(widget(node, "compatibility_preset").value, "UncensorFix");
+      assert.equal(widget(node, "tap_profile").value, "off");
+      edit(node, "tap_strength", .75);
+      flush();
+      assert.equal(widget(node, "compatibility_preset").value, "UncensorFix");
+      edit(node, "compatibility_preset", "Off");
+      flush();
+      edit(node, "compatibility_preset", "Custom");
+      flush();
+      assert.equal(widget(node, "compatibility_preset").value, "Custom");
+    });
+
+    test(`explicit selection wins over queued strength callbacks: ${mode}, reverse=${reverse}`, () => {
+      const { node, flush } = makeCombinedNode("UncensorFix", mode, reverse);
+      for (const [from, to] of [["UncensorFix", "Off"], ["Bypass 2", "Off"],
+        ["Off", "Custom"], ["Off", "UncensorFix"]]) {
+        edit(node, "compatibility_preset", from);
+        flush();
+        edit(node, "tap_strength", .75);
+        // Intentionally do not flush the old strength callback before selection.
+        edit(node, "compatibility_preset", to);
+        flush();
+        assert.equal(widget(node, "compatibility_preset").value, to);
+      }
+    });
+  }
+}

--- a/web/donut_krea2_fusion_control.js
+++ b/web/donut_krea2_fusion_control.js
@@ -2,6 +2,7 @@ import { app } from "../../scripts/app.js";
 
 const NODE_NAME = "DonutKrea2FusionControl";
 const CUSTOM = "Custom";
+const OFF = "Off";
 
 const TAP_DONUT = "Donut 12-tap gains";
 const TAP_REBALANCE = "nova452 Rebalance operation";
@@ -296,7 +297,10 @@ app.registerExtension({
           const uncensorFixActive = presetWidget?.value === "UncensorFix"
             || presetWidget?.value === "TeacherFix"
             || presetWidget?.value === "DONUT settings: Krea2 C33 TeacherFix EMA5000";
-          if (!node._donutApplyingKrea2Preset && presetWidget && !uncensorFixActive) {
+          // Off must stay off when dormant settings/strength are edited;
+          // otherwise the automatic Custom label would enable them again.
+          const offActive = presetWidget?.value === OFF;
+          if (!node._donutApplyingKrea2Preset && presetWidget && !uncensorFixActive && !offActive) {
             presetWidget.value = CUSTOM;
           }
           updateVisibility(node);

--- a/web/donut_krea2_fusion_simple_mode.js
+++ b/web/donut_krea2_fusion_simple_mode.js
@@ -359,6 +359,10 @@ app.registerExtension({
       if (presetWidget) {
         const previous = presetWidget.callback;
         presetWidget.callback = function (value) {
+          // A queued strength callback from an earlier selection must not
+          // restore that preset after the user explicitly selects Off/Custom.
+          const selectionVersion = (node._donutKrea2PresetSelectionVersion ?? 0) + 1;
+          node._donutKrea2PresetSelectionVersion = selectionVersion;
           const callbackResult = previous?.apply(this, arguments);
           const simplified = simplifyPresetName(value);
           applySimplePreset(node, simplified);
@@ -366,6 +370,7 @@ app.registerExtension({
           if (widget(node, "ui_mode")?.value === SIMPLE) {
             queueMicrotask(() => {
               if (widget(node, "ui_mode")?.value !== SIMPLE) return;
+              if (node._donutKrea2PresetSelectionVersion !== selectionVersion) return;
               syncSimpleStrength(node, simplified);
               updateModeVisibility(node);
             });
@@ -379,10 +384,12 @@ app.registerExtension({
         const previous = tapStrengthWidget.callback;
         tapStrengthWidget.callback = function (value) {
           const presetBefore = simplifyPresetName(presetWidget?.value);
+          const selectionVersion = node._donutKrea2PresetSelectionVersion ?? 0;
           const callbackResult = previous?.apply(this, arguments);
           if (widget(node, "ui_mode")?.value === SIMPLE && presetBefore && presetBefore !== CUSTOM) {
             queueMicrotask(() => {
               if (widget(node, "ui_mode")?.value !== SIMPLE) return;
+              if ((node._donutKrea2PresetSelectionVersion ?? 0) !== selectionVersion) return;
               if (presetWidget) presetWidget.value = presetBefore;
               syncSimpleStrength(node, presetBefore);
               updateModeVisibility(node);


### PR DESCRIPTION
## Experimental merge-bypass fix

UncensorFix previously registered all 33 patches on the main model even when Donut Model Merge Krea2's **Experimental bypass** executed retained model2 layers instead. The accepted-patch count could therefore report success while the swapped layers ignored the update.

This PR resolves the existing merge plan and patches the model that actually executes:

- Exact model2-swapped targets receive adapters on a **clone of the retained source patcher**. Unswapped and partially blended targets remain on the main patcher.
- Existing main/source LoRA patch lists, merge plans, runtime LoRA injections and unrelated additional models are preserved. No injection manager is replaced and no adapter is applied twice.
- Source-only updates receive a fresh outer attachment key and patch UUID so the clone cache cannot reuse the old swap source after a strength change.
- Missing source/plan metadata, wrong target shapes or incomplete patch acceptance raise an error rather than silently patching inactive weights.
- The existing save composition sees the same updated source patch stack.

Keep **Experimental bypass** selected on **Donut Model Merge Krea2**, connect its resulting MODEL (including an existing LoRA stack) to **Fusion Control → UncensorFix**, and use Fusion Control's MODEL output for sampling. Routing is automatic. This supports the upstream **model-merge bypass**; it does not introduce a separate activation-side execution mode for UncensorFix. Apply UncensorFix after the merge to affect the final merged model.

Full text-fusion swaps report `uncensorfix_bypass_source_targets=33`, `uncensorfix_model_targets=0`, and `uncensorfix_targets=33`.

## New Off preset

As additionally requested, the same PR now adds **Off** to the existing preset dropdown in both Simple and Advanced modes.

- True pass-through: the original MODEL and all four conditioning routes are returned by identity, including metadata and absent optional routes.
- No base fusion processing, tap/projector/enhancer changes, embedded-data decoding, new patches, wrappers or fusion budget—even if stored settings are non-neutral.
- Upstream LoRAs, merges and runtime injections remain untouched. Off disables only the changes this Fusion Control node would add.
- Stored settings are retained. Editing strength or dormant settings keeps Off selected rather than silently enabling Custom.
- An explicit preset selection wins over previously queued strength callbacks, preventing a stale callback from undoing Off or Custom.
- The existing Custom default, node ID, widget order and other preset behavior remain unchanged.

Off diagnostics include `preset_label=Off`, `fusion_control=off`, `uncensorfix_targets=0`, and `external_files_loaded=none`.

## Validation performed on the committed file contents

```sh
python test_krea2_fusion_preset.py -v       # 26 passed
python test_uncensorfix_merge_bypass.py -v # 22 passed
node --test tests/teacherfix_ui.test.mjs   # 30 passed
```

Python compilation and both frontend JavaScript syntax checks also pass. Uploaded Git blob hashes were checked against the tested local files.

The merge regressions reproduce the old accepted-but-inactive failure, then check CPU Linear forward outputs using the real Donut merge node, dynamic swap implementation and serialization helpers. Coverage includes full/mixed/partial swaps, overlapping ordinary and bypass LoRAs, source-only cache invalidation, later clones, sequential updates and save-state equivalence. Off regressions additionally cover object identity, no processing/decoding, preserved upstream bypass outputs, settings retention, saved-state configuration and rapid selection in both frontend registration orders and UI modes.

**Test boundary:** ComfyUI patcher, adapter, base-node and injection-manager APIs are explicit test doubles. Merge forward tests use small synthetic tensors on the canonical target names; the preset suite separately exercises the real embedded data. These are isolated CPU/JavaScript VM checks, not a full ComfyUI/GPU or quantized-checkpoint generation test.

**All changes are committed.** `uncensorfix_weights.py` is unchanged and already exists on main. No additional weight uploads, original safetensors files, new nodes or separate installation steps are needed beyond merging/updating the node pack.