### PR TITLE
Isolate NumPy dependency failures and add a native Donut Dependency Check

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -1,224 +1,51 @@
-# Register server routes for settings API
-from .shared import server_routes  # noqa: F401
+"""Register DonutNodes independently so one broken wheel cannot hide the pack."""
 
-# existing nodes' class mappings
-from .DonutDetailer         import NODE_CLASS_MAPPINGS as m1
-from .DonutDetailer         import NODE_DISPLAY_NAME_MAPPINGS as d_detailer
-from .DonutDetailer2        import NODE_CLASS_MAPPINGS as m2
-from .DonutDetailer4        import NODE_CLASS_MAPPINGS as m3
-from .DonutDetailer5        import NODE_CLASS_MAPPINGS as m4
-from .DonutDetailerXLBlocks import NODE_CLASS_MAPPINGS as m5
-from .DonutClipEncode       import NODE_CLASS_MAPPINGS as m6
-from .DonutWidenMerge       import NODE_CLASS_MAPPINGS as m7
+from .donut_dependencies import (
+    DonutDependencyCheck,
+    IMPORT_FAILURES,
+    LOGGER,
+    import_component,
+    installed_versions,
+    opencv_conflict,
+)
 
-# new LoRA nodes (include display names)
-from .donut_lora_nodes      import NODE_CLASS_MAPPINGS        as m_lora
-from .donut_lora_nodes      import NODE_DISPLAY_NAME_MAPPINGS as d_lora
 
-# Safe Krea2 LoRA application overrides only DonutApplyLoRAStack while keeping
-# the existing node id/display name so saved workflows remain compatible.
-from .DonutSafeApplyLoRAStack import NODE_CLASS_MAPPINGS        as m_safe_lora
-from .DonutSafeApplyLoRAStack import NODE_DISPLAY_NAME_MAPPINGS as d_safe_lora
+NODE_CLASS_MAPPINGS = {"DonutDependencyCheck": DonutDependencyCheck}
+NODE_DISPLAY_NAME_MAPPINGS = {"DonutDependencyCheck": "Donut Dependency Check"}
+IMPORT_FAILURES.clear()
 
-# hot reload functionality
-from .hot_reload            import NODE_CLASS_MAPPINGS        as m_reload
-from .hot_reload            import NODE_DISPLAY_NAME_MAPPINGS as d_reload
+# Settings/CivitAI routes are useful, but their dependencies must not prevent
+# unrelated model/conditioning nodes (or the diagnostic node) from loading.
+import_component(__name__, "shared.server_routes")
 
