### PR TITLE
Fix UncensorFix LoRA parity with Donut Apply and preserve Off passthrough

### DIFF
--- a/DonutKrea2FusionPreset.py
+++ b/DonutKrea2FusionPreset.py
@@ -49,6 +49,10 @@ LEGACY_PRESET_TO_SIMPLE[LEGACY_TEACHERFIX] = PRESET_UNCENSORFIX
 LEGACY_PRESET_TO_SIMPLE[LEGACY_TEACHERFIX_SHORT] = PRESET_UNCENSORFIX
 
 UNCENSORFIX_TARGET_COUNT = 33
+UNCENSORFIX_LORA_ONLY = "LoRA only"
+UNCENSORFIX_WITH_CONTROLS = "LoRA + fusion controls"
+UNCENSORFIX_CONTROL_MODES = (UNCENSORFIX_LORA_ONLY, UNCENSORFIX_WITH_CONTROLS)
+UNCENSORFIX_EXECUTION_MODES = ("Comfy patches", "Experimental bypass")
 _UNCENSORFIX_SOURCE_ID_PREFIX = "donut_uncensorfix_source_identity:"
 
 
@@ -66,17 +70,19 @@ def _uncensorfix_factors():
     return get_uncensorfix_factors()
 
 
-def _apply_uncensorfix(model, strength):
-    """Construct model patches from embedded tensors, without any LoRA loader."""
+def _apply_uncensorfix(model, strength, execution_mode="Comfy patches"):
+    """Apply embedded factors using the selected Donut LoRA execution path."""
+    if execution_mode not in UNCENSORFIX_EXECUTION_MODES:
+        raise ValueError(f"Unknown UncensorFix execution mode: {execution_mode}")
     strength = float(strength)
     if not math.isfinite(strength):
         raise ValueError("UncensorFix strength must be finite")
     if strength == 0.0:
         return model, 0, "embedded (strength 0)"
 
-    # Use the same weight arithmetic as ComfyUI's ordinary patch route, but
-    # construct adapters directly. No load_lora, load_torch_file, key-map scan,
-    # safetensors parser, or external asset is involved.
+    # Native mode constructs the same adapters as Comfy's LoRA loader. Bypass
+    # mode hands an in-memory state dict to Donut Apply's shared execution
+    # helper. Neither mode reads a LoRA file or changes the cached factors.
     from comfy.weight_adapter.lora import LoRAAdapter
 
     factors = _uncensorfix_factors()
@@ -125,7 +131,12 @@ def _apply_uncensorfix(model, strength):
     patched = model.clone()
     loaded = set()
     if main_patches:
-        accepted = set(patched.add_patches(main_patches, strength_patch=strength))
+        if execution_mode == "Experimental bypass":
+            from .donut_uncensorfix_lora import apply_embedded_bypass
+            patched = apply_embedded_bypass(model, main_patches, strength)
+            accepted = set(main_patches)
+        else:
+            accepted = set(patched.add_patches(main_patches, strength_patch=strength))
         if accepted != set(main_patches):
             raise RuntimeError(
                 f"UncensorFix could not patch every target on main model: {len(accepted)}/{len(main_patches)} loaded"
@@ -136,8 +147,13 @@ def _apply_uncensorfix(model, strength):
         # Never mutate model2 or replace its existing patch lists. Its cloned
         # patch stack includes earlier LoRAs. The main model's runtime LoRA
         # injections, merge plans, and other additional models remain intact.
-        source = source_model.clone()
-        accepted = set(source.add_patches(source_patches, strength_patch=strength))
+        if execution_mode == "Experimental bypass":
+            from .donut_uncensorfix_lora import apply_embedded_bypass
+            source = apply_embedded_bypass(source_model, source_patches, strength)
+            accepted = set(source_patches)
+        else:
+            source = source_model.clone()
+            accepted = set(source.add_patches(source_patches, strength_patch=strength))
         if accepted != source_keys:
             raise RuntimeError(
                 f"UncensorFix could not patch every target on merge-bypass model2: {len(accepted)}/{len(source_keys)} loaded"
@@ -188,7 +204,9 @@ class DonutKrea2FusionControl(base.DonutKrea2FusionControl):
         "Krea 2 text-fusion controls with Simple/Advanced UI modes and short preset names. "
         "UncensorFix uses numerical factors embedded in Python; no external LoRA "
         "installation, file selection or download is required. Krea2 Experimental "
-        "merge-bypass targets are patched on their retained model2 source."
+        "merge-bypass targets are patched on their retained model2 source. "
+        "LoRA only ignores this node's stored fusion controls. Match execution_mode "
+        "and Donut Apply's text_weight for an equivalent LoRA comparison."
     )
 
     @classmethod
@@ -211,13 +229,36 @@ class DonutKrea2FusionControl(base.DonutKrea2FusionControl):
         # Append only: do not shift saved workflows' legacy widget positions.
         required["ui_mode"] = (list(UI_MODES), {
             "default": UI_MODE_ADVANCED,
-            "tooltip": "Simple shows mode, preset and tap_strength. Advanced restores the full controls.",
+            "tooltip": "Simple hides individual fusion controls. UncensorFix composition and execution remain explicit.",
         })
-        return {**schema, "required": required}
+        # Optional, appended widgets preserve old workflow widget indices.
+        optional = dict(schema.get("optional", {}))
+        optional["uncensorfix_controls"] = (list(UNCENSORFIX_CONTROL_MODES), {
+            "default": UNCENSORFIX_LORA_ONLY,
+            "tooltip": "UncensorFix only: LoRA only leaves conditioning and upstream controls untouched. "
+                       "Select LoRA + fusion controls to deliberately combine the Advanced settings.",
+        })
+        optional["execution_mode"] = (list(UNCENSORFIX_EXECUTION_MODES), {
+            "default": "Comfy patches",
+            "tooltip": "UncensorFix only: match Donut Apply LoRA Stack's execution_mode. "
+                       "Experimental bypass reuses its forward-adapter path and compatibility fallbacks. "
+                       "The two execution modes are not numerically interchangeable, especially with quantization.",
+        })
+        return {**schema, "required": required, "optional": optional}
 
-    def apply(self, *args, ui_mode=UI_MODE_ADVANCED, **kwargs):
+    def apply(
+        self, *args, ui_mode=UI_MODE_ADVANCED,
+        uncensorfix_controls=UNCENSORFIX_LORA_ONLY,
+        execution_mode="Comfy patches", **kwargs,
+    ):
         if ui_mode not in UI_MODES:
             raise ValueError(f"Unknown Krea2 Fusion UI mode: {ui_mode}")
+        if args:
+            # Resolve ALL legacy positional inputs before inspecting preset or
+            # strength, not only conditioning routes in the Off branch.
+            from inspect import signature
+            kwargs = signature(super().apply).bind_partial(*args, **kwargs).arguments
+            args = ()
         preset = kwargs.get("compatibility_preset", PRESET_CUSTOM)
         if preset == PRESET_OFF:
             # Do not call the base node: hidden tap/projector/fusion settings
@@ -225,11 +266,6 @@ class DonutKrea2FusionControl(base.DonutKrea2FusionControl):
             # original objects, including upstream patches, injections and
             # conditioning metadata. Off only disables this node's changes.
             inputs = kwargs
-            if args:
-                # Preserve direct Python callers' legacy positional arguments
-                # without duplicating the base node's parameter order.
-                from inspect import signature
-                inputs = signature(super().apply).bind_partial(*args, **kwargs).arguments
             conditionings = (
                 inputs["conditioning_in_1"],
                 inputs.get("conditioning_in_2"),
@@ -245,13 +281,35 @@ class DonutKrea2FusionControl(base.DonutKrea2FusionControl):
             return (inputs["model"], *conditionings, diagnostics)
 
         if preset in (PRESET_UNCENSORFIX, LEGACY_TEACHERFIX, LEGACY_TEACHERFIX_SHORT):
+            if uncensorfix_controls not in UNCENSORFIX_CONTROL_MODES:
+                raise ValueError(f"Unknown UncensorFix controls mode: {uncensorfix_controls}")
             strength = float(kwargs.get("tap_strength", 1.0))
-            delegated = dict(kwargs)
-            delegated["compatibility_preset"] = base.PRESET_MANUAL
-            result = list(super().apply(*args, **delegated))
-            patched_model, loaded_count, source_details = _apply_uncensorfix(result[0], strength)
+            if uncensorfix_controls == UNCENSORFIX_LORA_ONLY:
+                # Enforce parity server-side, including API workflows and
+                # stale/hidden widget values. Do not depend on JS resetting
+                # controls and do not clear any upstream wrappers or patches.
+                conditionings = tuple(kwargs.get(f"conditioning_in_{i}") for i in range(1, 5))
+                diagnostics = (
+                    f"preset_label={base.PRESET_MANUAL}; preset_is_ui_only=true\n"
+                    "fusion_control=lora_only; conditioning=unchanged\n"
+                    f"conditioning_routes={sum(value is not None for value in conditionings)}/4\n"
+                    "external_files_loaded=none"
+                )
+                result = [kwargs["model"], *conditionings, diagnostics]
+            else:
+                delegated = dict(kwargs)
+                delegated["compatibility_preset"] = base.PRESET_MANUAL
+                result = list(super().apply(*args, **delegated))
+            patched_model, loaded_count, source_details = _apply_uncensorfix(
+                result[0], strength, execution_mode=execution_mode,
+            )
             result[0] = patched_model
             result[-1] = _rewrite_uncensorfix_diagnostics(result[-1], strength, loaded_count, source_details)
+            result[-1] += (
+                f"\nuncensorfix_controls={uncensorfix_controls}; "
+                f"uncensorfix_execution_mode={execution_mode}; "
+                f"reference_text_weight={strength:g}"
+            )
             return tuple(result)
 
         legacy_preset = SIMPLE_PRESET_TO_LEGACY.get(preset, preset)

--- a/docs/teacherfix.md
+++ b/docs/teacherfix.md
@@ -1,138 +1,169 @@
 # Embedded UncensorFix preset
 
 UncensorFix lives in the existing Donut Krea2 Fusion Control node. Its numerical
-factor tensors are embedded in `uncensorfix_weights.py`. The original safetensors
-file and its metadata are not included. There is no separate asset, file lookup,
-file picker, safetensors parser, LoRA-file loader, or runtime download.
+factors remain in `uncensorfix_weights.py`; no original safetensors file, source
+checkpoint metadata, weight-file lookup, file picker or runtime download is
+required. The embedded numerical data is unchanged by the execution-mode update.
 
-## Use
+## Compare with Donut Apply LoRA Stack
 
-Select **UncensorFix**, then adjust `tap_strength`. Both Simple and Advanced mode
-keep UncensorFix selected during edits. Select **Off** for pass-through, or select another preset to change effects. Strength zero skips the embedded patch and does not decode its data.
-The existing short names, node ID and legacy widget order are retained.
+Use the same incoming MODEL, conditioning, upstream patches, sampler settings
+and seed on both branches. Do not apply this LoRA twice.
 
-Selecting UncensorFix disables extra tap/projector profiles and selects standard
-fusion. Leave them that way for a comparison with ordinary LoRA application.
-Enabling extra Advanced controls intentionally combines their effects with the
-embedded UncensorFix patch. Do not also apply UncensorFix elsewhere in the chain.
+| Setting | Fusion Control branch | Donut Apply branch |
+| --- | --- | --- |
+| Preset | UncensorFix | Fusion Control Off, or omit Fusion Control |
+| UncensorFix controls | LoRA only | No additional fusion-control changes |
+| Strength | `tap_strength = s` | This LoRA's `text_weight = s` |
+| Execution | `execution_mode = Comfy patches` | `execution_mode = Comfy patches` |
+| Safety | No automatic attenuation | `safe_stack = Off`, `fusion_aware = Off` |
+
+For an Experimental bypass comparison, select **Experimental bypass on both
+branches**, not on just the Donut Apply node. This is the LoRA execution mode,
+not Donut Model Merge Krea2's separate Experimental bypass setting.
+
+All 33 targets in this LoRA are diffusion-side `txtfusion` weights. Donut Apply
+routes them through `text_weight` (the stack's `clip_weight`/`cw` field), not its
+main `model_weight`. This does not patch a separate CLIP encoder. A nonzero main
+model weight with text weight zero is therefore not an equivalent comparison.
+
+**Comfy patches and Experimental bypass are not numerically interchangeable.**
+Native execution patches model weights. Bypass keeps the base forward and adds
+a separately evaluated low-rank contribution, using Donut Apply's own helper.
+Rounding and quantization can distinguish these computations even with identical
+factors. The shared helper retains Donut Apply's conservative regular-patch
+fallbacks for unsupported targets and existing runtime injections; check the
+console for those fallback messages. Diagnostics report the requested mode.
+
+## LoRA-only and combined controls
+
+`uncensorfix_controls` defaults to **LoRA only** in both UI modes. The backend
+skips this node's tap gains, projector changes, enhancer, wrapper registration
+and fusion-budget publication, even when hidden or restored widget values are
+non-neutral. All four incoming conditioning routes are returned by identity.
+Existing upstream controls and patches are preserved, not cleared.
+
+This backend behavior also covers API workflows: it does not rely on frontend
+preset callbacks resetting controls. Strength zero in LoRA-only mode returns
+the original MODEL and conditioning without decoding the embedded payload.
+
+Select **LoRA + fusion controls** to intentionally combine UncensorFix with the
+Advanced settings. That combination is not equivalent to applying the LoRA
+alone. **Migration:** older workflows that intentionally combined Advanced
+controls with UncensorFix must select this option to retain that combination.
+Stored control values are not erased. Selecting or editing these options does
+not require renaming the active preset to Custom.
+
+Both comparison options are appended as optional widgets, leaving legacy
+widget indices and the node ID intact. They remain explicit in both Simple and
+Advanced mode. Existing TeacherFix preset labels are still accepted.
+
+Diagnostics include, for example:
+
+```text
+preset_label=UncensorFix; preset_is_ui_only=false
+fusion_control=lora_only; conditioning=unchanged
+uncensorfix_source=embedded; uncensorfix_strength=0.75; uncensorfix_targets=33
+uncensorfix_controls=LoRA only; uncensorfix_execution_mode=Comfy patches; reference_text_weight=0.75
+```
 
 ## Off preset
 
-**Off** disables this Fusion Control node's processing, independently of any
-stored tap, projector, enhancer or UncensorFix settings. The incoming MODEL and
-all four conditioning routes are returned as the exact same objects, including
-metadata and unused optional slots. No embedded weights are decoded, no model
-is cloned or patched, and no fusion wrapper or budget is added.
+**Off** returns the incoming MODEL and all four conditioning routes as the exact
+same objects. No model is cloned, no embedded data is decoded, and no patches,
+wrappers or fusion budget are added. Stored settings remain dormant.
 
-Off does **not** remove upstream LoRAs, merges, runtime injections or UncensorFix
-applied by a different node. It only skips the changes this node would add.
-Stored control values are kept, and editing them or strength while Off is
-selected does not silently reactivate the node. Select an active preset to
-resume, or Custom to use the stored manual settings. Off is available in both
-Simple and Advanced modes; the existing Custom default and widget order stay
-unchanged. Diagnostics report `preset_label=Off` and `fusion_control=off`.
+Off does **not** remove upstream LoRAs, merges, runtime injections, or UncensorFix
+applied by another node. `uncensorfix_targets=0` means this node added no targets;
+it does not mean the incoming model has no LoRA patches. Switching this node to
+Off does not mutate an earlier output from a run where it was enabled.
 
 ## Representation and execution
 
-The generated Python module stores only raw little-endian float32 up/down
-factor values, losslessly compressed and text-encoded, plus target keys, shapes
-and alpha values. This is not the original safetensors file encoded as a string:
-there is no original container header or source-checkpoint metadata. The
-numerical values are reconstructible; this is a packaging format, not encryption.
+The data module contains losslessly compressed, text-encoded little-endian
+float32 up/down values, canonical target names, shapes and alpha values. It is
+not the original safetensors container encoded as a string. Its payload is
+checksummed and decoded lazily once. Packaging is not encryption.
 
-The module checks its tensor-data SHA-256 and decodes once, lazily. The node
-constructs `comfy.weight_adapter.lora.LoRAAdapter` objects directly, using
-`(up, down, alpha, None, None, None)`. It does not call `comfy.lora.load_lora`.
-The native ComfyUI weight-patch arithmetic is retained, not approximated with tap
-gains or converted to a potentially huge set of dense difference matrices.
-Every one of the 33 canonical model targets must exist with the expected shape
-and be accepted by `add_patches`. The input model is cloned, and fresh factor
-copies isolate the cached embedded tensors from downstream mutation.
+The repository's recorded factor-payload SHA-256 is:
 
-This requires the ComfyUI LoRAAdapter API used by current Krea2-capable versions.
-Its factors still use ordinary weight-patch arithmetic. It now supports an
-upstream **Donut Model Merge Krea2 → Experimental bypass** automatically; it does
-not add a separate activation-side execution mode or a new node.
+```text
+f3c817bd957e6d47883346237b5e067697f0b9e1c9909bd06353da455949aacf
+```
+
+The reference upload used for this parity investigation has the same checksum
+for its 3,457,232-byte, sorted-target, up-then-down float32 factor payload. It
+contains 33 rank-4 targets with alpha 4, so alpha/rank is 1. No factor values or
+strength convention were changed to make this match.
+
+Native mode constructs `comfy.weight_adapter.lora.LoRAAdapter` objects with
+`(up, down, alpha, None, None, None)` and appends them to cloned patch lists.
+This is the same adapter layout produced by the ordinary Comfy LoRA loader.
+It retains native weight-patch arithmetic and does not form dense deltas.
+Native mode still does not import the LoRA-file loader.
+
+Experimental bypass uses `donut_uncensorfix_lora.py` to reconstruct canonical
+LoRA tensor keys **in memory**, then calls
+`DonutSafeApplyLoRAStack._apply_bypass_applications` with the same
+`_TEXT_MERGE_VECTOR` used for Donut Apply's fused-text route. There is no separate
+bypass arithmetic implementation. A preflight requires every expected target
+to map at unit block weight; missing, renamed or muted targets raise an error.
+The bridge rejects a helper result that installs neither new regular patches
+nor a new forward injection. Standard loader dependencies are needed for this
+mode, but no LoRA file is read.
+
+Both modes retain model shape validation and independent copies of the cached
+factor tensors. They append to existing patches rather than replacing them.
 
 ## Experimental model-merge bypass
 
-Connect the merged MODEL (including any existing LoRA stack) to Fusion Control,
-select UncensorFix, and send Fusion Control's MODEL output to the sampler. No
-extra mode switch is needed in Fusion Control.
+Apply UncensorFix **after** a model merge to affect the resulting model. A later
+merge can intentionally replace weights patched earlier in the chain.
 
-Exact model2 swaps in the upstream merge execute retained model2 layers. For
-these targets, UncensorFix appends its adapters to a **clone of that source
-patcher**. Unswapped and partially blended targets stay on the main patcher.
-There is no patch applied to an unused model1 copy of a swapped target, and no
-extra copy of UncensorFix is added through a forward hook.
+Exact model2 swaps execute retained model2 layers. Their UncensorFix targets are
+routed to a clone of that source patcher; unswapped and partially blended targets
+stay on the main patcher. This routing is retained for both LoRA execution modes.
+Do not confuse the merge's bypass mode with the separate LoRA execution choice.
 
-Existing main/source patch stacks and runtime LoRA injections are preserved.
-Only the output model references the newly patched source. Source-only changes
-also invalidate the outer model's clone cache so a later run does not retain
-the old swap forward. The existing save/extract helpers see the same source
-patch stack, so the routed changes remain available for serialization.
+Existing main/source patches, injections and merge plans are preserved. Only the
+output references the updated source. A fresh source-identity attachment and
+patch UUID invalidate the outer clone cache for source-only changes. Native
+source patches remain visible to the existing save/extract helpers. Bypass
+injections retain Donut's existing bypass serialization/materialization rules.
 
-For a full 33-target text-fusion swap the diagnostics include:
-
-```text
-uncensorfix_source=embedded
-uncensorfix_bypass_source_targets=33
-uncensorfix_model_targets=0
-uncensorfix_targets=33
-```
-
-Mixed merges report the corresponding counts. Missing source/plan metadata or
-wrong target shapes raise an error instead of silently patching inactive
-weights. The original embedded data, strengths, and Simple/Advanced UI do not
-change. UncensorFix strength zero still performs no decoding or patching.
-
-Apply UncensorFix **after** a model merge to affect the resulting merged model.
-A later model merge can intentionally replace weights, including adapters
-applied before that merge. This fix does not override those merge semantics.
+A full 33-target source swap reports `uncensorfix_bypass_source_targets=33` and
+`uncensorfix_model_targets=0`, as well as the total target count. Mixed merges
+report the corresponding counts. Missing plans/injections or incompatible
+source shapes fail instead of patching inactive main-model weights.
 
 ## Validation
 
 Run from the node-pack root:
 
 ```sh
+python test_uncensorfix_lora_parity.py -v
 python test_krea2_fusion_preset.py -v
 python test_uncensorfix_merge_bypass.py -v
 node --test tests/teacherfix_ui.test.mjs
 ```
 
-The preset Python suite has 26 CPU tests of the actual embedded data, including checksum,
-shape, rank/alpha, corruption handling, cloning, strength propagation, target
-validation, unchanged UI schema, and operation with safetensors, comfy.lora,
-comfy.utils and folder_paths imports blocked. ComfyUI model/base/adapter interfaces
-are test doubles. The 30 JavaScript tests execute the actual preset-label mutation
-callback and both frontend extensions in both registration orders. They include
-legacy-label migration and Simple/Advanced strength edits in an isolated VM, not a full browser.
+The new parity suite has 20 CPU contract tests. It executes the modified preset
+and bypass bridge with doubles for ComfyUI, the base fusion node and the shared
+Donut Apply helper's environment. It covers LoRA-only isolation, explicit
+combined controls, conditioning identity, positive/negative/zero strengths,
+same-target patch accumulation, Off, legacy positional arguments and labels,
+canonical bypass factors, shared-helper dispatch, fallback preservation,
+invalid target mapping, silent no-op rejection, and main/source routing.
 
-A separate local comparison against the private original checked all 99 tensor
-and alpha values and 66 full CPU weight/linear-output comparisons (33 targets at
-strengths 0.75 and 1.0) against the ordinary LoRA reference formula. All were
-bitwise equal. This was not a full ComfyUI/GPU image-generation A/B test.
-
-The Off regressions check exact model/conditioning identity, preservation of
-upstream patches and bypass forwards, no base fusion processing or embedded-data
-access, saved settings, switching modes/presets, and rapid selection while old
-strength callbacks are queued. The merge-bypass suite has 22 CPU tests.
+The original code fails the new stored-controls isolation and full positional
+preset regressions; the modified code passes the 20-test suite. This is not a
+full ComfyUI/CUDA, quantized-checkpoint or image-generation A/B test. The existing
+embedded-data, merge-bypass and frontend suites provide additional coverage and
+should also be run in a complete checkout.
 
 ## Distribution
 
-Ship `uncensorfix_weights.py` alongside `DonutKrea2FusionPreset.py`, not an
-`assets/*.safetensors` file. The complete Embedded Update ZIP contains the module
-and needs no original weight file. This replaces the earlier bundled-file ZIP.
-
-## Rename compatibility
-
-The visible preset is **UncensorFix** and its data module is `uncensorfix_weights.py`.
-Saved workflows using either previous TeacherFix label are normalized to UncensorFix;
-the numerical data is unchanged. The existing documentation and test filenames are
-retained to avoid breaking links and test commands.
-
-The merge-bypass regression suite uses small CPU linear layers with the actual
-Donut merge-plan resolver and swap-injection implementation. ComfyUI's patcher,
-adapter, and injection-manager interfaces are test doubles. It checks forward
-outputs and save-state routing, not just accepted patch counts. It is not a
-full ComfyUI/GPU or quantized-checkpoint image-generation test.
+Ship `uncensorfix_weights.py`, `DonutKrea2FusionPreset.py` and
+`donut_uncensorfix_lora.py` with the rest of DonutNodes. Do not add a separate
+`assets/*.safetensors` file. The original data module is unchanged. Existing node
+IDs and the older documentation/test filenames are retained.

--- a/donut_uncensorfix_lora.py
+++ b/donut_uncensorfix_lora.py
@@ -1,0 +1,66 @@
+"""Bridge embedded UncensorFix factors to Donut Apply's bypass implementation.
+
+No filesystem lookup or safetensors parsing is involved. Keeping this import
+lazy also leaves native patches, Off and strength zero free of loader imports.
+"""
+
+import torch
+
+
+def _canonical_lora_state(patches):
+    """Reconstruct ordinary LoRA tensor keys, not a serialized LoRA file."""
+    lora = {}
+    for key, adapter in patches.items():
+        weights = adapter.weights
+        if not key.endswith(".weight") or len(weights) != 6:
+            raise RuntimeError(f"Unexpected embedded UncensorFix adapter: {key}")
+        up, down, alpha, mid, dora, reshape = weights
+        if any(value is not None for value in (mid, dora, reshape)):
+            raise RuntimeError(f"UncensorFix expects plain linear LoRA factors: {key}")
+        stem = key[:-len(".weight")]
+        lora[stem + ".lora_up.weight"] = up
+        lora[stem + ".lora_down.weight"] = down
+        lora[stem + ".alpha"] = torch.tensor(float(alpha), dtype=torch.float32)
+    return lora
+
+
+def apply_embedded_bypass(model, patches, strength):
+    """Use the exact helper, text vector and fallbacks used by Donut Apply."""
+    from .DonutSafeApplyLoRAStack import _apply_bypass_applications
+    from .donut_lora_nodes import _TEXT_MERGE_VECTOR
+    from .lora_block_weight import LoraLoaderBlockWeight
+
+    lora = _canonical_lora_state(patches)
+    # Donut Apply normally permits partially matching LoRAs. The embedded
+    # preset promises all targets, so reject any lost/remapped/muted target
+    # before installing adapters. The shared helper performs its own normal
+    # load afterwards; no monkey-patching or separate bypass math is used.
+    block_weights, muted, _ = LoraLoaderBlockWeight.load_lbw(
+        model, None, lora, inverse=False, seed=0, A=1.0, B=1.0,
+        block_vector=_TEXT_MERGE_VECTOR,
+    )
+    if (
+        set(block_weights) != set(patches)
+        or muted
+        or any(float(ratio) != 1.0 for _, ratio in block_weights.values())
+    ):
+        raise RuntimeError(
+            "UncensorFix bypass must preserve every embedded target at unit block weight: "
+            f"{len(block_weights)}/{len(patches)} mapped"
+        )
+    result = _apply_bypass_applications(model, [(lora, strength, _TEXT_MERGE_VECTOR)])
+
+    # The shared helper can use regular patches for unsupported modules or
+    # existing injections. Require either appended patches or a NEW bypass
+    # injection, rather than reporting success for an unchanged model.
+    before = getattr(model, "patches", {})
+    after = getattr(result, "patches", {})
+    regular = {
+        key for key in patches
+        if len(after.get(key, ())) > len(before.get(key, ()))
+    }
+    old_injection = getattr(model, "injections", {}).get("donut_bypass_lora")
+    new_injection = getattr(result, "injections", {}).get("donut_bypass_lora")
+    if regular != set(patches) and (not new_injection or new_injection is old_injection):
+        raise RuntimeError("UncensorFix bypass did not install the expected patches or forward adapters")
+    return result

--- a/test_uncensorfix_lora_parity.py
+++ b/test_uncensorfix_lora_parity.py
@@ -1,0 +1,395 @@
+"""CPU contract regressions for UncensorFix / Donut Apply parity.
+
+Run: python test_uncensorfix_lora_parity.py -v
+The preset and bypass bridge are real; ComfyUI, the base fusion node, and the
+Donut Apply helper's environment are doubles. These tests establish routing,
+not GPU/image-generation or quantized-kernel equivalence.
+"""
+
+import copy
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest import mock
+
+import torch
+
+ROOT = Path(__file__).resolve().parent
+PACKAGE = "_donut_uncensorfix_parity"
+BASE_NAMES = (
+    "PRESET_MANUAL", "PRESET_BYPASS_2", "PRESET_BYPASS_3", "PRESET_REBALANCE",
+    "PRESET_ENHANCER", "PRESET_REBALANCE_ENHANCER", "PRESET_REBALANCE_BYPASS_2",
+    "PRESET_REBALANCE_BYPASS_3", "PRESET_DONUT_BALANCED", "PRESET_DONUT_BALANCED_ENHANCER",
+)
+
+
+class Adapter:
+    def __init__(self, loaded_keys, weights):
+        self.loaded_keys, self.weights = loaded_keys, weights
+
+
+class Patcher:
+    """Append-only Comfy-like patch lists; never overwrite existing patches."""
+    def __init__(self, factors):
+        self.state = {key: torch.zeros(up.shape[0], down.shape[1])
+                      for key, up, down, _ in factors}
+        self.model = self
+        self.patches = {}
+        self.injections = {}
+        self.additional_models = {}
+        self.attachments = {}
+        self.model_options = {"transformer_options": {"upstream": object()}}
+        self.bypass = {}
+        self.merge_info = None
+        self.patches_uuid = None
+
+    def state_dict(self):
+        return self.state
+
+    def clone(self):
+        result = copy.copy(self)
+        result.model = result
+        result.patches = {key: list(value) for key, value in self.patches.items()}
+        result.injections = dict(self.injections)
+        result.additional_models = dict(self.additional_models)
+        result.attachments = dict(self.attachments)
+        result.model_options = copy.deepcopy(self.model_options)
+        result.bypass = dict(self.bypass)
+        return result
+
+    def add_patches(self, patches, strength_patch=1.0):
+        accepted = []
+        for key, patch in patches.items():
+            if key not in self.state:
+                continue
+            self.patches.setdefault(key, []).append((strength_patch, patch, 1.0, None, None))
+            accepted.append(key)
+        return accepted
+
+    def set_additional_models(self, key, models):
+        self.additional_models[key] = models
+
+    def set_attachments(self, key, value):
+        self.attachments[key] = value
+
+    def effective_weight(self, key):
+        weight = self.state[key].clone()
+        for strength, adapter, _, _, _ in self.patches.get(key, ()):
+            up, down, alpha, *_ = adapter.weights
+            weight += (strength * (alpha / down.shape[0])) * (up @ down)
+        return weight
+
+
+class UncensorFixParityTests(unittest.TestCase):
+    def setUp(self):
+        package = types.ModuleType(PACKAGE)
+        package.__path__ = [str(ROOT)]
+        base = types.ModuleType(PACKAGE + ".DonutKrea2FusionControl")
+        for name in BASE_NAMES:
+            setattr(base, name, name)
+        base.PRESET_MANUAL = "Custom settings"
+        self.base_calls = []
+        calls = self.base_calls
+
+        class Base:
+            @classmethod
+            def INPUT_TYPES(cls):
+                return {"required": {
+                    "model": ("MODEL",), "conditioning_in_1": ("CONDITIONING",),
+                    "compatibility_preset": (["Custom settings"], {}),
+                    "tap_strength": ("FLOAT", {"default": 1.0}),
+                }, "optional": {"conditioning_in_2": ("CONDITIONING",)}}
+
+            def apply(self, model, conditioning_in_1, tap_strength=1.0,
+                      compatibility_preset="Custom settings", conditioning_in_2=None,
+                      conditioning_in_3=None, conditioning_in_4=None, **kwargs):
+                calls.append(kwargs)
+                model = model.clone()
+                model.model_options["fusion_controls_executed"] = True
+                return (model, conditioning_in_1 * 2, conditioning_in_2, conditioning_in_3,
+                        conditioning_in_4,
+                        "preset_label=Custom settings; preset_is_ui_only=true\nexternal_files_loaded=none")
+
+        base.DonutKrea2FusionControl = Base
+        package.DonutKrea2FusionControl = base
+        comfy = types.ModuleType("comfy")
+        comfy.__path__ = []
+        weight_adapter = types.ModuleType("comfy.weight_adapter")
+        weight_adapter.__path__ = []
+        lora = types.ModuleType("comfy.weight_adapter.lora")
+        lora.LoRAAdapter = Adapter
+        serialization = types.ModuleType(PACKAGE + ".donut_krea2_merge_serialization")
+        serialization.KREA2_MERGE_INJECTION_KEY = "merge_swap"
+        serialization.KREA2_MERGE_SOURCE_KEY = "merge_source"
+        serialization.get_krea2_merge_bypass_info = lambda model: model.merge_info
+        nodes = types.ModuleType(PACKAGE + ".donut_lora_nodes")
+        nodes._TEXT_MERGE_VECTOR = ",".join(["1"] * 13)
+        block = types.ModuleType(PACKAGE + ".lora_block_weight")
+
+        def load_lbw(model, clip, state, **kwargs):
+            patches = {}
+            for key in state:
+                if key.endswith(".lora_up.weight"):
+                    stem = key[:-len(".lora_up.weight")]
+                    target = stem + ".weight"
+                    if target in model.state:
+                        patches[target] = (Adapter(set(), (
+                            state[key], state[stem + ".lora_down.weight"],
+                            float(state[stem + ".alpha"]), None, None, None)), 1.0)
+            return patches, [], kwargs["block_vector"]
+
+        block.LoraLoaderBlockWeight = types.SimpleNamespace(load_lbw=mock.Mock(side_effect=load_lbw))
+        self.loader = block.LoraLoaderBlockWeight
+        safe = types.ModuleType(PACKAGE + ".DonutSafeApplyLoRAStack")
+
+        def shared_bypass(model, applications):
+            result = model.clone()
+            for state, strength, vector in applications:
+                weights, _, _ = load_lbw(model, None, state, block_vector=vector)
+                for key, (adapter, ratio) in weights.items():
+                    if any(model.injections.values()):
+                        result.add_patches({key: adapter}, strength * ratio)
+                    else:
+                        result.bypass[key] = (adapter, strength * ratio)
+            if result.bypass:
+                result.injections["donut_bypass_lora"] = [object()]
+            return result
+
+        safe._apply_bypass_applications = mock.Mock(side_effect=shared_bypass)
+        self.shared_bypass = safe._apply_bypass_applications
+        self.modules = mock.patch.dict(sys.modules, {
+            PACKAGE: package, base.__name__: base,
+            "comfy": comfy, "comfy.weight_adapter": weight_adapter,
+            "comfy.weight_adapter.lora": lora,
+            serialization.__name__: serialization, nodes.__name__: nodes,
+            block.__name__: block, safe.__name__: safe,
+        })
+        self.modules.start()
+        self.addCleanup(self.modules.stop)
+        self.module = self.load("DonutKrea2FusionPreset")
+        self.bridge = self.load("donut_uncensorfix_lora")
+        self.factors = tuple(
+            (f"diffusion_model.txtfusion.test{i}.weight",
+             torch.arange(8, dtype=torch.float32).reshape(2, 4) / (i + 5),
+             torch.arange(12, dtype=torch.float32).reshape(4, 3) / 20, 4.0)
+            for i in range(33)
+        )
+        patch = mock.patch.object(self.module, "_uncensorfix_factors", return_value=self.factors)
+        self.factors_mock = patch.start()
+        self.addCleanup(patch.stop)
+        self.model = Patcher(self.factors)
+        self.cond = torch.arange(6, dtype=torch.float32).reshape(1, 2, 3)
+
+    def load(self, name):
+        spec = importlib.util.spec_from_file_location(PACKAGE + "." + name, ROOT / (name + ".py"))
+        module = importlib.util.module_from_spec(spec)
+        sys.modules[spec.name] = module
+        spec.loader.exec_module(module)
+        return module
+
+    def apply(self, **kwargs):
+        inputs = dict(model=self.model, conditioning_in_1=self.cond,
+                      compatibility_preset="UncensorFix", tap_strength=1.0)
+        inputs.update(kwargs)
+        return self.module.DonutKrea2FusionControl().apply(**inputs)
+
+    def test_default_is_lora_only_in_both_ui_modes(self):
+        for mode in ("Simple", "Advanced"):
+            result = self.apply(ui_mode=mode, tap_profile="classic", projector_strength=2.0,
+                                fusion_method="enhancer", fusion_strength=2.0)
+            self.assertIs(result[1], self.cond)
+            self.assertEqual(len(result[0].patches), 33)
+            self.assertNotIn("fusion_controls_executed", result[0].model_options)
+            self.assertIn("uncensorfix_controls=LoRA only", result[-1])
+        self.assertEqual(self.base_calls, [])
+
+    def test_inactive_malformed_controls_do_not_affect_lora_only(self):
+        result = self.apply(per_layer_weights="not a profile", projector_strength=float("nan"))
+        self.assertIs(result[1], self.cond)
+        self.assertFalse(self.base_calls)
+
+    def test_all_conditioning_routes_preserved_by_identity(self):
+        routes = (self.cond, [], None, [[object(), {"mask": object()}]])
+        result = self.apply(**{f"conditioning_in_{i}": route for i, route in enumerate(routes, 1)})
+        for actual, expected in zip(result[1:5], routes):
+            self.assertIs(actual, expected)
+        self.assertIn("conditioning_routes=3/4", result[-1])
+
+    def test_fusion_controls_remain_available_by_explicit_opt_in(self):
+        result = self.apply(uncensorfix_controls="LoRA + fusion controls", tap_profile="classic")
+        self.assertEqual(len(self.base_calls), 1)
+        self.assertTrue(torch.equal(result[1], self.cond * 2))
+        self.assertEqual(len(result[0].patches), 33)
+
+    def test_zero_lora_only_is_exact_noop_even_with_dirty_controls(self):
+        self.factors_mock.side_effect = AssertionError("decoded")
+        result = self.apply(tap_strength=0.0, tap_profile="classic", fusion_strength=2.0,
+                            execution_mode="Experimental bypass")
+        self.assertIs(result[0], self.model)
+        self.assertIs(result[1], self.cond)
+        self.assertFalse(self.base_calls)
+        self.shared_bypass.assert_not_called()
+
+    def test_off_preserves_all_upstream_state_and_ignores_execution_settings(self):
+        self.model.patches["upstream"] = [object()]
+        self.model.injections["upstream"] = [object()]
+        before = dict(vars(self.model))
+        self.factors_mock.side_effect = AssertionError("decoded")
+        result = self.apply(compatibility_preset="Off", execution_mode="invalid",
+                            uncensorfix_controls="invalid", tap_strength=float("nan"))
+        self.assertIs(result[0], self.model)
+        self.assertIs(result[1], self.cond)
+        for key, value in before.items():
+            self.assertIs(getattr(self.model, key), value)
+        self.assertFalse(self.base_calls)
+
+    def test_native_matches_ordinary_loaded_factor_patch_stack(self):
+        for strength in (-0.5, 0.75, 1.0, 2.0):
+            reference = self.model.clone()
+            for key, up, down, alpha in self.factors:
+                reference.add_patches({key: Adapter(set(), (up, down, alpha, None, None, None))}, strength)
+            actual = self.apply(tap_strength=strength)[0]
+            for key in reference.patches:
+                self.assertTrue(torch.equal(actual.effective_weight(key), reference.effective_weight(key)))
+                self.assertEqual(actual.patches[key][0][0], strength)
+        self.shared_bypass.assert_not_called()
+
+    def test_native_appends_same_target_patches_and_does_not_mutate_input(self):
+        key, up, down, alpha = self.factors[0]
+        previous = Adapter(set(), (up * 2, down, alpha, None, None, None))
+        self.model.add_patches({key: previous}, 0.3)
+        result = self.apply(tap_strength=0.75)[0]
+        self.assertEqual(len(self.model.patches[key]), 1)
+        self.assertEqual(len(result.patches[key]), 2)
+        self.assertIs(result.patches[key][0][1], previous)
+        self.assertTrue(torch.equal(result.effective_weight(key),
+                                   (0.3 * (up * 2 @ down)) + (0.75 * (up @ down))))
+
+    def test_cached_factors_are_not_shared_with_native_adapters(self):
+        result = self.apply()[0]
+        for key, up, down, _ in self.factors:
+            copied = result.patches[key][0][1].weights
+            self.assertNotEqual(copied[0].data_ptr(), up.data_ptr())
+            self.assertNotEqual(copied[1].data_ptr(), down.data_ptr())
+
+    def test_bypass_reuses_donut_apply_helper_with_exact_factors_and_text_strength(self):
+        result = self.apply(execution_mode="Experimental bypass", tap_strength=0.75)[0]
+        self.shared_bypass.assert_called_once()
+        model, applications = self.shared_bypass.call_args.args
+        self.assertIs(model, self.model)
+        state, strength, vector = applications[0]
+        self.assertEqual(strength, 0.75)
+        self.assertEqual(vector, ",".join(["1"] * 13))
+        self.assertEqual(len(state), 99)
+        for key, up, down, alpha in self.factors:
+            stem = key[:-7]
+            self.assertTrue(torch.equal(state[stem + ".lora_up.weight"], up))
+            self.assertTrue(torch.equal(state[stem + ".lora_down.weight"], down))
+            self.assertEqual(float(state[stem + ".alpha"]), alpha)
+        self.assertEqual(len(result.bypass), 33)
+        self.assertFalse(result.patches)
+        self.assertFalse(self.model.bypass)
+
+    def test_bypass_retains_shared_helper_regular_fallback(self):
+        self.model.injections["upstream"] = [object()]
+        result = self.apply(execution_mode="Experimental bypass")[0]
+        self.assertEqual(len(result.patches), 33)
+        self.assertIs(result.injections["upstream"], self.model.injections["upstream"])
+        self.assertFalse(result.bypass)
+
+    def test_bypass_preflight_rejects_missing_remapped_or_muted_targets(self):
+        valid_load = self.loader.load_lbw.side_effect
+        for failure in ("missing", "remapped", "muted", "ratio"):
+            def broken(*args, **kwargs):
+                weights, muted, vector = valid_load(*args, **kwargs)
+                key = next(iter(weights))
+                if failure == "missing":
+                    weights.pop(key)
+                elif failure == "remapped":
+                    weights["wrong.weight"] = weights.pop(key)
+                elif failure == "muted":
+                    muted.append(key)
+                else:
+                    weights[key] = (weights[key][0], 0.5)
+                return weights, muted, vector
+            with self.subTest(failure=failure):
+                self.loader.load_lbw.side_effect = broken
+                with self.assertRaisesRegex(RuntimeError, "unit block weight"):
+                    self.apply(execution_mode="Experimental bypass")
+        self.shared_bypass.assert_not_called()
+
+    def test_bypass_rejects_silent_noop_helper(self):
+        self.shared_bypass.side_effect = lambda model, applications: model.clone()
+        with self.assertRaisesRegex(RuntimeError, "did not install"):
+            self.apply(execution_mode="Experimental bypass")
+
+    def test_modes_and_legacy_labels_keep_strength_and_diagnostics(self):
+        for preset in ("UncensorFix", "TeacherFix", self.module.LEGACY_TEACHERFIX):
+            for mode in ("Comfy patches", "Experimental bypass"):
+                result = self.apply(compatibility_preset=preset, execution_mode=mode, tap_strength=-0.5)
+                self.assertIn("uncensorfix_targets=33", result[-1])
+                self.assertIn(f"uncensorfix_execution_mode={mode}", result[-1])
+                self.assertIn("reference_text_weight=-0.5", result[-1])
+
+    def test_full_legacy_positional_preset_and_strength_are_resolved(self):
+        result = self.module.DonutKrea2FusionControl().apply(self.model, self.cond, 0.75, "UncensorFix")
+        self.assertEqual(len(result[0].patches), 33)
+        self.assertEqual(next(iter(result[0].patches.values()))[0][0], 0.75)
+        self.assertIs(result[1], self.cond)
+        self.assertFalse(self.base_calls)
+
+    def test_positional_off_does_not_run_base(self):
+        result = self.module.DonutKrea2FusionControl().apply(self.model, self.cond, 3.0, "Off")
+        self.assertIs(result[0], self.model)
+        self.assertFalse(self.base_calls)
+
+    def test_invalid_active_modes_and_strength_fail(self):
+        for kwargs in ({"execution_mode": "wrong"}, {"uncensorfix_controls": "wrong"},
+                       {"tap_strength": float("inf")}, {"tap_strength": float("nan")}):
+            with self.subTest(kwargs=kwargs), self.assertRaises(ValueError):
+                self.apply(**kwargs)
+
+    def test_optional_controls_are_appended_and_existing_node_id_is_retained(self):
+        schema = self.module.DonutKrea2FusionControl.INPUT_TYPES()
+        self.assertEqual(list(schema["required"])[-1], "ui_mode")
+        self.assertEqual(list(schema["optional"])[-2:], ["uncensorfix_controls", "execution_mode"])
+        self.assertEqual(schema["optional"]["uncensorfix_controls"][1]["default"], "LoRA only")
+        self.assertEqual(list(self.module.NODE_CLASS_MAPPINGS), ["DonutKrea2FusionControl"])
+
+    def test_partial_merge_routes_both_modes_without_mutating_model2(self):
+        for mode in ("Comfy patches", "Experimental bypass"):
+            with self.subTest(mode=mode):
+                model = Patcher(self.factors)
+                source = Patcher(self.factors)
+                keys = [self.factors[i][0] for i in range(5)]
+                # Match the false-y yet non-empty composable swap list.
+                class Composable(list):
+                    def __bool__(self):
+                        return False
+                model.injections["merge_swap"] = Composable([object()])
+                model.merge_info = (source, [(None, key, None) for key in keys], None)
+                result = self.apply(model=model, execution_mode=mode)[0]
+                patched_source = result.additional_models["merge_source"][0]
+                main_keys = set(result.patches) | set(result.bypass)
+                source_keys = set(patched_source.patches) | set(patched_source.bypass)
+                self.assertEqual(main_keys, {x[0] for x in self.factors} - set(keys))
+                self.assertEqual(source_keys, set(keys))
+                self.assertFalse(source.patches)
+                self.assertFalse(source.bypass)
+                self.assertFalse(model.patches)
+                self.assertTrue(result.attachments)
+                self.assertIsNotNone(result.patches_uuid)
+
+    def test_native_off_and_zero_never_call_bypass_loader(self):
+        self.loader.load_lbw.side_effect = AssertionError("bypass loader called")
+        self.apply()
+        self.apply(compatibility_preset="Off")
+        self.apply(tap_strength=0.0, execution_mode="Experimental bypass")
+        self.shared_bypass.assert_not_called()
+
+
+if __name__ == "__main__":
+    torch.set_num_threads(1)
+    unittest.main()


### PR DESCRIPTION
## Findings

Investigated the discrepancy between Fusion Control's embedded UncensorFix and Donut Apply LoRA Stack against main at `effd4efa2b92390a9194015f803072d619699718`.

- `Off` already returns the original MODEL and conditioning objects. It does not clear inherited LoRA patches or runtime injections. This behavior is retained and regression-tested.
- The supplied reference contains 33 rank-4 text-fusion targets with alpha 4. Its sorted up/down float32 payload is 3,457,232 bytes and hashes to `f3c817bd957e6d47883346237b5e067697f0b9e1c9909bd06353da455949aacf`, matching the repository's recorded embedded-payload checksum. The embedded weights module is unchanged.
- UncensorFix previously always ran the base fusion controls before adding adapters. Restored/hidden non-neutral settings could therefore apply extra conditioning gains, projector changes or enhancement in addition to the LoRA.
- Donut Apply supports both `Comfy patches` and `Experimental bypass`; UncensorFix previously supported only weight patches. Comparing different modes is not a numerical parity test, especially with quantized weights.
- This LoRA is diffusion-side fused text, so its effective Donut Apply strength is `text_weight` (`cw`), not the main `model_weight`.

These are concrete application-path differences, not a claim that the user's exact image mismatch was reproduced. No full workflow/checkpoint was available for image-generation A/B testing.

## Changes

1. Add `uncensorfix_controls`, defaulting to **LoRA only** in both UI modes. The backend skips this node's dormant fusion controls and returns all conditioning routes unchanged, preserving upstream model state. Explicit **LoRA + fusion controls** retains intentional combined operation.
2. Add an appended optional `execution_mode` matching Donut Apply. Native mode retains direct `LoRAAdapter` construction and ordinary patch arithmetic. Experimental mode reconstructs canonical tensor keys in memory and reuses `DonutSafeApplyLoRAStack._apply_bypass_applications` with the same text vector and fallbacks. No weight file lookup, safetensors read, download, dense-delta conversion or separate bypass math is added.
3. Validate complete, unit-weight target mapping before bypass installation and reject a silent no-op result.
4. Preserve existing main/source model2 swap routing, patch accumulation, factor-copy isolation and source-only cache invalidation for both execution choices.
5. Resolve legacy positional preset/strength inputs before dispatch; add requested execution mode and equivalent text strength to diagnostics.
6. Document matching comparison settings and validation limitations.

**Migration:** workflows intentionally combining Advanced fusion settings with UncensorFix must select **LoRA + fusion controls**. Their stored settings are preserved. Existing node IDs and widget indices are unchanged; the two options are appended as optional widgets. `Off` remains exact passthrough.

## Validation performed

`python test_uncensorfix_lora_parity.py -v` — **20/20 CPU tests passed**.

The tests execute the actual modified preset and bypass bridge with doubles for ComfyUI, the base fusion node and the shared Donut Apply helper's environment. Coverage includes same-target patch accumulation, conditioning identity, dormant controls, explicit composition, Off, negative/zero/nonzero strengths, cached-factor isolation, canonical bypass data/helper dispatch, regular fallback, missing/remapped/muted targets, silent no-op rejection, legacy labels/positional inputs, schema compatibility and mixed main/source routing.

Red/green checks: the original preset fails the stored-controls isolation regression and errors on the fully positional preset regression; the modified preset passes both.

The real uploaded factor payload was checked against the checksum recorded in the existing repository suite. The uploaded safetensors and its metadata are not committed.

**Not performed:** full ComfyUI/CUDA or quantized-model image-generation A/B; the existing embedded-data, merge-bypass and JavaScript suites in a complete checkout. Those suites remain documented for additional validation. This PR does not claim bit-identical rendered images.

## Matching A/B settings

- Fusion branch: `UncensorFix`, `uncensorfix_controls=LoRA only`, `tap_strength=s`.
- Donut Apply branch: this LoRA's `text_weight=s`, `safe_stack=Off`, `fusion_aware=Off`; Fusion Control Off or omitted.
- Use identical `execution_mode` on both branches, identical incoming model/conditioning and sampler/seed. Apply the LoRA exactly once on each branch.

Only application code, tests and documentation changed. `uncensorfix_weights.py` is untouched.