-# optuna optimization (temporarily disabled - DonutOptunaNode.py not in repo)
-# from .DonutOptunaNode       import NODE_CLASS_MAPPINGS        as m_optuna
-# from .DonutOptunaNode       import NODE_DISPLAY_NAME_MAPPINGS as d_optuna
-
-# SDXL TeaCache (Base - High Performance)
-from .DonutSDXLTeaCache     import NODE_CLASS_MAPPINGS        as m_teacache
-from .DonutSDXLTeaCache     import NODE_DISPLAY_NAME_MAPPINGS as d_teacache
-
-# Block Calibration
-from .DonutBlockCalibration import NODE_CLASS_MAPPINGS        as m_calibration
-from .DonutBlockCalibration import NODE_DISPLAY_NAME_MAPPINGS as d_calibration
-
-# Frequency Analysis
-from .DonutFrequencyAnalysis import NODE_CLASS_MAPPINGS       as m_freq_analysis
-from .DonutFrequencyAnalysis import NODE_DISPLAY_NAME_MAPPINGS as d_freq_analysis
-
-# Spectral Noise Sharpening (2024 Research-Based)
-from .DonutSpectralNoiseSharpener import NODE_CLASS_MAPPINGS      as m_spectral_sharpener
-from .DonutSpectralNoiseSharpener import NODE_DISPLAY_NAME_MAPPINGS as d_spectral_sharpener
-
-# DonutSampler - CFG Linear Progression
-from .DonutKSamplerCFGLinear import NODE_CLASS_MAPPINGS        as m_donut_sampler
-from .DonutKSamplerCFGLinear import NODE_DISPLAY_NAME_MAPPINGS as d_donut_sampler
-
-# LoRA CivitAI Integration
-from .donut_lora_civitai import NODE_CLASS_MAPPINGS        as m_lora_civitai
-from .donut_lora_civitai import NODE_DISPLAY_NAME_MAPPINGS as d_lora_civitai
-
-# Tiled Upscale
-from .DonutTiledUpscale import NODE_CLASS_MAPPINGS        as m_tiled_upscale
-from .DonutTiledUpscale import NODE_DISPLAY_NAME_MAPPINGS as d_tiled_upscale
-
-# Tiled Upscale + color preservation
-from .DonutColorPreservingUpscale import NODE_CLASS_MAPPINGS        as m_color_upscale
-from .DonutColorPreservingUpscale import NODE_DISPLAY_NAME_MAPPINGS as d_color_upscale
-
-# ZIT Detailer (Z-Image Turbo / Lumina2)
-from .DonutDetailerZIT import NODE_CLASS_MAPPINGS        as m_zit_detailer
-from .DonutDetailerZIT import NODE_DISPLAY_NAME_MAPPINGS as d_zit_detailer
-
-# ZIT Model Merge (Z-Image Turbo / Lumina2)
-from .ModelMergeZIT import NODE_CLASS_MAPPINGS        as m_merge_zit
-from .ModelMergeZIT import NODE_DISPLAY_NAME_MAPPINGS as d_merge_zit
-
-# Krea2 Model Merge with optional quantized forward bypass
-from .DonutModelMergeKrea2 import NODE_CLASS_MAPPINGS        as m_merge_krea2
-from .DonutModelMergeKrea2 import NODE_DISPLAY_NAME_MAPPINGS as d_merge_krea2
-
-# ZIT Model Merge Blocks (individual layer control)
-from .ModelMergeZITBlocks import NODE_CLASS_MAPPINGS        as m_merge_zit_blocks
-from .ModelMergeZITBlocks import NODE_DISPLAY_NAME_MAPPINGS as d_merge_zit_blocks
-
-# Model Save (No Workflow)
-from .DonutModelSave import NODE_CLASS_MAPPINGS        as m_model_save
-from .DonutModelSave import NODE_DISPLAY_NAME_MAPPINGS as d_model_save
-
-# Face Detailer with max_faces limit
-from .DonutFaceDetailer import NODE_CLASS_MAPPINGS        as m_face_detailer
-from .DonutFaceDetailer import NODE_DISPLAY_NAME_MAPPINGS as d_face_detailer
-
-# Universal Detailer (Florence-2)
-from .DonutUniversalDetailer import NODE_CLASS_MAPPINGS        as m_universal_detailer
-from .DonutUniversalDetailer import NODE_DISPLAY_NAME_MAPPINGS as d_universal_detailer
-
-# Weight-Vector Scale (helper for third-party ConditioningKrea2Rebalance and LoRA block_vector strings)
-from .DonutWeightVectorScale import NODE_CLASS_MAPPINGS        as m_weight_vector_scale
-from .DonutWeightVectorScale import NODE_DISPLAY_NAME_MAPPINGS as d_weight_vector_scale
-
-# Gamma Correction
-from .DonutGammaCorrection import NODE_CLASS_MAPPINGS        as m_gamma
-from .DonutGammaCorrection import NODE_DISPLAY_NAME_MAPPINGS as d_gamma
-
-# Auto Gamma Correction (4 methods)
-from .DonutAutoGamma import NODE_CLASS_MAPPINGS        as m_auto_gamma
-from .DonutAutoGamma import NODE_DISPLAY_NAME_MAPPINGS as d_auto_gamma
-
-# Histogram Stretch
-from .DonutHistogramStretch import NODE_CLASS_MAPPINGS        as m_hist_stretch
-from .DonutHistogramStretch import NODE_DISPLAY_NAME_MAPPINGS as d_hist_stretch
-
-# Auto White Balance
-from .DonutAutoWhiteBalance import NODE_CLASS_MAPPINGS        as m_white_balance
-from .DonutAutoWhiteBalance import NODE_DISPLAY_NAME_MAPPINGS as d_white_balance
-
-# Sharpening Methods (USM, High Pass, Smart, Deconv, HiRaLoAm, CAS)
-from .DonutSharpen import NODE_CLASS_MAPPINGS        as m_sharpen
-from .DonutSharpen import NODE_DISPLAY_NAME_MAPPINGS as d_sharpen
-
-# Prompt Injection (Style Prompts)
-from .DonutPromptInjection import NODE_CLASS_MAPPINGS        as m_prompt_injection
-from .DonutPromptInjection import NODE_DISPLAY_NAME_MAPPINGS as d_prompt_injection
-
-# ZiT Conditioning Rebalance (input-side gain for Z-Image Turbo)
-from .DonutZitConditioningRebalance import NODE_CLASS_MAPPINGS        as m_zit_rebalance
-from .DonutZitConditioningRebalance import NODE_DISPLAY_NAME_MAPPINGS as d_zit_rebalance
-
-# ZiT Layer-Blend Encode (multi-layer depth blend for Z-Image Turbo)
-from .DonutZitLayerBlendEncode import NODE_CLASS_MAPPINGS        as m_zit_layerblend
-from .DonutZitLayerBlendEncode import NODE_DISPLAY_NAME_MAPPINGS as d_zit_layerblend
-
-# Krea2 Image Conditioning (multi-image, per-image strength, per-channel rebalance)
-from .DonutKrea2ImageConditioning import NODE_CLASS_MAPPINGS        as m_krea2_cond
-from .DonutKrea2ImageConditioning import NODE_DISPLAY_NAME_MAPPINGS as d_krea2_cond
-
-# Krea2 Fusion Control (pure activation-space tap + projector controls)
-from .DonutKrea2FusionControl import NODE_CLASS_MAPPINGS        as m_krea2_fusion
-from .DonutKrea2FusionControl import NODE_DISPLAY_NAME_MAPPINGS as d_krea2_fusion
-
-# Keep the same Krea2 Fusion Control node id while adding the hash-verified
-# TeacherFix preset and the Simple/Advanced frontend mode.
-from .DonutKrea2FusionPreset import NODE_CLASS_MAPPINGS        as m_krea2_fusion_preset
-from .DonutKrea2FusionPreset import NODE_DISPLAY_NAME_MAPPINGS as d_krea2_fusion_preset
-
-# Image Adjust (unified tone/color/contrast/sharpen)
-from .DonutImageAdjust import NODE_CLASS_MAPPINGS        as m_image_adjust
-from .DonutImageAdjust import NODE_DISPLAY_NAME_MAPPINGS as d_image_adjust
-
-# build globals
-NODE_CLASS_MAPPINGS = {
-    **m1, **m2, **m3, **m4, **m5,
-    **m6, **m7,
-    **m_lora,
-    **m_safe_lora,
-    **m_reload,
-    # **m_optuna,  # disabled - file not in repo
-    **m_teacache,
-    **m_calibration,
-    **m_freq_analysis,
-    **m_spectral_sharpener,
-    **m_donut_sampler,
-    **m_lora_civitai,
-    **m_tiled_upscale,
-    **m_color_upscale,
-    **m_zit_detailer,
-    **m_merge_zit,
-    **m_merge_krea2,
-    **m_merge_zit_blocks,
-    **m_model_save,
-    **m_face_detailer,
-    **m_universal_detailer,
-    **m_weight_vector_scale,
-    **m_gamma,
-    **m_auto_gamma,
-    **m_hist_stretch,
-    **m_white_balance,
-    **m_sharpen,
-    **m_prompt_injection,
-    **m_zit_rebalance,
-    **m_zit_layerblend,
-    **m_krea2_cond,
-    **m_krea2_fusion,
-    **m_krea2_fusion_preset,
-    **m_image_adjust,
+# Keep the original registration order. The two overrides are deliberate:
+# failed overrides must NOT quietly expose an older, incompatible node class.
+_NODE_MODULES = (
+    "DonutDetailer", "DonutDetailer2", "DonutDetailer4", "DonutDetailer5",
+    "DonutDetailerXLBlocks", "DonutClipEncode", "DonutWidenMerge",
+    "donut_lora_nodes", "DonutSafeApplyLoRAStack", "hot_reload",
+    "DonutSDXLTeaCache", "DonutBlockCalibration", "DonutFrequencyAnalysis",
+    "DonutSpectralNoiseSharpener", "DonutKSamplerCFGLinear", "donut_lora_civitai",
+    "DonutTiledUpscale", "DonutColorPreservingUpscale", "DonutDetailerZIT",
+    "ModelMergeZIT", "DonutModelMergeKrea2", "ModelMergeZITBlocks",
+    "DonutModelSave", "DonutFaceDetailer", "DonutUniversalDetailer",
+    "DonutWeightVectorScale", "DonutGammaCorrection", "DonutAutoGamma",
+    "DonutHistogramStretch", "DonutAutoWhiteBalance", "DonutSharpen",
+    "DonutPromptInjection", "DonutZitConditioningRebalance", "DonutZitLayerBlendEncode",
+    "DonutKrea2ImageConditioning", "DonutKrea2FusionControl", "DonutKrea2FusionPreset",
+    "DonutImageAdjust",
+)
+_REQUIRED_OVERRIDES = {
+    "DonutSafeApplyLoRAStack": ("DonutApplyLoRAStack",),
+    "DonutKrea2FusionPreset": ("DonutKrea2FusionControl",),
 }
+for _module in _NODE_MODULES:
+    import_component(
+        __name__, _module, NODE_CLASS_MAPPINGS, NODE_DISPLAY_NAME_MAPPINGS,
+        overrides=_REQUIRED_OVERRIDES.get(_module, ()),
+    )
 
-NODE_DISPLAY_NAME_MAPPINGS = {
-    **d_lora,
-    **d_safe_lora,
-    **d_reload,
-    # **d_optuna,  # disabled - file not in repo
-    **d_teacache,
-    **d_calibration,
-    **d_freq_analysis,
-    **d_spectral_sharpener,
-    **d_donut_sampler,
-    **d_lora_civitai,
-    **d_tiled_upscale,
-    **d_color_upscale,
-    **d_zit_detailer,
-    **d_merge_zit,
-    **d_merge_krea2,
-    **d_merge_zit_blocks,
-    **d_model_save,
-    **d_face_detailer,
-    **d_universal_detailer,
-    **d_weight_vector_scale,
-    **d_gamma,
-    **d_auto_gamma,
-    **d_hist_stretch,
-    **d_white_balance,
-    **d_sharpen,
-    **d_prompt_injection,
-    **d_zit_rebalance,
-    **d_zit_layerblend,
-    **d_krea2_cond,
-    **d_krea2_fusion,
-    **d_krea2_fusion_preset,
-    **d_detailer,
-    **d_image_adjust,
-}
-
-# Nodes that were folded into multipurpose nodes. They stay registered so saved
-# workflows keep loading, but ComfyUI's DEPRECATED flag hides them from the
-# Add-Node menu. Labels keep a "(DEPRECATED)" suffix for any frontend that still
-# lists deprecated nodes.
+# Nodes folded into multipurpose nodes stay registered for saved workflows.
 _DEPRECATED_DISPLAY = {
     "DonutModelSave":                  "Model Save (No Workflow) (DEPRECATED)",
     "DonutCheckpointSave":             "Checkpoint Save (No Workflow) (DEPRECATED)",
@@ -226,7 +53,7 @@ _DEPRECATED_DISPLAY = {
     "Donut Simple Calibration":        "Donut Simple Calibration (DEPRECATED)",
     "Donut Sharpener (from reference)": "Donut Sharpener (from reference) (DEPRECATED)",
     "Donut Sharpener":                 "Donut Sharpener (DEPRECATED)",
-    "DonutLoRACivitAIInfo":            "Donut LoRA CivitAI Info (DEPRECATED)",
+    "DonutLoRACivitAIInfo":             "Donut LoRA CivitAI Info (DEPRECATED)",
     "DonutLoRAHashLookup":             "Donut LoRA Hash Lookup (DEPRECATED)",
     "DonutSampler (Advanced)":         "DonutSampler (Advanced) (DEPRECATED)",
     "DonutMultiModelSampler":          "DonutMultiModelSampler (DEPRECATED)",
@@ -248,8 +75,18 @@ for _cid, _label in _DEPRECATED_DISPLAY.items():
         _cls.DEPRECATED = True
         NODE_DISPLAY_NAME_MAPPINGS[_cid] = _label
 
-# Display name for the combined filler (its module exports no display mapping)
-NODE_DISPLAY_NAME_MAPPINGS["DonutFiller"] = "Donut Filler (Model + CLIP)"
+if "DonutFiller" in NODE_CLASS_MAPPINGS:
+    NODE_DISPLAY_NAME_MAPPINGS["DonutFiller"] = "Donut Filler (Model + CLIP)"
 
-# Web directory for custom JavaScript extensions
+_conflict = opencv_conflict(installed_versions())
+if _conflict:
+    LOGGER.warning("[DonutNodes] %s", _conflict)
+if IMPORT_FAILURES:
+    LOGGER.warning(
+        "[DonutNodes] Loaded %d nodes; %d component(s) failed. "
+        "Open a blank workflow and add Donut Dependency Check to inspect the errors. "
+        "Failed components: %s",
+        len(NODE_CLASS_MAPPINGS), len(IMPORT_FAILURES), ", ".join(IMPORT_FAILURES),
+    )
+
 WEB_DIRECTORY = "./web"

--- a/docs/dependencies.md
+++ b/docs/dependencies.md
@@ -1,0 +1,142 @@
+# Dependency compatibility and the built-in checker
+
+DonutNodes does not downgrade NumPy, reinstall PyTorch, or run pip when ComfyUI
+starts or a node executes. Those packages are shared with ComfyUI and other
+custom node packs. Repairing one pack must not silently change everyone else's
+runtime.
+
+## What is handled natively
+
+Each node module registers independently. A catchable import failure in an
+image-analysis or other component no longer discards every Donut node. The
+console names the failed component and retains the complete traceback. Nodes
+that actually require the broken dependency remain unavailable; the failure is
+not replaced by an identity operation or hidden behind a successful output.
+The settings/CivitAI routes are isolated too; a route import failure is recorded
+and those routes remain unavailable until repaired.
+
+The Safe LoRA and Krea2 Fusion preset overrides are mandatory for their existing
+node IDs. If an override fails, DonutNodes does not silently register its older
+base implementation with different behavior. Other nodes still load.
+
+OpenCV is no longer imported by the shared LoRA/block-weight utilities during
+startup. It is loaded only when mask dilation/erosion is executed, with an
+explicit dependency error on failure. The mask algorithm, LoRA arithmetic,
+model patches, fusion presets and saved input positions are unchanged.
+
+The binary dependencies in `requirements.txt` have minimum versions:
+
+| Dependency | Minimum |
+| --- | --- |
+| opencv-python-headless | 4.10.0.84 |
+| scipy | 1.13.1 |
+| matplotlib | 3.9.2 |
+
+These floors prevent an old pre-NumPy-2 wheel generation from satisfying a new
+DonutNodes installation merely because the package name is already installed.
+They are **not** a guarantee that every custom build or every future NumPy/Python
+combination is compatible. Pip still resolves versions for the active Python.
+No global NumPy upper bound, forced NumPy major version or PyTorch requirement
+is added. Dependency installation may still change transitive dependencies as
+part of pip's normal resolution; review the environment manager's proposed
+changes. Updating code alone does not repair previously installed wheels.
+
+## In ComfyUI
+
+Open a blank workflow, add **Donut Dependency Check** from **Donut/diagnostics**,
+and queue it. Use a blank workflow when the original workflow contains missing
+nodes, since ComfyUI cannot validate such a workflow just to run its checker.
+
+The default check is fast and read-only: it lists installed versions, the actual
+Python executable, failed DonutNodes startup components and their tracebacks.
+It also warns when multiple OpenCV distributions share the `cv2` namespace.
+The report appears as selectable text on the node, in its STRING output and in
+the console. The report widget is not serialized into the workflow.
+
+Enable `probe_imports` to test NumPy, the PyTorch/NumPy conversion bridge,
+OpenCV, SciPy FFT/ndimage/optimization, and Matplotlib's noninteractive renderer.
+Each test uses a separate child process with the same Python and import paths,
+a 20-second timeout, and a temporary Matplotlib cache. A crashed extension or a
+stalled probe is reported without crashing the **checker**. No model is loaded,
+no GPU is used, and no package-install command is executed. Normal startup
+imports are not subprocess-isolated; a true native crash during startup cannot
+be recovered by Python's exception handling.
+
+## When ComfyUI itself cannot start
+
+Run `donut_dependencies.py` as a script using the Python executable that launches
+ComfyUI. This standalone mode probes imports automatically; it cannot know a
+previous ComfyUI process's startup errors. Examples from the portable root or
+with an already activated virtual environment:
+
+```powershell
+# Windows portable, from the folder containing python_embeded and ComfyUI:
+.\python_embeded\python.exe -s ComfyUI\custom_nodes\ComfyUI-DonutNodes\donut_dependencies.py
+```
+
+```sh
+# Activated ComfyUI virtual environment; adapt the node-pack folder if renamed:
+python ComfyUI/custom_nodes/ComfyUI-DonutNodes/donut_dependencies.py
+```
+
+## Repair the identified package, not a guessed NumPy version
+
+For `compiled using NumPy 1.x`, `_ARRAY_API not found`, `multiarray failed to
+import` or `numpy.dtype size changed`, find the first traceback frame outside
+NumPy. Repair the indicated binary package using ComfyUI's interpreter or its
+environment manager, then **fully restart ComfyUI**. The checker does not infer
+a particular offending package from the generic NumPy warning alone.
+
+For DonutNodes' declared dependencies, update the pack and rerun its dependency
+installation (ComfyUI Manager's repair/reinstall route, or `-m pip install -r
+requirements.txt` using that interpreter). Review the OpenCV warning first.
+`pip check` can detect declared version conflicts but cannot establish that
+compiled extensions actually import; that is why the checker has import probes.
+
+A range such as `numpy<2.5,>=2.0` still installs **NumPy 2**. It does not resolve a
+NumPy-1-only extension's ABI mismatch by itself. An old PyTorch build may import
+with warnings yet fail on `.numpy()`/`torch.from_numpy()`; use the PyTorch/NumPy
+probe and repair the ComfyUI environment instead of replacing CUDA packages from
+inside a custom node.
+
+### OpenCV variants
+
+`opencv-python`, `opencv-python-headless`, `opencv-contrib-python`, and
+`opencv-contrib-python-headless` all supply `cv2`. Use only one appropriate
+variant. Donut's standard requirements select headless; requirements files
+cannot express "any one of these four installed distributions". If another
+node requires standard/contrib OpenCV, manage one compatible variant explicitly
+rather than blindly adding headless. The checker detects conflicts but does
+not uninstall other packs' dependencies. Even two identically versioned
+OpenCV distributions can overwrite the same files.
+
+## Scope and validation
+
+This protects DonutNodes registration and supplies diagnosis for the listed
+binary packages. It does not repair unrelated custom nodes, identify a package
+absent from the supplied traceback, fix a broken ComfyUI installation, or make
+an incompatible native binary safe to execute.
+
+```sh
+python test_dependency_isolation.py -v
+node --test tests/dependency_check_ui.test.mjs
+python donut_dependencies.py
+```
+
+The regression suite runs the real initializer with stand-ins for individual
+node modules and simulates import errors, failed required overrides, timeouts,
+and native crashes. The utility tests use real Torch/NumPy/Pillow/OpenCV when
+available; those tests are skipped when their optional test dependencies are
+missing. The frontend tests run the actual extension in an isolated JavaScript
+VM, not a full browser. Full ComfyUI/GPU/Windows-portable testing is separate.
+
+### Upstream references
+
+- NumPy's downstream import-error guidance:
+  https://numpy.org/devdocs/user/troubleshooting-importerror.html
+- SciPy 1.13 NumPy 2 support:
+  https://docs.scipy.org/doc/scipy/release/1.13.0-notes.html
+- OpenCV package releases and NumPy 2 wheels:
+  https://github.com/opencv/opencv-python/releases
+- OpenCV's one-variant installation guidance:
+  https://pypi.org/project/opencv-python/

--- a/donut_dependencies.py
+++ b/donut_dependencies.py
@@ -1,0 +1,267 @@
+"""Dependency isolation and read-only diagnostics; uses only the standard library.
+
+Never runs pip, changes NumPy, suppresses ABI errors, or imports optional binary
+packages just to query their versions. Import probes run only on request, in
+short-lived child processes, so a broken extension cannot crash the checker.
+"""
+
+import importlib
+from importlib import metadata
+import logging
+import os
+import shlex
+import subprocess
+import sys
+import tempfile
+import traceback
+
+
+LOGGER = logging.getLogger("DonutNodes.dependencies")
+IMPORT_FAILURES = {}
+OPENCV_DISTRIBUTIONS = (
+    "opencv-python", "opencv-python-headless",
+    "opencv-contrib-python", "opencv-contrib-python-headless",
+)
+DISTRIBUTIONS = ("numpy", "torch", "scipy", "matplotlib") + OPENCV_DISTRIBUTIONS
+ABI_MARKERS = (
+    "compiled using numpy 1.x", "_array_api not found",
+    "numpy.core.multiarray failed to import", "numpy.core.umath failed to import",
+    "numpy.dtype size changed", "numpy.ufunc size changed",
+)
+
+
+def _failure_record(component, error):
+    trace = "".join(traceback.format_exception(type(error), error, error.__traceback__))
+    return {
+        "component": component,
+        "error": f"{type(error).__name__}: {error}",
+        "numpy_abi_error": any(marker in trace.lower() for marker in ABI_MARKERS),
+        "traceback": trace,
+    }
+
+
+def import_component(package, module_name, classes=None, display_names=None, *, overrides=()):
+    """Import one component without disabling unrelated nodes on failure.
+
+    Required overrides fail closed: never silently fall back to an older node
+    implementation with different options, outputs or weight arithmetic.
+    Programming errors retain their complete traceback and are NOT labelled as
+    NumPy errors unless a recognized ABI error actually appears in the chain.
+    """
+    try:
+        module = importlib.import_module(f".{module_name}", package)
+        if classes is not None:
+            mappings = module.NODE_CLASS_MAPPINGS
+            names = getattr(module, "NODE_DISPLAY_NAME_MAPPINGS", {})
+            if not isinstance(mappings, dict) or not isinstance(names, dict):
+                raise TypeError(f"{module_name} must export dictionary node mappings")
+            missing = set(overrides) - mappings.keys()
+            if missing:
+                raise ValueError(f"{module_name} is missing required overrides: {sorted(missing)}")
+            # Validate everything before updating either public mapping.
+            classes.update(mappings)
+            if display_names is not None:
+                display_names.update(names)
+    except MemoryError:
+        raise
+    except Exception as error:
+        if classes is not None:
+            for key in overrides:
+                classes.pop(key, None)
+                if display_names is not None:
+                    display_names.pop(key, None)
+        record = _failure_record(module_name, error)
+        IMPORT_FAILURES[module_name] = record
+        kind = "NumPy binary incompatibility" if record["numpy_abi_error"] else "import failure"
+        LOGGER.error(
+            "[DonutNodes] %s: %s. Unrelated nodes will continue loading. "
+            "Use Donut Dependency Check for versions and diagnostics.\n%s",
+            module_name, kind, record["traceback"],
+        )
+        return None
+    IMPORT_FAILURES.pop(module_name, None)
+    return module
+
+
+def require_cv2(feature):
+    """OpenCV is only needed when executing image/mask operations, not LoRAs."""
+    try:
+        return importlib.import_module("cv2")
+    except (ImportError, AttributeError, ValueError, OSError, RuntimeError) as error:
+        raise RuntimeError(
+            f"[DonutNodes] {feature} requires a working OpenCV (cv2) installation. "
+            "Run Donut Dependency Check with probe_imports enabled in a blank workflow "
+            "to see the failing binary and installed OpenCV variants. Repair that "
+            "package in ComfyUI's Python environment and restart ComfyUI; do not "
+            "blindly change NumPy. Original error: "
+            f"{type(error).__name__}: {error}"
+        ) from error
+
+
+def installed_versions():
+    """Read distribution metadata without importing potentially broken wheels."""
+    result = {}
+    for name in DISTRIBUTIONS:
+        try:
+            result[name] = metadata.version(name)
+        except metadata.PackageNotFoundError:
+            result[name] = None
+    return result
+
+
+def opencv_conflict(versions):
+    present = [name for name in OPENCV_DISTRIBUTIONS if versions.get(name)]
+    if len(present) < 2:
+        return None
+    return (
+        "Multiple OpenCV distributions are installed: " + ", ".join(present) + ". "
+        "They share the cv2 namespace. Keep only one variant appropriate for your "
+        "other node packs; do not install headless alongside an existing variant. "
+        "Nothing has been uninstalled or changed automatically."
+    )
+
+
+def python_command(*arguments):
+    """Display a command for the actual interpreter, including portable -s."""
+    parts = [sys.executable]
+    if sys.flags.no_user_site:
+        parts.append("-s")
+    parts.extend(arguments)
+    if os.name == "nt":
+        # PowerShell needs & before a quoted executable; quote arguments too.
+        return "& " + " ".join("'" + part.replace("'", "''") + "'" for part in parts)
+    return shlex.join(parts)
+
+
+# Fixed allowlist, not arbitrary code supplied through a node or server route.
+_PROBES = {
+    "numpy": "import numpy as np; assert np.zeros((2, 2)).sum() == 0",
+    "torch_numpy": (
+        "import numpy as np, torch; a = np.arange(4, dtype=np.float32); "
+        "assert np.array_equal(torch.from_numpy(a).numpy(), a)"
+    ),
+    "opencv": (
+        "import numpy as np, cv2; a = np.zeros((2, 2, 3), dtype=np.uint8); "
+        "assert cv2.cvtColor(a, cv2.COLOR_RGB2GRAY).shape == (2, 2)"
+    ),
+    "scipy": (
+        "import numpy as np; from scipy import fft, ndimage; "
+        "from scipy.optimize import linear_sum_assignment; "
+        "assert fft.fft2(np.zeros((2, 2))).shape == (2, 2); "
+        "assert ndimage.gaussian_filter(np.ones((2, 2)), 1).shape == (2, 2); "
+        "assert len(linear_sum_assignment(np.eye(2))[0]) == 2"
+    ),
+    "matplotlib": (
+        "from matplotlib.figure import Figure; "
+        "from matplotlib.backends.backend_agg import FigureCanvasAgg; "
+        "figure = Figure(figsize=(1, 1)); figure.subplots().plot([0, 1]); "
+        "FigureCanvasAgg(figure).draw()"
+    ),
+}
+
+
+def probe_dependency(name, timeout=20):
+    """Smoke-test imports and their NumPy bridge in an isolated child process."""
+    code = _PROBES[name]  # Reject unknown probes before starting any process.
+    command = [sys.executable]
+    if sys.flags.no_user_site:
+        command.append("-s")
+    # Match the running ComfyUI environment, including explicitly added paths.
+    paths = [os.path.abspath(path) for path in sys.path]
+    code = "import sys\nsys.path = " + repr(paths) + "\n" + code
+    command.extend(["-c", code])
+    with tempfile.TemporaryDirectory(prefix="donut-dependency-check-") as temp:
+        env = dict(os.environ, MPLBACKEND="Agg", MPLCONFIGDIR=temp)
+        try:
+            process = subprocess.run(
+                command, capture_output=True, text=True, encoding="utf-8",
+                errors="replace", timeout=timeout, env=env, cwd=temp,
+                shell=False,
+            )
+        except subprocess.TimeoutExpired:
+            return {"name": name, "status": "timeout", "output": f"Exceeded {timeout}s"}
+        except OSError as error:
+            return {"name": name, "status": "error", "output": str(error)}
+    output = (process.stdout + process.stderr).strip()
+    abi_warning = any(marker in output.lower() for marker in ABI_MARKERS)
+    return {
+        "name": name,
+        "status": "failed" if process.returncode or abi_warning else "ok",
+        "returncode": process.returncode,
+        "output": output,
+    }
+
+
+def dependency_report(probe_imports=False):
+    versions = installed_versions()
+    lines = [
+        "DonutNodes dependency report (read-only)",
+        f"Python: {sys.version.split()[0]}",
+        f"Interpreter: {sys.executable}",
+        "No packages were installed, removed, upgraded or downgraded.",
+        "\nInstalled distributions (metadata only, not proof of ABI compatibility):",
+    ]
+    lines.extend(f"  {name}: {value or 'not installed'}" for name, value in versions.items())
+    conflict = opencv_conflict(versions)
+    if conflict:
+        lines.extend(["", "WARNING: " + conflict])
+    lines.append(f"\nDonutNodes startup failures: {len(IMPORT_FAILURES)}")
+    for record in IMPORT_FAILURES.values():
+        lines.extend([f"\n[{record['component']}] {record['error']}", record["traceback"]])
+    if probe_imports:
+        lines.append("\nIsolated import/NumPy-bridge checks (up to 20 seconds each):")
+        for name in _PROBES:
+            result = probe_dependency(name)
+            lines.append(f"  {name}: {result['status']} (exit={result.get('returncode', 'n/a')})")
+            if result["output"]:
+                lines.append(result["output"])
+    else:
+        lines.append("\nImport checks not run. Enable probe_imports to test binary compatibility.")
+    lines.extend([
+        "\nNext steps for a failing check:",
+        "Repair/update the package identified by the first non-NumPy traceback frame, "
+        "using the interpreter above (or your environment manager), then restart ComfyUI.",
+        "For DonutNodes dependencies, rerun its installation requirements after updating "
+        "the node pack. Review OpenCV variant conflicts before doing so.",
+        "Do not blindly force-reinstall NumPy: a NumPy 2.x version range cannot make "
+        "a NumPy-1-only extension compatible. PyTorch/CUDA repairs belong to the "
+        "ComfyUI environment, not a custom node's automatic installer.",
+        "Package metadata check (does not test binary compatibility):",
+        python_command("-m", "pip", "check"),
+        "Only DonutNodes failures and the fixed probes above are covered; failures in "
+        "other node packs require their own traceback.",
+    ])
+    return "\n".join(lines)
+
+
+class DonutDependencyCheck:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {"probe_imports": ("BOOLEAN", {
+            "default": False,
+            "tooltip": "Read-only checks of NumPy, PyTorch/NumPy, OpenCV, SciPy and "
+                       "Matplotlib in child processes (up to 20 seconds each). "
+                       "Never installs packages. Use a blank workflow if nodes are missing.",
+        })}}
+
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("report",)
+    FUNCTION = "check"
+    CATEGORY = "Donut/diagnostics"
+    OUTPUT_NODE = True
+    DESCRIPTION = "Inspect dependency versions and startup failures without changing your Python environment."
+
+    @classmethod
+    def IS_CHANGED(cls, **kwargs):
+        return float("nan")
+
+    def check(self, probe_imports=False):
+        report = dependency_report(probe_imports)
+        print(report)
+        return {"ui": {"text": [report]}, "result": (report,)}
+
+
+if __name__ == "__main__":
+    # Standalone mode also works when ComfyUI itself cannot start. It has no
+    # in-process startup history, so probe imports unconditionally.
+    print(dependency_report(probe_imports=True))

--- a/libs/utils.py
+++ b/libs/utils.py
@@ -4,7 +4,6 @@ import numpy as np
 import torch
 from PIL import Image, ImageDraw
 import math
-import cv2
 import folder_paths
 import logging
 
@@ -307,6 +306,10 @@ def make_3d_mask(mask):
 
 def dilate_mask(mask: torch.Tensor, dilation_factor: float) -> torch.Tensor:
     """Dilate a mask using a square kernel with a given dilation factor."""
+    # LoRA/block-weight loading also imports this module, but does not use cv2.
+    from ..donut_dependencies import require_cv2
+    cv2 = require_cv2("Mask dilation/erosion")
+
     kernel_size = int(dilation_factor * 2) + 1
     kernel = np.ones((abs(kernel_size), abs(kernel_size)), np.uint8)
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,14 @@
 # Runtime dependencies not supplied by ComfyUI itself.
+# Minimum binary-wheel generations with NumPy 2 support. Do not pin/downgrade
+# NumPy globally: ComfyUI and other node packs share this interpreter.
+# These are floors, not a guarantee for every later NumPy/Python version.
 # ComfyUI Manager installs this file automatically; manual installs must use
 # the same Python interpreter that launches ComfyUI.
-opencv-python-headless
-scipy
-matplotlib
+# OpenCV variants share cv2: keep only one. See docs/dependencies.md if another
+# node pack already installed opencv-python or a contrib variant.
+opencv-python-headless>=4.10.0.84
+scipy>=1.13.1
+matplotlib>=3.9.2
 psutil
 tqdm
 requests

--- a/test_dependency_isolation.py
+++ b/test_dependency_isolation.py
@@ -1,0 +1,380 @@
+"""CPU dependency/registration regressions; no ComfyUI server or GPU required.
+
+Registration tests execute the real initializer with stand-ins for node modules.
+The shared utility tests below use real Torch/NumPy/Pillow when available.
+"""
+
+import ast
+import builtins
+from contextlib import redirect_stdout
+import importlib.util
+import io
+import math
+from pathlib import Path
+import subprocess
+import sys
+import types
+import unittest
+from unittest import mock
+
+ROOT = Path(__file__).resolve().parent
+spec = importlib.util.spec_from_file_location("_donut_dependency_tests", ROOT / "donut_dependencies.py")
+deps = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(deps)
+
+
+class DependencyTests(unittest.TestCase):
+    def setUp(self):
+        deps.IMPORT_FAILURES.clear()
+        self.logging = mock.patch.object(deps.LOGGER, "error")
+        self.logging.start()
+        self.addCleanup(self.logging.stop)
+
+    def test_failed_module_does_not_remove_unrelated_nodes(self):
+        existing = object()
+        classes, names = {"working": existing}, {"working": "Working"}
+        with mock.patch.object(deps.importlib, "import_module", side_effect=ImportError("numpy.core.multiarray failed to import")):
+            result = deps.import_component("test", "Broken", classes, names)
+        self.assertIsNone(result)
+        self.assertIs(classes["working"], existing)
+        self.assertEqual(names, {"working": "Working"})
+        self.assertTrue(deps.IMPORT_FAILURES["Broken"]["numpy_abi_error"])
+
+    def test_all_common_numpy_abi_signatures_are_recognized(self):
+        for message in deps.ABI_MARKERS:
+            with self.subTest(message=message):
+                record = deps._failure_record("test", ImportError(message))
+                self.assertTrue(record["numpy_abi_error"])
+
+    def test_chained_abi_failure_retains_original_traceback(self):
+        try:
+            try:
+                raise AttributeError("_ARRAY_API not found")
+            except AttributeError as error:
+                raise ImportError("outer import failed") from error
+        except ImportError as error:
+            record = deps._failure_record("cv2", error)
+        self.assertTrue(record["numpy_abi_error"])
+        self.assertIn("outer import failed", record["traceback"])
+        self.assertIn("_ARRAY_API not found", record["traceback"])
+        self.assertIn("test_chained_abi_failure", record["traceback"])
+
+    def test_programming_errors_are_not_mislabelled_numpy_errors(self):
+        with mock.patch.object(deps.importlib, "import_module", side_effect=ValueError("bad node schema")):
+            deps.import_component("test", "Broken", {})
+        record = deps.IMPORT_FAILURES["Broken"]
+        self.assertFalse(record["numpy_abi_error"])
+        self.assertIn("ValueError", record["traceback"])
+
+    def test_successful_import_merges_mappings_and_clears_stale_failure(self):
+        deps.IMPORT_FAILURES["Good"] = {"old": "failure"}
+        module = types.SimpleNamespace(NODE_CLASS_MAPPINGS={"A": object()}, NODE_DISPLAY_NAME_MAPPINGS={"A": "Alias"})
+        classes, names = {}, {}
+        with mock.patch.object(deps.importlib, "import_module", return_value=module):
+            self.assertIs(deps.import_component("test", "Good", classes, names), module)
+        self.assertIs(classes["A"], module.NODE_CLASS_MAPPINGS["A"])
+        self.assertEqual(names["A"], "Alias")
+        self.assertNotIn("Good", deps.IMPORT_FAILURES)
+
+    def test_display_mapping_is_optional(self):
+        module = types.SimpleNamespace(NODE_CLASS_MAPPINGS={"A": object()})
+        classes, names = {}, {}
+        with mock.patch.object(deps.importlib, "import_module", return_value=module):
+            deps.import_component("test", "Good", classes, names)
+        self.assertIn("A", classes)
+        self.assertEqual(names, {})
+
+    def test_invalid_display_mapping_does_not_partially_register(self):
+        module = types.SimpleNamespace(NODE_CLASS_MAPPINGS={"A": object()}, NODE_DISPLAY_NAME_MAPPINGS=None)
+        classes = {}
+        with mock.patch.object(deps.importlib, "import_module", return_value=module):
+            deps.import_component("test", "Bad", classes, {})
+        self.assertEqual(classes, {})
+
+    def test_failed_required_override_is_not_silently_replaced_by_base(self):
+        classes, names = {"Override": object(), "keep": object()}, {"Override": "Old"}
+        with mock.patch.object(deps.importlib, "import_module", side_effect=ImportError("missing dependency")):
+            deps.import_component("test", "OverrideModule", classes, names, overrides=("Override",))
+        self.assertNotIn("Override", classes)
+        self.assertNotIn("Override", names)
+        self.assertIn("keep", classes)
+
+    def test_missing_required_export_fails_closed(self):
+        module = types.SimpleNamespace(NODE_CLASS_MAPPINGS={"wrong": object()})
+        classes = {"Required": object()}
+        with mock.patch.object(deps.importlib, "import_module", return_value=module):
+            deps.import_component("test", "BadOverride", classes, {}, overrides=("Required",))
+        self.assertEqual(classes, {})
+        self.assertIn("missing required overrides", deps.IMPORT_FAILURES["BadOverride"]["error"])
+
+    def test_interrupt_exit_and_out_of_memory_are_not_swallowed(self):
+        for error in (KeyboardInterrupt(), SystemExit(), MemoryError()):
+            with self.subTest(error=type(error).__name__):
+                with mock.patch.object(deps.importlib, "import_module", side_effect=error):
+                    with self.assertRaises(type(error)):
+                        deps.import_component("test", "Broken", {})
+
+    def test_non_node_component_can_register_routes(self):
+        module = types.SimpleNamespace()
+        with mock.patch.object(deps.importlib, "import_module", return_value=module):
+            self.assertIs(deps.import_component("test", "routes"), module)
+
+    def test_metadata_checks_do_not_import_binary_packages(self):
+        def version(name):
+            if name == "numpy":
+                return "2.5.1"
+            raise deps.metadata.PackageNotFoundError(name)
+        with mock.patch.object(deps.metadata, "version", side_effect=version), mock.patch.object(
+            deps.importlib, "import_module", side_effect=AssertionError("binary import")
+        ):
+            versions = deps.installed_versions()
+        self.assertEqual(versions["numpy"], "2.5.1")
+        self.assertIsNone(versions["scipy"])
+
+    def test_opencv_conflict_checks_all_four_distributions(self):
+        for other in deps.OPENCV_DISTRIBUTIONS[1:]:
+            with self.subTest(other=other):
+                warning = deps.opencv_conflict({"opencv-python": "4.13", other: "4.13"})
+                self.assertIn(other, warning)
+                self.assertIn("share the cv2 namespace", warning)
+        self.assertIsNone(deps.opencv_conflict({"opencv-python": "4.13"}))
+        self.assertIsNone(deps.opencv_conflict({}))
+
+    def test_cv2_is_returned_without_changing_image_arithmetic(self):
+        cv2 = object()
+        with mock.patch.object(deps.importlib, "import_module", return_value=cv2) as loader:
+            self.assertIs(deps.require_cv2("Masks"), cv2)
+        loader.assert_called_once_with("cv2")
+
+    def test_cv2_failure_is_actionable_and_preserves_cause(self):
+        for error in (ImportError("missing"), AttributeError("_ARRAY_API not found"),
+                      ValueError("numpy.dtype size changed"), OSError("DLL load failed")):
+            with self.subTest(error=error):
+                with mock.patch.object(deps.importlib, "import_module", side_effect=error):
+                    with self.assertRaisesRegex(RuntimeError, "Donut Dependency Check") as raised:
+                        deps.require_cv2("Mask dilation/erosion")
+                self.assertIs(raised.exception.__cause__, error)
+                self.assertIn("Mask dilation/erosion", str(raised.exception))
+
+    def test_cv2_helper_does_not_catch_unrelated_type_error(self):
+        with mock.patch.object(deps.importlib, "import_module", side_effect=TypeError("bug")):
+            with self.assertRaises(TypeError):
+                deps.require_cv2("Mask")
+
+    def test_unknown_probe_never_starts_a_process(self):
+        with mock.patch.object(deps.subprocess, "run", side_effect=AssertionError("spawned")):
+            with self.assertRaises(KeyError):
+                deps.probe_dependency("arbitrary code")
+
+    def test_probes_use_running_python_no_shell_and_bounded_timeout(self):
+        result = types.SimpleNamespace(returncode=0, stdout="", stderr="")
+        with mock.patch.object(deps.subprocess, "run", return_value=result) as runner:
+            checked = deps.probe_dependency("numpy", timeout=7)
+        arguments, options = runner.call_args
+        self.assertEqual(arguments[0][0], sys.executable)
+        self.assertIn("-c", arguments[0])
+        self.assertNotIn("pip", arguments[0])
+        self.assertFalse(options["shell"])
+        self.assertEqual(options["timeout"], 7)
+        self.assertEqual(options["env"]["MPLBACKEND"], "Agg")
+        self.assertEqual(checked["status"], "ok")
+
+    def test_probes_preserve_portable_no_user_site_flag(self):
+        result = types.SimpleNamespace(returncode=0, stdout="", stderr="")
+        with mock.patch.object(deps.sys, "flags", types.SimpleNamespace(no_user_site=True)), mock.patch.object(
+            deps.subprocess, "run", return_value=result
+        ) as runner:
+            deps.probe_dependency("numpy")
+        self.assertEqual(runner.call_args.args[0][:2], [sys.executable, "-s"])
+
+    def test_timeout_and_native_crash_are_reported(self):
+        with mock.patch.object(deps.subprocess, "run", side_effect=subprocess.TimeoutExpired(["python"], 2)):
+            self.assertEqual(deps.probe_dependency("numpy", timeout=2)["status"], "timeout")
+        with mock.patch.object(deps.subprocess, "run", return_value=types.SimpleNamespace(returncode=-11, stdout="", stderr="crashed")):
+            result = deps.probe_dependency("numpy")
+        self.assertEqual(result["status"], "failed")
+        self.assertEqual(result["returncode"], -11)
+
+    def test_spawn_failure_is_reported(self):
+        with mock.patch.object(deps.subprocess, "run", side_effect=OSError("permission denied")):
+            self.assertEqual(deps.probe_dependency("numpy")["status"], "error")
+
+    def test_success_exit_with_numpy_abi_warning_is_not_a_pass(self):
+        with mock.patch.object(deps.subprocess, "run", return_value=types.SimpleNamespace(
+            returncode=0, stdout="", stderr="A module that was compiled using NumPy 1.x cannot be run"
+        )):
+            self.assertEqual(deps.probe_dependency("numpy")["status"], "failed")
+
+    def test_report_default_never_spawns_processes(self):
+        with mock.patch.object(deps, "installed_versions", return_value={"numpy": "2.5.1"}), mock.patch.object(
+            deps.subprocess, "run", side_effect=AssertionError("subprocess")
+        ):
+            report = deps.dependency_report()
+        self.assertIn(sys.executable, report)
+        self.assertIn("NumPy 2.x version range cannot", report)
+        self.assertIn("Import checks not run", report)
+        self.assertIn("pip", report)
+
+    def test_report_probes_are_fixed_allowlist(self):
+        with mock.patch.object(deps, "installed_versions", return_value={}), mock.patch.object(
+            deps, "probe_dependency", return_value={"status": "ok", "returncode": 0, "output": ""}
+        ) as probe:
+            report = deps.dependency_report(True)
+        self.assertEqual([c.args[0] for c in probe.call_args_list], list(deps._PROBES))
+        self.assertIn("torch_numpy: ok", report)
+
+    def test_diagnostic_node_has_visible_text_and_string_output(self):
+        with mock.patch.object(deps, "dependency_report", return_value="test report"), redirect_stdout(io.StringIO()):
+            output = deps.DonutDependencyCheck().check()
+        self.assertEqual(output["ui"]["text"], ["test report"])
+        self.assertEqual(output["result"], ("test report",))
+        self.assertTrue(deps.DonutDependencyCheck.OUTPUT_NODE)
+        self.assertTrue(math.isnan(deps.DonutDependencyCheck.IS_CHANGED()))
+
+    def test_requirements_have_binary_floors_but_no_global_numpy_pin(self):
+        text = (ROOT / "requirements.txt").read_text()
+        requirements = [line for line in text.splitlines() if line and not line.startswith("#")]
+        self.assertIn("opencv-python-headless>=4.10.0.84", requirements)
+        self.assertIn("scipy>=1.13.1", requirements)
+        self.assertIn("matplotlib>=3.9.2", requirements)
+        self.assertFalse(any(line.lower().startswith(("numpy", "torch")) for line in requirements))
+
+
+class BootstrapTests(unittest.TestCase):
+    def boot(self, failing=()):
+        package = "_donut_boot_test"
+        spec = importlib.util.spec_from_file_location(package, ROOT / "__init__.py", submodule_search_locations=[str(ROOT)])
+        module = importlib.util.module_from_spec(spec)
+        loaded = []
+        base_class, replacement_class = type("Base", (), {}), type("Override", (), {})
+
+        def importer(name, parent):
+            name = name[1:]
+            loaded.append(name)
+            if name in failing:
+                raise ImportError("numpy.core.multiarray failed to import")
+            mapping = {name: type(name, (), {})}
+            if name == "DonutKrea2FusionControl":
+                mapping = {"DonutKrea2FusionControl": base_class}
+            elif name == "DonutKrea2FusionPreset":
+                mapping = {"DonutKrea2FusionControl": replacement_class}
+            elif name == "donut_lora_nodes":
+                mapping = {"DonutApplyLoRAStack": base_class, "DonutFiller": type("Filler", (), {})}
+            elif name == "DonutSafeApplyLoRAStack":
+                mapping = {"DonutApplyLoRAStack": replacement_class}
+            return types.SimpleNamespace(NODE_CLASS_MAPPINGS=mapping, NODE_DISPLAY_NAME_MAPPINGS={})
+
+        with mock.patch.dict(sys.modules, {package: module, package + ".donut_dependencies": deps}), mock.patch.object(
+            deps.importlib, "import_module", side_effect=importer
+        ), mock.patch.object(deps, "installed_versions", return_value={}), mock.patch.object(
+            deps.LOGGER, "error"
+        ), mock.patch.object(deps.LOGGER, "warning"):
+            spec.loader.exec_module(module)
+        return module, loaded, replacement_class
+
+    def test_real_initializer_preserves_order_and_required_overrides(self):
+        module, loaded, replacement = self.boot()
+        self.assertEqual(loaded, ["shared.server_routes", *module._NODE_MODULES])
+        self.assertEqual(len(module._NODE_MODULES), 38)
+        for key in ("DonutApplyLoRAStack", "DonutKrea2FusionControl"):
+            self.assertIs(module.NODE_CLASS_MAPPINGS[key], replacement)
+        self.assertIn("DonutDependencyCheck", module.NODE_CLASS_MAPPINGS)
+        self.assertEqual(module.WEB_DIRECTORY, "./web")
+        self.assertEqual(module.NODE_DISPLAY_NAME_MAPPINGS["DonutFiller"], "Donut Filler (Model + CLIP)")
+
+    def test_broken_analysis_and_server_routes_do_not_hide_lora_or_fusion(self):
+        module, loaded, _ = self.boot({"DonutFrequencyAnalysis", "DonutSpectralNoiseSharpener", "shared.server_routes"})
+        for key in ("DonutApplyLoRAStack", "DonutKrea2FusionControl", "DonutImageAdjust", "DonutDependencyCheck"):
+            self.assertIn(key, module.NODE_CLASS_MAPPINGS)
+        self.assertEqual(len(deps.IMPORT_FAILURES), 3)
+        self.assertIn("DonutImageAdjust", loaded)
+
+    def test_failed_fusion_or_safe_lora_override_does_not_offer_wrong_base_node(self):
+        module, _, _ = self.boot({"DonutKrea2FusionPreset", "DonutSafeApplyLoRAStack"})
+        self.assertNotIn("DonutKrea2FusionControl", module.NODE_CLASS_MAPPINGS)
+        self.assertNotIn("DonutApplyLoRAStack", module.NODE_CLASS_MAPPINGS)
+        self.assertIn("DonutDependencyCheck", module.NODE_CLASS_MAPPINGS)
+        self.assertIn("DonutImageAdjust", module.NODE_CLASS_MAPPINGS)
+
+    def test_diagnostics_survive_when_all_real_components_fail(self):
+        source = ast.parse((ROOT / "__init__.py").read_text())
+        modules = next(ast.literal_eval(node.value) for node in source.body if isinstance(node, ast.Assign)
+                       and any(isinstance(t, ast.Name) and t.id == "_NODE_MODULES" for t in node.targets))
+        module, _, _ = self.boot(set(modules) | {"shared.server_routes"})
+        self.assertEqual(set(module.NODE_CLASS_MAPPINGS), {"DonutDependencyCheck"})
+
+    def test_deprecated_flags_still_apply_to_healthy_nodes(self):
+        module, _, _ = self.boot()
+        self.assertTrue(module.NODE_CLASS_MAPPINGS["DonutAutoGamma"].DEPRECATED)
+        self.assertTrue(module.NODE_DISPLAY_NAME_MAPPINGS["DonutAutoGamma"].endswith("(DEPRECATED)"))
+
+
+class SharedUtilsTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        try:
+            import torch
+            import numpy
+            import PIL
+        except ImportError as error:
+            raise unittest.SkipTest(f"Real utility tests need Torch, NumPy and Pillow: {error}")
+        cls.torch = torch
+        cls.numpy = numpy
+
+    def load_utils(self):
+        package_name = "_donut_utils_test"
+        package = types.ModuleType(package_name)
+        package.__path__ = [str(ROOT)]
+        libs = types.ModuleType(package_name + ".libs")
+        libs.__path__ = [str(ROOT / "libs")]
+        folders = types.ModuleType("folder_paths")
+        folders.folder_names_and_paths = {}
+        folders.add_model_folder_path = mock.Mock()
+        context = mock.patch.dict(sys.modules, {
+            package_name: package, libs.__name__: libs,
+            package_name + ".donut_dependencies": deps,
+            "folder_paths": folders,
+        })
+        context.start()
+        self.addCleanup(context.stop)
+        spec = importlib.util.spec_from_file_location(libs.__name__ + ".utils", ROOT / "libs" / "utils.py")
+        result = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(result)
+        return result, folders
+
+    def test_real_shared_utils_and_folder_setup_work_with_opencv_import_blocked(self):
+        original = builtins.__import__
+        def guarded(name, *args, **kwargs):
+            if name == "cv2" or name.startswith("cv2."):
+                raise ImportError("_ARRAY_API not found")
+            return original(name, *args, **kwargs)
+        with mock.patch("builtins.__import__", side_effect=guarded):
+            utils, folders = self.load_utils()
+            utils.add_folder_path_and_extensions("lbw_models", ["/models/lbw"], {".safetensors"})
+            self.assertEqual(utils.empty_latent().shape, (1, 4, 8, 8))
+            self.assertEqual(folders.folder_names_and_paths["lbw_models"], (["/models/lbw"], {".safetensors"}))
+
+    def test_dilation_fails_at_use_not_import_with_clear_message(self):
+        utils, _ = self.load_utils()
+        with mock.patch.object(deps.importlib, "import_module", side_effect=ImportError("_ARRAY_API not found")):
+            with self.assertRaisesRegex(RuntimeError, "Mask dilation/erosion"):
+                utils.dilate_mask(self.torch.ones((1, 4, 4)), 1)
+
+    def test_dilation_erosion_arithmetic_matches_previous_opencv_path(self):
+        try:
+            import cv2
+        except ImportError as error:
+            self.skipTest(f"Working OpenCV not installed: {error}")
+        utils, _ = self.load_utils()
+        mask = self.torch.tensor([[[0., 1., 0.], [1., 0., 0.], [0., 0., 1.]]])
+        for factor in (-2., -1., -.5, 0., .5, 1., 2.):
+            with self.subTest(factor=factor):
+                k = abs(int(factor * 2) + 1)
+                kernel = self.numpy.ones((k, k), self.numpy.uint8)
+                operation = cv2.dilate if factor > 0 else cv2.erode
+                reference = self.torch.stack([self.torch.from_numpy(operation(m, kernel, iterations=1)) for m in mask.numpy()])
+                self.assertTrue(self.torch.equal(utils.dilate_mask(mask, factor), reference))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/dependency_check_ui.test.mjs
+++ b/tests/dependency_check_ui.test.mjs
@@ -1,0 +1,85 @@
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import test from "node:test";
+import vm from "node:vm";
+
+const source = readFileSync(new URL("../web/donut_dependency_check.js", import.meta.url), "utf8")
+  .replace(/^import .*;\n/, "");
+
+function setup() {
+  let extension;
+  const app = { registerExtension(value) { extension = value; } };
+  const elements = [];
+  const document = {
+    createElement(tag) {
+      assert.equal(tag, "textarea");
+      const element = { style: {}, setAttribute(name, value) { this[name] = value; } };
+      elements.push(element);
+      return element;
+    },
+  };
+  vm.runInNewContext(source, { app, document });
+  const node = {
+    comfyClass: "DonutDependencyCheck", size: [200, 100], widgets: [],
+    addDOMWidget(name, type, element, options) {
+      const widget = { name, type, element, options };
+      this.widgets.push(widget);
+      return widget;
+    },
+    setSize(value) { this.size = value; },
+    setDirtyCanvas() { this.dirty = true; },
+  };
+  return { extension, node, elements };
+}
+
+test("only the diagnostic node is modified", () => {
+  const { extension, node, elements } = setup();
+  node.comfyClass = "DonutApplyLoRAStack";
+  extension.nodeCreated(node);
+  assert.equal(elements.length, 0);
+  assert.equal(node.widgets.length, 0);
+});
+
+test("report is selectable read-only text and not serialized into workflows", () => {
+  const { extension, node, elements } = setup();
+  extension.nodeCreated(node);
+  assert.equal(elements[0].readOnly, true);
+  assert.equal(node.widgets[0].options.serialize, false);
+  assert.equal(node.widgets[0].options.getValue(), "");
+  assert.equal(node.size[0], 520);
+});
+
+test("nodeCreated is idempotent", () => {
+  const { extension, node, elements } = setup();
+  extension.nodeCreated(node);
+  extension.nodeCreated(node);
+  assert.equal(elements.length, 1);
+  assert.equal(node.widgets.length, 1);
+});
+
+test("reports are displayed literally, not evaluated as HTML", () => {
+  const { extension, node, elements } = setup();
+  extension.nodeCreated(node);
+  node.onExecuted({ text: ["<script>unsafe()</script>", "NumPy failure"] });
+  assert.equal(elements[0].value, "<script>unsafe()</script>\nNumPy failure");
+  assert.equal(elements[0].innerHTML, undefined);
+  assert.equal(node.dirty, true);
+});
+
+test("execution preserves earlier callback context and return value", () => {
+  const { extension, node } = setup();
+  let context, received;
+  node.onExecuted = function (message) { context = this; received = message; return 42; };
+  extension.nodeCreated(node);
+  const message = { text: ["ok"] };
+  assert.equal(node.onExecuted(message), 42);
+  assert.equal(context, node);
+  assert.equal(received, message);
+});
+
+test("empty output does not crash the UI", () => {
+  const { extension, node, elements } = setup();
+  extension.nodeCreated(node);
+  node.onExecuted({});
+  assert.equal(elements[0].value, "");
+});

--- a/web/donut_dependency_check.js
+++ b/web/donut_dependency_check.js
@@ -1,0 +1,37 @@
+import { app } from "../../scripts/app.js";
+
+app.registerExtension({
+  name: "Donut.DependencyCheck",
+  nodeCreated(node) {
+    if (node.comfyClass !== "DonutDependencyCheck" || node._donutDependencyReport) return;
+    const text = document.createElement("textarea");
+    text.className = "comfy-multiline-input";
+    text.readOnly = true;
+    text.spellcheck = false;
+    text.placeholder = "Queue this node to inspect dependencies. No packages will be changed.";
+    text.style.fontFamily = "monospace";
+    text.style.fontSize = "12px";
+    text.style.width = "100%";
+    text.style.height = "100%";
+    text.setAttribute("aria-label", "DonutNodes dependency report");
+    const widget = node.addDOMWidget("dependency_report", "customtext", text, {
+      serialize: false,
+      getValue: () => "",
+      setValue: () => {},
+    });
+    widget.options.serialize = false;
+    node._donutDependencyReport = text;
+    node.setSize([Math.max(node.size[0], 520), Math.max(node.size[1], 320)]);
+
+    // Only this diagnostic node instance; no global/prototype patches or
+    // executable HTML. The report is selectable for copying into bug reports.
+    const previous = node.onExecuted;
+    node.onExecuted = function (message) {
+      const result = previous?.apply(this, arguments);
+      const value = message?.text;
+      text.value = Array.isArray(value) ? value.map(String).join("\n") : String(value ?? "");
+      this.setDirtyCanvas?.(true, true);
+      return result;
+    };
+  },
+});


### PR DESCRIPTION
## Why

A user reported the NumPy-1.x/NumPy-2.x binary incompatibility warning after installing missing node packs. The screenshot does not include the offending package's traceback, so this PR does **not** claim to identify or reproduce that user's exact environment failure.

Inspection of main at `d007308c24a9243d35f9c67b86b23bf3570d69af` found three preventable weaknesses in DonutNodes:

- OpenCV, SciPy and Matplotlib requirements had no minimum versions, allowing old installed binary generations to satisfy them.
- The initializer eagerly imported every node and the settings routes as one operation: a catchable error in one component could hide the entire pack.
- Shared LoRA/block-weight utilities imported OpenCV at module scope although only mask dilation/erosion used it.

## Changes

### Keep unrelated nodes available

Register all 38 original node modules independently, in the original order, with full exception-chain logging and a list of failed components. Settings/CivitAI routes are isolated as well. Preserve node IDs, deprecated flags, labels and `WEB_DIRECTORY`.

Required overrides fail closed: if Safe LoRA or the Krea2 Fusion preset implementation fails, the old base implementation is **not** silently exposed under that same node ID. Unrelated nodes and the diagnostic node remain available. MemoryError, KeyboardInterrupt and SystemExit propagate normally; ordinary programming errors retain their traceback and are not mislabelled as NumPy failures.

### Remove the unnecessary OpenCV dependency from LoRA startup

Move the `cv2` import from shared utilities into the mask operation, using a small helper with an actionable, chained error message. Existing mask arithmetic is unchanged. No LoRA math, fusion settings, model patches or embedded weights are changed.

### Improve installation requirements

Add minimum binary dependency generations:

```
opencv-python-headless>=4.10.0.84
scipy>=1.13.1
matplotlib>=3.9.2
```

No global NumPy pin, forced reinstall, PyTorch/CUDA replacement, startup pip command or node-execution package installation is introduced. These are minimum versions, not a guarantee for every future NumPy/Python release or custom build. Pip's normal dependency resolution can still change transitive dependencies during installation.

### Add native, read-only diagnostics

Add **Donut Dependency Check** under **Donut/diagnostics**, with selectable report text, a STRING output and console output. It reports the actual Python interpreter, installed distribution versions, DonutNodes startup failures and duplicate OpenCV providers.

Optional `probe_imports` runs five fixed checks in separate child processes using the same interpreter and import paths, preserving portable `-s` mode, with a 20-second timeout per check:

1. NumPy operations.
2. PyTorch/NumPy conversion in both directions.
3. OpenCV image conversion on a NumPy array.
4. SciPy FFT, ndimage and optimization.
5. Matplotlib's noninteractive renderer.

Crashes, timeouts, nonzero exits and NumPy ABI warnings are reported without crashing the checker. No arbitrary probe code or package-install operation is exposed. The script can also run standalone when ComfyUI cannot start. The report widget is plain text, read-only and not serialized into workflows.

Document usage, portable/venv commands, targeted repair, OpenCV variants and limits in `docs/dependencies.md`.

## Validation performed

- `python test_dependency_isolation.py -v`: **34/34 passed**, no skips in the local environment.
- `node --test tests/dependency_check_ui.test.mjs`: **6/6 passed**.
- All **5 real isolated dependency probes passed** locally.
- Modified Python files compile.
- Git blob hashes of all eight committed files match the exact locally tested files.

The registration tests execute the real initializer with stand-ins for individual node modules. They cover ABI errors and chained exceptions, unrelated-node survival, required-override failure, metadata-only checks, duplicate OpenCV packages, subprocess isolation/flags/allowlist, timeouts, simulated crashes and report output. JavaScript tests execute the actual extension in a VM, not a full browser.

The shared-utility tests use real Torch, NumPy, Pillow and OpenCV. With `cv2` imports deliberately blocked, the original byte-verified `libs/utils.py` fails to import, while the new utility module imports and its non-image helpers work. Mask dilation/erosion outputs match the original OpenCV operations exactly for seven positive/negative/zero factors.

Real probe environment: Python **3.13.5**, NumPy **2.3.5**, Torch **2.10.0+cpu**, SciPy **1.17.0**, Matplotlib **3.10.8**, OpenCV **4.13.0.92**. The local environment contains both standard and headless OpenCV; the checker correctly warns about that without changing either installation.

## Scope / limitations

- This is native prevention, failure isolation and diagnosis, **not an automatic repair of every custom node pack**.
- The screenshot's exact culprit remains unknown. `numpy<2.5,>=2.0` still selects NumPy 2.x and does not by itself fix a NumPy-1-only binary.
- Existing users with bad wheels need an appropriate dependency repair and a full ComfyUI restart; updating Python source alone does not replace installed binaries.
- Requirements still select headless OpenCV. Other installed OpenCV variants share `cv2`; the checker detects conflicts but does not uninstall dependencies that another pack may need. Requirements cannot express any-one-of-four providers.
- Normal startup imports are not subprocess-isolated: true native crashes at startup cannot be recovered by Python exception handling. Only the explicit probes have process isolation.
- Full ComfyUI workflow/GPU, Windows-portable, NumPy 1.x matrix and the reported NumPy 2.5.1 environment were **not** tested. The full repository suite was not run.

Based on main **after the merge of PR #45**. This PR leaves its LoRA/fusion changes and `uncensorfix_weights.py` untouched.