### PR TITLE
Streamline workflow: recursive text, dynamic LoRAs and seed domains (68 → 40 nodes)

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -18,7 +18,7 @@ IMPORT_FAILURES.clear()
 # unrelated model/conditioning nodes (or the diagnostic node) from loading.
 import_component(__name__, "shared.server_routes")
 
-# Keep the original registration order. The two overrides are deliberate:
+# Keep the original registration order. The overrides are deliberate:
 # failed overrides must NOT quietly expose an older, incompatible node class.
 _NODE_MODULES = (
     "DonutDetailer", "DonutDetailer2", "DonutDetailer4", "DonutDetailer5",
@@ -34,10 +34,15 @@ _NODE_MODULES = (
     "DonutPromptInjection", "DonutZitConditioningRebalance", "DonutZitLayerBlendEncode",
     "DonutKrea2ImageConditioning", "DonutKrea2FusionControl", "DonutKrea2FusionPreset",
     "DonutImageAdjust",
+    "donut_prompt", "donut_seed_plan", "donut_dynamic_lora",
+    "donut_upscale_stage", "donut_prompt_injection_recursive", "donut_grouped_merge",
 )
 _REQUIRED_OVERRIDES = {
     "DonutSafeApplyLoRAStack": ("DonutApplyLoRAStack",),
     "DonutKrea2FusionPreset": ("DonutKrea2FusionControl",),
+    "donut_upscale_stage": ("DonutTiledUpscale",),
+    "donut_prompt_injection_recursive": ("DonutPromptInjection",),
+    "donut_grouped_merge": ("DonutModelMergeKrea2",),
 }
 for _module in _NODE_MODULES:
     import_component(

--- a/docs/WORKFLOW_STREAMLINING.md
+++ b/docs/WORKFLOW_STREAMLINING.md
@@ -1,0 +1,130 @@
+# Workflow streamlining
+
+This change targets the supplied `ComfyUI_00016_.json`, not arbitrary graphs.
+It removes glue nodes while keeping model loading/merging, prompt authoring,
+conditioning, sampling, each upscale stage, face detailing and saving separate.
+
+## Result
+
+Across the root and both original subgraphs: **68 -> 40 nodes**, including
+subgraph proxies. Six external node packs are no longer referenced by the
+migrated workflow. This is a graph/dependency reduction, not a measured GPU
+speedup or a claim of pixel-identical output.
+
+| Original | Replacement |
+| --- | --- |
+| Eleven wildcard processors | Three Donut Text editors, each recursively resolves its own text |
+| Two three-slot LoRA stacks + apply + global-vector primitive | One Donut LoRA Loader with six preserved, editable rows and add/remove/reorder |
+| Five seed generators + filename seed string | One Donut Seed Plan with independent text, sampler and filename controls |
+| Concatenation, edit-negative text, three encoders, negative zeroing and display | One Donut Prompt Conditioning node with distinct full/face and raw/zeroed outputs |
+| Two Anything Everywhere controllers | Four explicit, checked links |
+| Group bypass controller | First/second-upscale enable switches, with lazy disabled execution |
+| Merge subgraph with two primitive fan-outs | Grouped body/fusion controls on the existing merge node; per-block controls remain available |
+
+Removed packs: `mikey_nodes`, `RES4LYF`, `cg-use-everywhere`,
+`derfuu_comfyui_moddednodes`, `ComfyUI_Comfyroll_CustomNodes`, `rgthree-comfy`.
+
+Intentionally retained: `ComfyUI-bleh` for the exact configured sampler preset,
+`was-node-suite-comfyui` for the configured WebP/history/naming/metadata saver,
+`comfyui-impact-pack` and `comfyui-impact-subpack` for SAM/detection/detailing,
+and `krea2-nag` for adjustable NAG. Hiding these imports in wrappers would not
+remove a dependency. Replacing these algorithms without validating parity
+would conflict with the requirement to retain functionality.
+
+## Install and load
+
+Use the PR branch `feat/workflow-streamlining` in the existing DonutNodes
+installation, restart ComfyUI, then refresh the browser to load the new
+extension. Load the separately supplied `ComfyUI_00016_Donut_Streamlined.json`; no manual rewiring is
+required. The ordinary model files, source image, wildcard text files and the
+five retained packs must still be present. Do not replace the whole DonutNodes
+installation with only the files changed in this PR.
+
+For reproducibility, the guarded migration can regenerate the graph from the
+original uploaded JSON:
+
+```sh
+python tools/streamline_workflow.py /path/to/ComfyUI_00016_.json workflows/ComfyUI_00016_Donut_Streamlined.json
+```
+
+The source is never overwritten. Unknown layouts or incompatible link sources
+fail rather than silently dropping them. The original workflow remains usable
+with its original packs; the old three-slot LoRA nodes remain registered.
+
+## Text and seed behavior
+
+Donut Text supports TXT wildcards in the existing ComfyUI user/root wildcard
+locations, registered wildcard directories and this pack's `wildcards` folder.
+It supports nested `__file__` references, `{a|b}` choices, `<random:min:max>`,
+`N$$__file__`, repeated-name `!`, `+`, `-`, `*` modifiers, whole-word OR filters,
+subfolders, date macros and node/widget macros. File-line selection and
+per-pass seed restarts follow the source processor's convention. Blank lines
+and comment-looking lines still count. The default nesting limit is 128,
+configurable up to 1024, with cycle, expansion-count and output-size guards.
+Missing files default to a clear error rather than disappearing; `keep` and
+legacy-style `empty` policies are available. Paths cannot escape wildcard
+roots. RNG state is local, and file changes invalidate cached results.
+
+All authoring text editors, prompt injection and the editable negative text in
+conditioning receive the same **text seed**. Already-expanded face/scene text
+is not expanded again in conditioning. The face prompt is not silently changed
+to the combined scene prompt. Raw negative conditioning still reaches NAG;
+zeroed negative conditioning still reaches the sampling stages.
+
+Sampling uses a separate master seed. The four stage seeds are master plus
+`0, 2, 3, 4`, modulo `2**53`, so they remain distinct and lossless in JavaScript.
+The old second-upscale/face collision is intentionally fixed. This changes the
+face stage's seed from the previous master+3 to master+4. Text and sampler
+controls start with the source's current seed but can now be frozen/randomized
+independently. Filename randomness has its own retained control. Per-face and
+per-model variation inside the existing samplers is not rewritten.
+
+## LoRA behavior
+
+Rows have stable IDs and are serialized as one canonical JSON value, not as a
+variable list of positional widgets. Reordering/removal therefore moves the
+entire row, including model/CLIP strengths, block preset/vector, global-vector
+inheritance, disabled state and hash. There is no fixed three/six-slot ceiling;
+a two-megabyte configuration limit prevents unreasonable inputs. The editor
+preserves malformed saved JSON for repair rather than replacing it with `[]`.
+Filename edits clear stale hashes; late execution results cannot attach a hash
+to a different filename. CivitAI per-row information/previews are retained.
+
+The existing Donut stack builder handles resolution and metadata in chunks;
+**the existing safe applier is called only once, on the complete stack**. This
+preserves whole-stack energy budgeting, duplicate handling, text-fusion weights,
+block weighting, safety options and experimental bypass behavior. The separate
+Donut Dynamic LoRA Stack node remains available for workflows that need a
+reusable stack without loading a model at the same boundary.
+
+## Compatibility and validation
+
+Existing Tiled Upscale defaults to enabled, and existing Krea2 merge defaults to
+Per block. Their original algorithms remain the implementation. Prompt
+Injection retains its original type and style controls, with recursive output
+processing added. Registration uses Donut's existing isolated-import mechanism;
+a failed override is reported rather than silently exposing an incompatible
+older implementation.
+
+Run the dependency-free tests from the repository root:
+
+```sh
+DONUT_WORKFLOW_SOURCE=/path/to/ComfyUI_00016_.json python -m unittest discover -s tests -p test_streamlining.py -v
+node --test tests/test_streamlining_frontend.cjs
+```
+
+At preparation: **45 Python tests and 11 JavaScript contract tests pass**.
+Python checks reciprocal links/types, subgraph boundaries, acyclicity,
+parameter and bypass preservation against the original upload, seed routing,
+recursive wildcard safety and mocked legacy delegation. JavaScript executes
+the extension against a small DOM/Comfy harness, covering row operations,
+serialization, repair, hash races, presets, seed controls and grouped widgets.
+The eight real-workflow tests require `DONUT_WORKFLOW_SOURCE`; without it they
+are explicitly skipped and the 37 other Python tests still run. No workflow
+fixture is committed; the workflow files are delivered separately.
+
+Not performed: a real ComfyUI browser import/queue, model loading, CivitAI
+network access, GPU inference or image-output parity testing. The PR is a draft
+until those are checked. In particular, test both upscale toggles, editing on
+and off, NAG enabled, LoRA add/reorder/save/reload, and a fixed-seed queue with
+real nested wildcard files. No claim is made that CPU mocks prove GPU parity.

--- a/donut_dynamic_lora.py
+++ b/donut_dynamic_lora.py
@@ -1,0 +1,163 @@
+"""Resizable LoRA rows; reuse Donut resolution/metadata and whole-stack safety."""
+from __future__ import annotations
+from copy import deepcopy
+import json
+import math
+import logging
+from pathlib import Path
+
+from . import donut_lora_nodes as _legacy
+from .donut_lora_nodes import DonutLoRAStack
+from .DonutSafeApplyLoRAStack import DonutApplyLoRAStackSafe
+
+
+def parse_slots(value):
+    if isinstance(value, str):
+        if len(value) > 2_000_000:
+            raise ValueError("LoRA slot configuration is too large")
+        value = json.loads(value)
+    if not isinstance(value, list):
+        raise ValueError("LoRA slots must be a JSON array")
+    result, ids = [], set()
+    for index, item in enumerate(value):
+        if not isinstance(item, dict):
+            raise ValueError(f"LoRA row {index + 1} must be an object")
+        row = dict(id=str(index + 1), enabled=True, lora_name="None", model_weight=1.0,
+                   clip_weight=1.0, block_vector="", block_preset="None", lora_hash="", inherit_block_vector=False)
+        row.update(item)
+        row["id"] = str(row["id"])
+        if not row["id"] or row["id"] in ids:
+            raise ValueError(f"Duplicate/empty LoRA row ID: {row['id']!r}")
+        ids.add(row["id"])
+        for flag in ("enabled", "inherit_block_vector"):
+            if not isinstance(row[flag], bool):
+                raise ValueError(f"Row {index + 1}: {flag} must be true or false")
+        for key in ("lora_name", "block_vector", "block_preset", "lora_hash"):
+            if not isinstance(row[key], str):
+                raise ValueError(f"Row {index + 1}: {key} must be text")
+        for key in ("model_weight", "clip_weight"):
+            if isinstance(row[key], bool):
+                raise ValueError(f"Row {index + 1}: {key} must be a finite number")
+            row[key] = float(row[key])
+            if not math.isfinite(row[key]) or not -1000 <= row[key] <= 1000:
+                raise ValueError(f"Row {index + 1}: {key} must be finite and between -1000 and 1000")
+        result.append(row)
+    return result
+
+
+def slot_inputs():
+    legacy = DonutLoRAStack.INPUT_TYPES()["required"]
+    return {
+        "model_type": deepcopy(legacy["model_type"]),
+        "slots_json": ("STRING", {"default": "[]", "multiline": True, "dynamicPrompts": False,
+                                   "donut_loras": list(legacy["lora_name_1"][0]),
+                                   "donut_presets": list(legacy["block_preset_1"][0])}),
+        "global_block_vector": ("STRING", {"default": "", "tooltip": "Used only by rows with Inherit global enabled."}),
+        "civitai_lookup": deepcopy(legacy["civitai_lookup"]),
+    }
+
+
+def build_dynamic_stack(slots_json, model_type="Auto", global_block_vector="", civitai_lookup="Off", lora_stack=None):
+    rows = parse_slots(slots_json)
+    stack, metadata = list(lora_stack or ()), []
+    builder = DonutLoRAStack()
+    # The legacy builder remains a single source of truth for block vectors,
+    # hash-based relocation and CivitAI metadata. Applying in chunks would be
+    # WRONG: the limiter must see the complete stack, once, after this loop.
+    for start in range(0, len(rows), 3):
+        chunk = rows[start:start + 3]
+        args = dict(model_type=model_type, civitai_lookup=civitai_lookup, lora_stack=stack,
+                    unique_id="dynamic-slots", extra_pnginfo={"workflow": {"nodes": [
+                        {"id": "dynamic-slots", "properties": {"lora_hashes": [r["lora_hash"] for r in chunk]}}
+                    ]}})
+        for slot in range(1, 4):
+            row = chunk[slot - 1] if slot <= len(chunk) else None
+            args.update({f"switch_{slot}": "On" if row and row["enabled"] else "Off",
+                         f"lora_name_{slot}": row["lora_name"] if row else "None",
+                         f"model_weight_{slot}": row["model_weight"] if row else 1.0,
+                         f"clip_weight_{slot}": row["clip_weight"] if row else 1.0,
+                         f"block_preset_{slot}": row["block_preset"] if row else "None",
+                         f"block_vector_{slot}": (global_block_vector if row["inherit_block_vector"] else row["block_vector"]) if row else ""})
+        previous_length = len(stack)
+        built = builder.build_stack(**args)
+        stack = list(built["result"][0])
+        ui = built.get("ui", {})
+        texts, images = ui.get("text", []), ui.get("images", [])
+        resolved = iter(stack[previous_length:])
+        for index, row in enumerate(chunk):
+            file_hash = row["lora_hash"]
+            resolved_name = row["lora_name"]
+            if row["enabled"] and row["lora_name"] != "None":
+                resolved_name = next(resolved)[0]
+                hash_fn = getattr(_legacy, "get_or_compute_hash", None)
+                if hash_fn is not None:
+                    import folder_paths
+                    path = folder_paths.get_full_path("loras", resolved_name)
+                    if path and Path(path).is_file():
+                        try:
+                            file_hash = hash_fn(path, use_cache=True)
+                        except (OSError, ValueError) as exc:
+                            logging.getLogger(__name__).warning("LoRA metadata hash unavailable for %s: %s", resolved_name, exc)
+            metadata.append({"id": row["id"], "lora_name": row["lora_name"], "lora_hash": file_hash,
+                             "resolved_name": resolved_name,
+                             "text": texts[index + 3] if index + 3 < len(texts) else row["lora_name"],
+                             "image": images[index] if index < len(images) else None})
+    return stack, metadata
+
+
+class DonutDynamicLoRAStack:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": slot_inputs(), "optional": {"lora_stack": ("LORA_STACK",)}}
+    RETURN_TYPES = ("LORA_STACK",)
+    RETURN_NAMES = ("lora_stack",)
+    FUNCTION = "build"
+    CATEGORY = "donut/LoRA"
+    OUTPUT_NODE = True
+
+    def build(self, **kwargs):
+        stack, metadata = build_dynamic_stack(**kwargs)
+        return {"ui": {"donut_loras": metadata}, "result": (stack,)}
+
+    @classmethod
+    def IS_CHANGED(cls, slots_json="[]", lora_stack=None, **kwargs):
+        import folder_paths
+        names = [r["lora_name"] for r in parse_slots(slots_json) if r["enabled"]]
+        names += [entry[0] for entry in (lora_stack or ())]
+        result = []
+        for name in names:
+            path = folder_paths.get_full_path("loras", name) if name != "None" else None
+            if path and Path(path).is_file():
+                stat = Path(path).stat()
+                result.append((name, str(path), stat.st_mtime_ns, stat.st_size))
+            else:
+                result.append((name, None))
+        return tuple(result)
+
+
+class DonutLoRALoader(DonutDynamicLoRAStack):
+    @classmethod
+    def INPUT_TYPES(cls):
+        safety = deepcopy(DonutApplyLoRAStackSafe.INPUT_TYPES())
+        required = {"model": ("MODEL",), "clip": ("CLIP",), **slot_inputs()}
+        required.update({key: spec for key, spec in safety["required"].items() if key not in ("model", "clip", "lora_stack")})
+        # Keep execution_mode after the safety widgets, as in the original node.
+        required.update(safety.get("optional", {}))
+        return {"required": required, "optional": {"lora_stack": ("LORA_STACK",)}}
+    RETURN_TYPES = ("MODEL", "CLIP", "LORA_STACK", "STRING")
+    RETURN_NAMES = ("model", "clip", "lora_stack", "show_help")
+    FUNCTION = "load"
+    OUTPUT_NODE = False
+
+    def load(self, model, clip, slots_json="[]", model_type="Auto", global_block_vector="", civitai_lookup="Off", lora_stack=None, **safety):
+        stack, metadata = build_dynamic_stack(slots_json, model_type, global_block_vector, civitai_lookup, lora_stack)
+        import folder_paths
+        for name, mw, cw, _ in stack:
+            if (mw or cw) and not folder_paths.get_full_path("loras", name):
+                raise FileNotFoundError(f"Enabled LoRA could not be resolved: {name}")
+        model, clip, help_text = DonutApplyLoRAStackSafe().apply_stack(model, clip, stack, **safety)
+        return {"ui": {"donut_loras": metadata}, "result": (model, clip, stack, help_text)}
+
+
+NODE_CLASS_MAPPINGS = {"DonutDynamicLoRAStack": DonutDynamicLoRAStack, "DonutLoRALoader": DonutLoRALoader}
+NODE_DISPLAY_NAME_MAPPINGS = {"DonutDynamicLoRAStack": "Donut Dynamic LoRA Stack", "DonutLoRALoader": "Donut LoRA Loader · Dynamic"}

--- a/donut_grouped_merge.py
+++ b/donut_grouped_merge.py
@@ -1,0 +1,34 @@
+"""Replace ratio fan-out wiring with optional grouped controls; retain all sliders."""
+from copy import deepcopy
+from .DonutModelMergeKrea2 import NODE_CLASS_MAPPINGS as _nodes
+_Base = _nodes["DonutModelMergeKrea2"]
+
+
+class DonutModelMergeKrea2Grouped(_Base):
+    @classmethod
+    def INPUT_TYPES(cls):
+        result = deepcopy(_Base.INPUT_TYPES())
+        result.setdefault("optional", {}).update({
+            "ratio_mode": (["Per block", "Grouped"], {"default": "Per block"}),
+            "body_ratio": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+            "fusion_ratio": ("FLOAT", {"default": 1.0, "min": 0.0, "max": 1.0, "step": 0.01}),
+        })
+        return result
+    FUNCTION = "merge_grouped"
+
+    def merge_grouped(self, ratio_mode="Per block", body_ratio=1.0, fusion_ratio=1.0, **kwargs):
+        if ratio_mode not in ("Per block", "Grouped"):
+            raise ValueError(f"Unknown ratio mode: {ratio_mode}")
+        if ratio_mode == "Grouped":
+            if not 0 <= body_ratio <= 1 or not 0 <= fusion_ratio <= 1:
+                raise ValueError("Grouped merge ratios must be between 0 and 1")
+            for name in ("first.", "last.", *(f"blocks.{i}." for i in range(28))):
+                kwargs[name] = body_ratio
+            for name in ("txtfusion.layerwise_blocks.0.", "txtfusion.layerwise_blocks.1.", "txtfusion.projector.",
+                         "txtfusion.refiner_blocks.0.", "txtfusion.refiner_blocks.1."):
+                kwargs[name] = fusion_ratio
+        return getattr(_Base, _Base.FUNCTION)(self, **kwargs)
+
+
+NODE_CLASS_MAPPINGS = {"DonutModelMergeKrea2": DonutModelMergeKrea2Grouped}
+NODE_DISPLAY_NAME_MAPPINGS = {"DonutModelMergeKrea2": "Donut Model Merge Krea2"}

--- a/donut_prompt.py
+++ b/donut_prompt.py
@@ -1,0 +1,267 @@
+"""Bounded, deterministic prompt expansion; no third-party node imports.
+
+Mikey-compatible selection semantics are intentionally retained: file selection
+starts at seed % line_count, repeated names accept !/+/-/*, N$$ selects N lines,
+filters are whole-word OR matches, and each nesting pass restarts the seed.
+"""
+from __future__ import annotations
+
+from datetime import datetime
+from functools import lru_cache
+from pathlib import Path
+import json
+import random
+import re
+
+MAX_TEXT = 1_000_000
+MAX_EXPANSIONS = 10_000
+FILE_TOKEN = re.compile(r"(?:(\d+)\$\$)?__([!+*\-]?)([^|\n]*?)(\|[^\n]*?)?__")
+CHOICE = re.compile(r"\{([^{}]*)\}")
+NUMBER = re.compile(r"<random:(-?\d*\.?\d+):(-?\d*\.?\d+)>")
+MACRO = re.compile(r"%([^%\n]+)%")
+
+
+def wildcard_roots():
+    import folder_paths
+    user = Path(folder_paths.get_user_directory()) / "wildcards"
+    legacy = Path(folder_paths.__file__).resolve().parent / "wildcards"
+    roots = [user if user.is_dir() else legacy]
+    try:
+        roots.extend(Path(p) for p in folder_paths.get_folder_paths("wildcards"))
+    except KeyError:
+        pass
+    roots.append(Path(__file__).resolve().parent / "wildcards")
+    return tuple(dict.fromkeys(p.resolve() for p in roots))
+
+
+@lru_cache(maxsize=256)
+def _read_lines(path, mtime_ns, size):
+    if size > MAX_TEXT:
+        raise ValueError(f"Wildcard file exceeds {MAX_TEXT} bytes: {path}")
+    # Preserve blank lines/comment-looking lines: the source processor counts them.
+    with open(path, encoding="utf-8-sig") as handle:
+        return tuple(line.strip() for line in handle)
+
+
+def directory_fingerprint(roots=None):
+    result = []
+    for root in (wildcard_roots() if roots is None else roots):
+        root = Path(root).resolve()
+        for path in sorted(root.rglob("*.txt")) if root.is_dir() else ():
+            if path.is_file() and path.resolve().is_relative_to(root):
+                stat = path.stat()
+                result.append((str(path.resolve()), stat.st_mtime_ns, stat.st_size))
+    return tuple(result)
+
+
+def _file_lines(name, roots):
+    name = name.replace("\\", "/")
+    if not name or name.startswith("/") or ":" in name or ".." in name.split("/"):
+        raise ValueError(f"Unsafe wildcard path: {name!r}")
+    for root in roots:
+        root = Path(root).resolve()
+        path = (root / (name + ".txt")).resolve()
+        if not path.is_relative_to(root):
+            raise ValueError(f"Wildcard escapes its directory: {name!r}")
+        if path.is_file():
+            stat = path.stat()
+            lines = _read_lines(str(path), stat.st_mtime_ns, stat.st_size)
+            if not lines:
+                raise ValueError(f"Empty wildcard file: {path}")
+            return lines
+    return None
+
+
+def _macros(text, prompt, extra_pnginfo, now):
+    prompt = json.loads(prompt) if isinstance(prompt, str) else (prompt or {})
+    extra = json.loads(extra_pnginfo) if isinstance(extra_pnginfo, str) else (extra_pnginfo or {})
+    workflow = extra.get("workflow", extra)
+    workflow = json.loads(workflow) if isinstance(workflow, str) else workflow
+    nodes = list(workflow.get("nodes", [])) if isinstance(workflow, dict) else []
+    for graph in workflow.get("definitions", {}).get("subgraphs", []) if isinstance(workflow, dict) else []:
+        nodes.extend(graph.get("nodes", []))
+    aliases = {}
+    for node in nodes:
+        for alias in (str(node.get("id")), node.get("title"), node.get("properties", {}).get("Node name for S&R")):
+            if alias:
+                aliases.setdefault(alias, []).append(node)
+
+    def replace(match):
+        key = match[1]
+        if key.startswith("date:"):
+            values = dict(zip(("yyyy", "yy", "MM", "M", "dd", "d", "hh", "h", "mm", "m", "ss", "s"),
+                              (now.strftime("%Y"), now.strftime("%y"), f"{now.month:02}", str(now.month),
+                               f"{now.day:02}", str(now.day), f"{now.hour:02}", str(now.hour),
+                               f"{now.minute:02}", str(now.minute), f"{now.second:02}", str(now.second))))
+            return re.sub("|".join(values), lambda m: values[m[0]], key[5:])
+        if "." not in key:
+            return match[0]
+        alias, widget = key.split(".", 1)
+        matches = {str(n["id"]): n for n in aliases.get(alias, [])}
+        if not matches and alias in prompt:
+            value = prompt[alias].get("inputs", {}).get(widget)
+        elif len(matches) == 1:
+            uid, node = next(iter(matches.items()))
+            value = prompt.get(uid, {}).get("inputs", {}).get(widget)
+            if value is None:
+                value = node.get("widgets_values_named", {}).get(widget)
+        elif len(matches) > 1:
+            raise ValueError(f"Ambiguous prompt macro %{key}%; use a node ID")
+        else:
+            return match[0]
+        return str(value) if isinstance(value, (str, int, float, bool)) else match[0]
+    return MACRO.sub(replace, text)
+
+
+def expand_text(text, seed=0, max_depth=128, missing="error", *, roots=None, prompt=None, extra_pnginfo=None):
+    if not isinstance(text, str):
+        raise TypeError("Prompt must be a string")
+    if missing not in ("error", "keep", "empty"):
+        raise ValueError("missing must be error, keep, or empty")
+    if not 1 <= int(max_depth) <= 1024:
+        raise ValueError("max_depth must be between 1 and 1024")
+    roots = wildcard_roots() if roots is None else tuple(Path(p) for p in roots)
+    seed, seen, expansions = int(seed), set(), 0
+    now = datetime.now()
+    for _ in range(int(max_depth)):
+        if len(text) > MAX_TEXT:
+            raise ValueError("Expanded prompt exceeds the text size limit")
+        if text in seen:
+            raise ValueError("Cyclic wildcard expansion detected")
+        seen.add(text)
+        old = text
+        text = _macros(text, prompt, extra_pnginfo, now)
+        rng = random.Random(seed)
+        for _choice_depth in range(int(max_depth)):
+            if not CHOICE.search(text):
+                break
+            text, count = CHOICE.subn(lambda m: rng.choice(m[1].split("|")), text)
+            expansions += count
+            if expansions > MAX_EXPANSIONS:
+                raise ValueError("Wildcard expansion budget exceeded")
+        if CHOICE.search(text):
+            raise ValueError("Nested choices exceed max_depth")
+        rng = random.Random(seed)
+        text = NUMBER.sub(lambda m: str(round(rng.uniform(float(m[1]), float(m[2])), 4)), text)
+        rng = random.Random(seed)
+        offset, names, replaced = seed, set(), False
+
+        def replace_file(match):
+            nonlocal offset, expansions, replaced
+            count, modifier, name, filters = match.groups()
+            count = int(count or 1)
+            expansions += max(1, count)
+            if count > MAX_EXPANSIONS or expansions > MAX_EXPANSIONS:
+                raise ValueError("Wildcard expansion budget exceeded")
+            lines = _file_lines(name, roots)
+            if lines is None:
+                if missing == "error":
+                    raise ValueError(f"Wildcard not found: {name!r}; searched {', '.join(map(str, roots))}")
+                return match[0] if missing == "keep" else ""
+            replaced = True
+            current = offset
+            if name in names:
+                if modifier == "!": current = seed
+                elif modifier == "+": current = seed + 1
+                elif modifier == "-": current = seed - 1
+                else: current = rng.randint(0, 1_000_000)
+            selected = []
+            words = filters[1:].split("|") if filters else []
+            for index in range(count):
+                start = (current + index) % len(lines)
+                if words:
+                    found = next((lines[(start + j) % len(lines)] for j in range(len(lines))
+                                  if any(re.search(r"\b" + re.escape(word) + r"\b", lines[(start + j) % len(lines)], re.I)
+                                         for word in words)), None)
+                    if found is not None:
+                        selected.append(found)
+                else:
+                    selected.append(lines[start])
+            names.add(name)
+            offset += count
+            return ",".join(selected)
+
+        text = FILE_TOKEN.sub(replace_file, text)
+        if len(text) > MAX_TEXT:
+            raise ValueError("Expanded prompt exceeds the text size limit")
+        if text == old:
+            if replaced:
+                raise ValueError("Cyclic wildcard expansion detected")
+            return text
+        if not (FILE_TOKEN.search(text) or CHOICE.search(text) or NUMBER.search(text) or MACRO.search(text)):
+            return text
+    raise ValueError(f"Wildcard expansion exceeds max_depth={max_depth}")
+
+
+class DonutText:
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {
+            "text": ("STRING", {"default": "", "multiline": True, "dynamicPrompts": False}),
+            "seed": ("INT", {"default": 0, "min": 0, "max": 2**53 - 1, "control_after_generate": True}),
+            "max_depth": ("INT", {"default": 128, "min": 1, "max": 1024}),
+            "missing": (["error", "keep", "empty"],),
+        }, "optional": {"prefix": ("STRING", {"forceInput": True}),
+                         "suffix": ("STRING", {"forceInput": True}),
+                         "separator": ("STRING", {"default": ""})},
+            "hidden": {"prompt": "PROMPT", "extra_pnginfo": "EXTRA_PNGINFO"}}
+    RETURN_TYPES = ("STRING",)
+    RETURN_NAMES = ("text",)
+    FUNCTION = "process"
+    CATEGORY = "donut/text"
+
+    def process(self, text, seed=0, max_depth=128, missing="error", prefix=None, suffix=None, separator="", prompt=None, extra_pnginfo=None):
+        text = separator.join(part for part in (prefix, text, suffix) if part is not None)
+        result = expand_text(text, seed, max_depth, missing, prompt=prompt, extra_pnginfo=extra_pnginfo)
+        return {"ui": {"text": [result]}, "result": (result,)}
+
+    @classmethod
+    def IS_CHANGED(cls, **kwargs):
+        # Re-evaluate cheap text only (never CLIP) to include nested date/macros
+        # and file content changes in the dependency key, without global RNG.
+        parts = [kwargs.get(k) for k in ("prefix", "text", "suffix")]
+        text = kwargs.get("separator", "").join(t for t in parts if isinstance(t, str))
+        resolved = expand_text(text, kwargs.get("seed", 0) or 0,
+                               kwargs.get("max_depth", 128), kwargs.get("missing", "error"),
+                               prompt=kwargs.get("prompt"), extra_pnginfo=kwargs.get("extra_pnginfo"))
+        return directory_fingerprint(), resolved
+
+
+
+class DonutPromptConditioning:
+    """One encoding boundary; retain face/full prompts and raw/zeroed negatives."""
+    @classmethod
+    def INPUT_TYPES(cls):
+        return {"required": {
+            "clip": ("CLIP",), "face": ("STRING", {"forceInput": True}),
+            "scene": ("STRING", {"forceInput": True}), "negative": ("STRING", {"forceInput": True}),
+            "edit_negative": ("STRING", {"default": "", "multiline": True, "dynamicPrompts": False}),
+            "separator": ("STRING", {"default": ""}),
+            "text_seed": ("INT", {"default": 0, "min": 0, "max": 2**53 - 1}),
+        }}
+    RETURN_TYPES = ("STRING", "STRING", "STRING", "CONDITIONING", "CONDITIONING", "CONDITIONING", "CONDITIONING")
+    RETURN_NAMES = ("full_text", "face_text", "edit_negative", "positive", "face_positive", "negative_zeroed", "negative_raw")
+    FUNCTION = "encode"
+    CATEGORY = "donut/text"
+    OUTPUT_NODE = True
+
+    def encode(self, clip, face, scene, negative, edit_negative="", separator="", text_seed=0):
+        from nodes import CLIPTextEncode, ConditioningZeroOut
+        full = face + separator + scene  # Do not strip/normalise the user's text.
+        edit_negative = expand_text(edit_negative, text_seed)
+        encoder, cache = CLIPTextEncode(), {}
+        def encode_once(text):
+            if text not in cache:
+                cache[text] = encoder.encode(clip, text)[0]
+            return cache[text]
+        positive, face_positive, raw = (encode_once(t) for t in (full, face, negative))
+        zeroed = ConditioningZeroOut().zero_out(raw)[0]
+        return {"ui": {"text": [full]}, "result": (full, face, edit_negative, positive, face_positive, zeroed, raw)}
+
+    @classmethod
+    def IS_CHANGED(cls, edit_negative="", text_seed=0, **kwargs):
+        return directory_fingerprint(), expand_text(edit_negative or "", text_seed or 0)
+
+
+NODE_CLASS_MAPPINGS = {"DonutText": DonutText, "DonutPromptConditioning": DonutPromptConditioning}
+NODE_DISPLAY_NAME_MAPPINGS = {"DonutText": "Donut Text · Recursive Wildcards", "DonutPromptConditioning": "Donut Prompt Conditioning"}

--- a/donut_prompt_injection_recursive.py
+++ b/donut_prompt_injection_recursive.py
@@ -1,0 +1,36 @@
+"""Keep all existing style controls/UI; resolve their output with the text seed."""
+from copy import deepcopy
+from .DonutPromptInjection import NODE_CLASS_MAPPINGS as _nodes
+from .donut_prompt import expand_text, directory_fingerprint
+_Base = _nodes["DonutPromptInjection"]
+
+
+class DonutPromptInjectionRecursive(_Base):
+    @classmethod
+    def INPUT_TYPES(cls):
+        result = deepcopy(_Base.INPUT_TYPES())
+        result.setdefault("optional", {}).update({
+            "wildcard_depth": ("INT", {"default": 128, "min": 1, "max": 1024}),
+            "missing_wildcard": (["error", "keep", "empty"],),
+        })
+        # Disable client-side dynamic prompt expansion; Python owns the seed.
+        spec = result["required"]["prompt"]
+        result["required"]["prompt"] = (spec[0], {**(spec[1] if len(spec) > 1 else {}), "dynamicPrompts": False})
+        return result
+    FUNCTION = "process_recursive"
+
+    def process_recursive(self, wildcard_depth=128, missing_wildcard="error", **kwargs):
+        result = getattr(_Base, _Base.FUNCTION)(self, **kwargs)
+        values = list(result["result"] if isinstance(result, dict) else result)
+        values[0] = expand_text(values[0], kwargs.get("seed", 0), wildcard_depth, missing_wildcard)
+        if isinstance(result, dict):
+            return {**result, "result": tuple(values)}
+        return tuple(values)
+
+    @classmethod
+    def IS_CHANGED(cls, **kwargs):
+        return directory_fingerprint()
+
+
+NODE_CLASS_MAPPINGS = {"DonutPromptInjection": DonutPromptInjectionRecursive}
+NODE_DISPLAY_NAME_MAPPINGS = {"DonutPromptInjection": "Donut Prompt Injection"}

--- a/donut_seed_plan.py
+++ b/donut_seed_plan.py
@@ -1,0 +1,30 @@
+"""Explicit seed domains: one text seed, distinct reproducible sampling stages."""
+MAX_SEED = 2**53 - 1  # Lossless across Python, JSON and JavaScript.
+
+
+def stage_seeds(seed):
+    if isinstance(seed, bool) or not isinstance(seed, int) or not 0 <= seed <= MAX_SEED:
+        raise ValueError(f"seed must be an integer between 0 and {MAX_SEED}")
+    # Keep the old base/upscale offsets; fix the old upscale-2/face collision.
+    return tuple((seed + offset) % (MAX_SEED + 1) for offset in (0, 2, 3, 4))
+
+
+class DonutSeedPlan:
+    @classmethod
+    def INPUT_TYPES(cls):
+        seed = lambda: ("INT", {"default": 0, "min": 0, "max": MAX_SEED, "control_after_generate": True})
+        return {"required": {"text_seed": seed(), "sampler_seed": seed(), "filename_seed": seed()}}
+    RETURN_TYPES = ("INT", "INT", "INT", "INT", "INT", "STRING")
+    RETURN_NAMES = ("text", "base", "upscale_1", "upscale_2", "face", "filename")
+    CATEGORY = "donut/control"
+    FUNCTION = "generate"
+
+    def generate(self, text_seed, sampler_seed, filename_seed):
+        stage_seeds(text_seed)
+        stage_seeds(filename_seed)
+        stages = stage_seeds(sampler_seed)
+        return (text_seed, *stages, str(filename_seed))
+
+
+NODE_CLASS_MAPPINGS = {"DonutSeedPlan": DonutSeedPlan}
+NODE_DISPLAY_NAME_MAPPINGS = {"DonutSeedPlan": "Donut Seeds · Text / Samplers / Filename"}

--- a/donut_upscale_stage.py
+++ b/donut_upscale_stage.py
@@ -1,0 +1,29 @@
+"""Add a real, lazy enable switch without replacing the upscale algorithm."""
+from copy import deepcopy
+from .DonutTiledUpscale import NODE_CLASS_MAPPINGS as _nodes
+_Base = _nodes["DonutTiledUpscale"]
+
+
+class DonutTiledUpscaleStage(_Base):
+    @classmethod
+    def INPUT_TYPES(cls):
+        result = deepcopy(_Base.INPUT_TYPES())
+        for section in ("required", "optional"):
+            for name, spec in list(result.get(section, {}).items()):
+                if name != "image":
+                    result[section][name] = (spec[0], {**(spec[1] if len(spec) > 1 else {}), "lazy": True})
+        result.setdefault("optional", {})["enabled"] = ("BOOLEAN", {"default": True})
+        return result
+    FUNCTION = "run_stage"
+
+    def check_lazy_status(self, image, enabled=True, **kwargs):
+        return [key for key, value in kwargs.items() if value is None] if enabled else []
+
+    def run_stage(self, image, enabled=True, **kwargs):
+        if not enabled:
+            return (image, image)
+        return getattr(_Base, _Base.FUNCTION)(self, image=image, **kwargs)
+
+
+NODE_CLASS_MAPPINGS = {"DonutTiledUpscale": DonutTiledUpscaleStage}
+NODE_DISPLAY_NAME_MAPPINGS = {"DonutTiledUpscale": "Donut Tiled Upscale"}

--- a/tests/fixtures/README.md
+++ b/tests/fixtures/README.md
@@ -1,0 +1,11 @@
+# Workflow regression input
+
+The eight real-workflow migration checks use the supplied `ComfyUI_00016_.json`.
+Set `DONUT_WORKFLOW_SOURCE` to that file when running `test_streamlining.py`.
+Alternatively, place a gzip-compressed copy at `tests/fixtures/ComfyUI_00016_.json.gz`.
+Without the source, those eight checks are explicitly skipped; the 37 remaining
+Python unit/contract tests still run. The full user workflow and the migrated
+workflow are delivered separately rather than committed as test data.
+
+Original upload SHA-256:
+`d8be7eda6700ee4e9d35d36a53411c12b2a070363c178f2dd17748dc147fa9bc`

--- a/tests/test_streamlining.py
+++ b/tests/test_streamlining.py
@@ -1,0 +1,313 @@
+"""CPU-only unit/contract tests. They do not claim GPU or browser validation."""
+from copy import deepcopy
+from datetime import datetime as real_datetime
+import importlib.util
+import json
+import gzip
+import os
+from pathlib import Path
+import random
+import sys
+import tempfile
+import types
+import unittest
+from unittest.mock import patch
+
+ROOT = Path(__file__).resolve().parents[1]
+PKG = "_donut_streamline_test"
+package = types.ModuleType(PKG); package.__path__ = [str(ROOT)]; sys.modules[PKG] = package
+
+
+def load(name):
+    full = f"{PKG}.{name}"
+    spec = importlib.util.spec_from_file_location(full, ROOT / (name.replace(".", "/") + ".py"))
+    module = importlib.util.module_from_spec(spec); sys.modules[full] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+prompt = load("donut_prompt")
+seed_plan = load("donut_seed_plan")
+migration = load("tools.streamline_workflow")
+
+
+class PromptTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory(); self.root = Path(self.tmp.name)
+        self.roots = patch.object(prompt, "wildcard_roots", return_value=(self.root,)); self.roots.start()
+    def tearDown(self): self.roots.stop(); self.tmp.cleanup()
+    def file(self, name, text):
+        path = self.root / (name + ".txt"); path.parent.mkdir(parents=True, exist_ok=True); path.write_text(text, encoding="utf-8"); return path
+    def test_literal_whitespace_is_preserved(self): self.assertEqual(prompt.expand_text(" face  \n scene "), " face  \n scene ")
+    def test_nested_files_and_choices(self):
+        for i in range(40): self.file(f"n{i}", f"__n{i+1}__")
+        self.file("n40", "{red|blue} __subjects/bird__"); self.file("subjects/bird", "finch")
+        self.assertIn(prompt.expand_text("__n0__", 4), ("red finch", "blue finch"))
+    def test_exact_depth_choice(self): self.assertEqual(prompt.expand_text("{a}", max_depth=1), "a")
+    def test_repeated_modifiers_and_multi_line(self):
+        self.file("colors", "red\ngreen\nblue\n")
+        self.assertEqual(prompt.expand_text("__colors__ __!colors__ __+colors__ __-colors__", 2), "blue blue red green")
+        self.assertEqual(prompt.expand_text("2$$__colors__", 2), "blue,red")
+    def test_filters_are_whole_word_or(self):
+        self.file("birds", "redness\nred bird\nblue bird")
+        self.assertEqual(prompt.expand_text("__birds|red__", 0), "red bird")
+        self.assertEqual(prompt.expand_text("__birds|red|blue__", 2), "blue bird")
+    def test_repeat_random_is_deterministic(self):
+        self.file("n", "a\nb\nc\nd")
+        self.assertEqual(prompt.expand_text("__n__ __*n__ __n__", 400), prompt.expand_text("__n__ __*n__ __n__", 400))
+    def test_missing_policies(self):
+        with self.assertRaisesRegex(ValueError, "not found"): prompt.expand_text("__missing__")
+        self.assertEqual(prompt.expand_text("x __missing__", missing="keep"), "x __missing__")
+        self.assertEqual(prompt.expand_text("x __missing__", missing="empty"), "x ")
+    def test_empty_files(self):
+        self.file("empty", "")
+        with self.assertRaisesRegex(ValueError, "Empty wildcard"): prompt.expand_text("__empty__")
+    def test_cycles(self):
+        self.file("a", "__b__"); self.file("b", "__a__")
+        with self.assertRaisesRegex(ValueError, "Cyclic"): prompt.expand_text("__a__")
+        self.file("self", "__self__")
+        with self.assertRaisesRegex(ValueError, "Cyclic"): prompt.expand_text("__self__")
+    def test_depth_and_expansion_budget(self):
+        self.file("a", "__b__"); self.file("b", "__c__"); self.file("c", "done")
+        with self.assertRaisesRegex(ValueError, "max_depth"): prompt.expand_text("__a__", max_depth=1)
+        with self.assertRaisesRegex(ValueError, "budget"): prompt.expand_text("20000$$__a__")
+        with self.assertRaisesRegex(ValueError, "size limit"): prompt.expand_text("x" * (prompt.MAX_TEXT + 1))
+    def test_path_traversal(self):
+        for text in ("__../secret__", "__/etc/passwd__", "__C:/secret__"):
+            with self.assertRaisesRegex(ValueError, "Unsafe"): prompt.expand_text(text)
+    def test_symlink_escape(self):
+        with tempfile.TemporaryDirectory() as outside:
+            target = Path(outside) / "secret.txt"; target.write_text("secret")
+            (self.root / "escape.txt").symlink_to(target)
+            with self.assertRaisesRegex(ValueError, "escapes"): prompt.expand_text("__escape__")
+    def test_file_cache_invalidates(self):
+        path = self.file("a", "one")
+        before = prompt.DonutText.IS_CHANGED(text="__a__", seed=0)
+        stat = path.stat(); path.write_text("two"); os.utime(path, ns=(stat.st_atime_ns, stat.st_mtime_ns + 1_000_000))
+        self.assertNotEqual(before, prompt.DonutText.IS_CHANGED(text="__a__", seed=0))
+        self.assertEqual(prompt.expand_text("__a__"), "two")
+    def test_rng_is_local(self):
+        self.file("n", "a\nb\nc")
+        random.seed(892); state = random.getstate()
+        prompt.expand_text("{x|y} <random:-1:1> __n__ __*n__", 32)
+        self.assertEqual(state, random.getstate())
+    def test_numeric_random_syntax(self):
+        expected = str(round(random.Random(45).uniform(-1, 4), 4))
+        self.assertEqual(prompt.expand_text("<random:-1:4>", 45), expected)
+    def test_macros_inside_wildcard_files(self):
+        self.file("a", "%Seed.value%")
+        extra = {"workflow": {"nodes": [{"id": 7, "title": "Seed", "widgets_values_named": {"value": 42}}]}}
+        self.assertEqual(prompt.expand_text("__a__", extra_pnginfo=extra), "42")
+    def test_nested_date_invalidates_cache(self):
+        self.file("date", "%date:yyyy-MM-dd hh:mm:ss%")
+        class Clock:
+            @classmethod
+            def now(cls): return real_datetime(2026, 9, 7, 1, 2, cls.second)
+        Clock.second = 3
+        with patch.object(prompt, "datetime", Clock):
+            first = prompt.DonutText.IS_CHANGED(text="__date__")
+            Clock.second = 4
+            self.assertNotEqual(first, prompt.DonutText.IS_CHANGED(text="__date__"))
+    def test_prefix_suffix_expand_together(self):
+        self.file("color", "red")
+        result = prompt.DonutText().process("bird", prefix="__color__", suffix="photo", separator=" ")
+        self.assertEqual(result["result"], ("red bird photo",))
+    def test_blank_lines_preserve_selection_indices(self):
+        self.file("a", "first\n\n# literal\nlast\n")
+        self.assertEqual(prompt.expand_text("__a__", 1), "")
+        self.assertEqual(prompt.expand_text("__a__", 2), "# literal")
+
+
+class SeedTests(unittest.TestCase):
+    def test_stage_seeds_are_unique_and_repeatable(self):
+        self.assertEqual(seed_plan.stage_seeds(100), (100,102,103,104))
+    def test_browser_boundary_wraps(self):
+        values = seed_plan.stage_seeds(seed_plan.MAX_SEED)
+        self.assertEqual(len(set(values)), 4)
+        self.assertTrue(all(0 <= x <= seed_plan.MAX_SEED for x in values))
+    def test_invalid_seeds(self):
+        for seed in (-1, True, 1.2, "1", seed_plan.MAX_SEED+1):
+            with self.assertRaises(ValueError): seed_plan.stage_seeds(seed)
+    def test_independent_text_and_filename_domains(self):
+        self.assertEqual(seed_plan.DonutSeedPlan().generate(7,100,55), (7,100,102,103,104,"55"))
+
+
+class ContractTests(unittest.TestCase):
+    def setUp(self):
+        self.calls = []
+        calls = self.calls
+        class Builder:
+            @classmethod
+            def INPUT_TYPES(cls):
+                return {"required": {"model_type": (["Auto", "KREA2"],), "civitai_lookup": (["On","Off"],),
+                    "lora_name_1": (["None","test.safetensors"],), "block_preset_1": (["None","KREA2-ALL:1,1"],)}}
+            def build_stack(self, **kwargs):
+                calls.append(("build",deepcopy(kwargs)))
+                stack = list(kwargs.get("lora_stack", []))
+                for i in range(1,4):
+                    if kwargs[f"switch_{i}"] == "On" and kwargs[f"lora_name_{i}"] != "None":
+                        stack.append(tuple(kwargs[f"{key}_{i}"] for key in ("lora_name", "model_weight", "clip_weight", "block_vector")))
+                return {"result": (stack,), "ui": {"text": ["summary","triggers","urls","one","two","three"]}}
+        class Applier:
+            @classmethod
+            def INPUT_TYPES(cls): return {"required": {"model":("MODEL",),"clip":("CLIP",),"lora_stack":("LORA_STACK",),"safe_stack":(["Off","On"],)},"optional":{"execution_mode":(["Comfy patches","Experimental bypass"],)}}
+            def apply_stack(self, model, clip, stack, **kwargs):
+                calls.append(("apply",deepcopy(stack),kwargs)); return model,clip,"help"
+        class Upscaler:
+            FUNCTION="upscale"
+            @classmethod
+            def INPUT_TYPES(cls): return {"required":{"image":("IMAGE",),"model":("MODEL",),"seed":("INT",{"default":0})},"optional":{"color_reference":("IMAGE",)}}
+            def upscale(self, **kwargs): calls.append(("upscale",kwargs)); return ("upscaled","debug")
+        class Merge:
+            FUNCTION="merge"
+            @classmethod
+            def INPUT_TYPES(cls): return {"required":{"model1":("MODEL",),"model2":("MODEL",),"blocks.0.":("FLOAT",{"default":1})}}
+            def merge(self, **kwargs): calls.append(("merge",kwargs)); return (kwargs,)
+        class Injection:
+            FUNCTION="inject"
+            @classmethod
+            def INPUT_TYPES(cls): return {"required":{"prompt":("STRING",{"multiline":True}),"seed":("INT",{"default":0})}}
+            def inject(self, prompt, seed): return (prompt+" {a|b}","style preview")
+        modules = {}
+        for name, attrs in {
+            "donut_lora_nodes":{"DonutLoRAStack":Builder}, "DonutSafeApplyLoRAStack":{"DonutApplyLoRAStackSafe":Applier},
+            "DonutTiledUpscale":{"NODE_CLASS_MAPPINGS":{"DonutTiledUpscale":Upscaler}},
+            "DonutModelMergeKrea2":{"NODE_CLASS_MAPPINGS":{"DonutModelMergeKrea2":Merge}},
+            "DonutPromptInjection":{"NODE_CLASS_MAPPINGS":{"DonutPromptInjection":Injection}},
+        }.items():
+            module = types.ModuleType(f"{PKG}.{name}"); module.__dict__.update(attrs); modules[module.__name__] = module
+        folders = types.ModuleType("folder_paths"); folders.get_full_path = lambda kind,name: "/nonexistent-test-path" if name != "missing" else None
+        modules["folder_paths"] = folders
+        self.mock_modules = patch.dict(sys.modules, modules); self.mock_modules.start()
+        self.lora=load("donut_dynamic_lora"); self.stage=load("donut_upscale_stage"); self.merge=load("donut_grouped_merge"); self.injection=load("donut_prompt_injection_recursive")
+    def tearDown(self): self.mock_modules.stop()
+    def rows(self, n=7): return [dict(id=f"r{i}", lora_name=f"lora{i}", model_weight=i/10, clip_weight=-i/10, lora_hash=f"hash{i}") for i in range(n)]
+    def test_more_than_three_slots_and_single_apply(self):
+        rows=self.rows(); result=self.lora.DonutLoRALoader().load("MODEL","CLIP",json.dumps(rows), safe_stack="On", execution_mode="Experimental bypass")
+        self.assertEqual(len(result["result"][2]),7)
+        self.assertEqual(len([c for c in self.calls if c[0]=="build"]),3)
+        applies=[c for c in self.calls if c[0]=="apply"]
+        self.assertEqual(len(applies),1); self.assertEqual(len(applies[0][1]),7)
+        self.assertEqual(applies[0][2]["execution_mode"],"Experimental bypass")
+    def test_disabled_slots_and_inherited_vectors(self):
+        rows=self.rows(4); rows[1]["enabled"]=False; rows[2].update(inherit_block_vector=True,block_vector="0,0")
+        result=self.lora.DonutLoRALoader().load("m","c",rows,global_block_vector="1,1")
+        self.assertEqual([r[0] for r in result["result"][2]],["lora0","lora2","lora3"])
+        self.assertEqual(result["result"][2][1][3],"1,1")
+        self.assertEqual(len(result["ui"]["donut_loras"]),4)
+    def test_hashes_follow_rows_not_chunk_position(self):
+        self.lora.DonutDynamicLoRAStack().build(slots_json=self.rows(),model_type="KREA2")
+        calls=[c[1] for c in self.calls if c[0]=="build"]
+        self.assertEqual(calls[1]["extra_pnginfo"]["workflow"]["nodes"][0]["properties"]["lora_hashes"],["hash3","hash4","hash5"])
+    def test_upstream_stack_is_preserved(self):
+        result=self.lora.DonutDynamicLoRAStack().build(slots_json=self.rows(1),lora_stack=[("upstream",1,0,"")])
+        self.assertEqual(result["result"][0][0][0],"upstream")
+    def test_empty_stack(self): self.assertEqual(self.lora.DonutLoRALoader().load("m","c")["result"][:3],("m","c",[]))
+    def test_invalid_slot_state(self):
+        bad_values=[{},"{}",[1],[{"model_weight":float("nan")}],[{"enabled":"false"}],[{"id":"a"},{"id":"a"}],[{"clip_weight":True}]]
+        for value in bad_values:
+            with self.subTest(value=value), self.assertRaises((ValueError, TypeError)): self.lora.parse_slots(value)
+    def test_missing_active_lora_fails_clearly(self):
+        with self.assertRaisesRegex(FileNotFoundError,"missing"):
+            self.lora.DonutLoRALoader().load("m","c",[{"lora_name":"missing"}])
+    def test_disabled_stage_does_not_request_or_run_upscaler(self):
+        node=self.stage.DonutTiledUpscaleStage(); image=object()
+        self.assertEqual(node.check_lazy_status(image,enabled=False,model=None),[])
+        result=node.run_stage(image,enabled=False,model=None)
+        self.assertIs(result[0],image); self.assertIs(result[1],image); self.assertEqual(self.calls,[])
+    def test_enabled_stage_delegates_exactly(self):
+        node=self.stage.DonutTiledUpscaleStage()
+        self.assertEqual(node.check_lazy_status("img",enabled=True,model=None,seed=9),["model"])
+        self.assertEqual(node.run_stage("img",model="model",seed=9),("upscaled","debug"))
+        self.assertEqual(self.calls[0][1],dict(image="img",model="model",seed=9))
+    def test_stage_schema_is_backwards_compatible(self):
+        spec=self.stage.DonutTiledUpscaleStage.INPUT_TYPES()
+        self.assertTrue(spec["optional"]["enabled"][1]["default"])
+        self.assertTrue(spec["required"]["model"][1]["lazy"])
+        self.assertEqual(spec["required"]["image"],("IMAGE",))
+    def test_grouped_merge_preserves_unaffected_fields(self):
+        values=self.merge.DonutModelMergeKrea2Grouped().merge_grouped(ratio_mode="Grouped",body_ratio=.8,fusion_ratio=.2,model1="a",model2="b",**{"tmlp.":.7})[0]
+        self.assertEqual(values["blocks.27."],.8); self.assertEqual(values["txtfusion.projector."],.2); self.assertEqual(values["tmlp."],.7)
+    def test_per_block_merge_forwards_unchanged(self):
+        fields={"blocks.0.":.2,"txtfusion.projector.":.7}
+        self.assertEqual(self.merge.DonutModelMergeKrea2Grouped().merge_grouped(**fields)[0],fields)
+    def test_prompt_injection_uses_requested_text_seed(self):
+        with patch.object(prompt,"wildcard_roots",return_value=()):
+            result=self.injection.DonutPromptInjectionRecursive().process_recursive(prompt="face",seed=12)
+        self.assertEqual(result,("face "+random.Random(12).choice(["a","b"]),"style preview"))
+    def test_conditioning_raw_and_zeroed_are_distinct(self):
+        calls=[]
+        class Encode:
+            def encode(self,clip,text): calls.append((clip,text)); return ([{"text":text}],)
+        class Zero:
+            def zero_out(self,value): return ([{"zero_of":deepcopy(value)}],)
+        core=types.ModuleType("nodes"); core.CLIPTextEncode=Encode; core.ConditioningZeroOut=Zero
+        with patch.dict(sys.modules,{"nodes":core}),patch.object(prompt,"wildcard_roots",return_value=()):
+            out=prompt.DonutPromptConditioning().encode("clip","face","","negative")["result"]
+        self.assertEqual(len(calls),2)  # Reuse identical face/full encodings.
+        self.assertEqual(out[0],"face"); self.assertEqual(out[1],"face")
+        self.assertNotEqual(out[5],out[6]); self.assertEqual(out[6],[{"text":"negative"}])
+
+
+class MigrationTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        source=Path(os.environ.get("DONUT_WORKFLOW_SOURCE", ROOT / "tests" / "fixtures" / "ComfyUI_00016_.json.gz"))
+        if not source.is_file(): raise unittest.SkipTest("Set DONUT_WORKFLOW_SOURCE to the original uploaded workflow for the real-graph regression tests")
+        opener=gzip.open if source.suffix==".gz" else open
+        with opener(source,"rt",encoding="utf-8") as handle: cls.original=json.load(handle)
+        cls.migrated,cls.report=migration.migrate(cls.original)
+    def nodes(self,w): return {n["id"]:n for g in migration.graphs(w) for n in g["nodes"]}
+    def test_all_links_and_subgraph_boundaries_validate(self): self.assertTrue(migration.validate(self.migrated))
+    def test_node_count_and_dependencies(self):
+        self.assertEqual((self.report["before_nodes"],self.report["after_nodes"]),(68,40))
+        packs={n.get("properties",{}).get("cnr_id") for n in self.nodes(self.migrated).values()}
+        self.assertFalse(packs & migration.REMOVED_PACKS)
+        self.assertTrue(set(self.report["retained_reasons"]) <= packs)
+    def test_current_settings_and_bypasses_are_preserved(self):
+        before,after=self.nodes(self.original),self.nodes(self.migrated)
+        for node_id in (942,468,883,487,881,897,1033,893,1045,64,430,1120,1122,63,759,52,50,993,984,1118,1031,1095):
+            self.assertEqual(before[node_id].get("widgets_values_named"),after[node_id].get("widgets_values_named"),str(node_id))
+            self.assertEqual(before[node_id]["mode"],after[node_id]["mode"])
+        for node_id in (989,983):
+            fields=deepcopy(after[node_id]["widgets_values_named"]); enabled=fields.pop("enabled")
+            self.assertEqual(fields,before[node_id]["widgets_values_named"])
+            self.assertEqual(enabled,before[node_id]["mode"]!=4)
+        self.assertEqual(after[891]["mode"],4)
+    def test_six_lora_slots_including_disabled_settings(self):
+        before,after=self.nodes(self.original),self.nodes(self.migrated)
+        rows=json.loads(after[1055]["widgets_values_named"]["slots_json"])
+        self.assertEqual(len(rows),6)
+        for row in rows:
+            node_id,slot=map(int,row["id"].split(":")); old=before[node_id]["widgets_values_named"]
+            for key in ("lora_name","model_weight","clip_weight","block_vector","block_preset"):
+                self.assertEqual(row[key],old[f"{key}_{slot}"])
+            self.assertEqual(row["enabled"],old[f"switch_{slot}"]=="On")
+            self.assertTrue(row["inherit_block_vector"])
+    def test_sampler_and_text_seed_wiring(self):
+        main=self.migrated["definitions"]["subgraphs"][0]
+        edges=list(map(migration.unpack,main["links"]))
+        nodes=self.nodes(self.migrated)
+        expected={993:"seed",989:"seed_upscale_1",983:"seed_upscale_2",984:"seed_face"}
+        for node_id,name in expected.items():
+            slot=next(i for i,p in enumerate(nodes[node_id]["inputs"]) if p["name"]=="seed")
+            edge=next(e for e in edges if e["target_id"]==node_id and e["target_slot"]==slot)
+            self.assertEqual(edge["origin_id"],-10); self.assertEqual(main["inputs"][edge["origin_slot"]]["name"],name)
+        root_edges=list(map(migration.unpack,self.migrated["links"]))
+        for node_id in (53,56,57,891):
+            slot=next(i for i,p in enumerate(nodes[node_id]["inputs"]) if p["name"]=="seed")
+            edge=next(e for e in root_edges if e["target_id"]==node_id and e["target_slot"]==slot)
+            self.assertEqual((edge["origin_id"],edge["origin_slot"]),(195,0))
+    def test_source_is_not_mutated_and_migration_is_idempotent(self):
+        saved=deepcopy(self.original); output,report=migration.migrate(self.original)
+        self.assertEqual(saved,self.original)
+        second,_=migration.migrate(output); self.assertEqual(output,second)
+    def test_unknown_workflow_fails_closed(self):
+        bad=deepcopy(self.original); next(n for n in bad["nodes"] if n["id"]==855)["type"]="OtherLoRA"
+        with self.assertRaisesRegex(ValueError,"Unsupported"): migration.migrate(bad)
+    def test_validator_detects_broken_links(self):
+        bad=deepcopy(self.migrated); bad["links"][0][1]=99999999
+        with self.assertRaisesRegex(ValueError,"Dangling"): migration.validate(bad)
+
+
+if __name__ == "__main__": unittest.main()

--- a/tests/test_streamlining_frontend.cjs
+++ b/tests/test_streamlining_frontend.cjs
@@ -1,0 +1,127 @@
+// Dependency-free frontend contract tests, not a real ComfyUI browser session.
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+const test = require('node:test');
+class Element {
+  constructor(tag) { this.tag = tag; this.children = []; this.style = {}; this.events = {}; this.textContent = ''; }
+  append(...children) { this.children.push(...children); }
+  replaceChildren(...children) { this.children = [...children]; }
+  setAttribute(key, value) { this[key] = value; }
+  addEventListener(name, callback) { this.events[name] = callback; }
+  fire(name) { this.events[name]?.({preventDefault() {}}); }
+  checkValidity() { return Number.isFinite(this.valueAsNumber) && this.valueAsNumber >= -1000 && this.valueAsNumber <= 1000; }
+  get valueAsNumber() { return Number(this.value); }
+}
+function all(root, predicate) { return [root, ...root.children.flatMap(child => all(child, () => true))].filter(predicate); }
+let extension;
+const context = vm.createContext({ console, URLSearchParams, Math, Date,
+  document: {createElement: tag => new Element(tag)},
+  app: {registerExtension: value => { extension = value; }, graph: {change() {}}},
+  api: {apiURL: value => value},
+  ComfyWidgets: {STRING(node, name) { const widget = {name, value: '', inputEl: {}}; node.widgets.push(widget); return {widget}; }},
+});
+const source = fs.readFileSync(path.join(__dirname, '../web/donut_workflow.js'), 'utf8')
+  .replace(/^import .*;\n/gm, '').replace(/export function /g, 'function ');
+vm.runInContext(source, context);
+const definition = {name: 'DonutLoRALoader', input: {required: {slots_json: ['STRING', {
+  donut_loras: ['None', 'a.safetensors', 'b.safetensors'], donut_presets: ['None', 'KREA2-ALL:1,1', 'SDXL-ALL:1,1'],
+}]}}};
+const rows = count => Array.from({length: count}, (_, index) => ({id: `row-${index}`, enabled: index % 2 === 0,
+  lora_name: `lora-${index}`, model_weight: index / 10, clip_weight: index === 0 ? 0 : -index / 10, block_vector: `${index},1`,
+  block_preset: 'None', inherit_block_vector: index % 2 !== 0, lora_hash: `HASH${index}`, custom: {keep: index}}));
+function makeNode(name = definition.name, initial = '[]') {
+  class Node {
+    constructor() {
+      this.widgets = [{name: 'model_type', value: 'KREA2'}, {name: 'slots_json', value: initial, type: 'customtext'},
+        {name: 'global_block_vector', value: '1,1'}]; this.size = [400, 600]; this.parentEvents = [];
+    }
+    onNodeCreated() { this.parentEvents.push('created'); }
+    onConfigure() { this.parentEvents.push('configured'); }
+    onExecuted() { this.parentEvents.push('executed'); }
+    onSerialize(data) { this.parentEvents.push('serialized'); data.parent = true; }
+    addDOMWidget(name, type, root, options) { this.root = root; const w = {name, type, options}; this.widgets.push(w); return w; }
+    setDirtyCanvas() {}
+    setSize(size) { this.size = size; }
+    computeSize() { return this.size; }
+  }
+  extension.beforeRegisterNodeDef(Node, {...definition, name});
+  return new Node();
+}
+const state = node => node.widgets.find(w => w.name === 'slots_json');
+const saved = node => JSON.parse(state(node).value);
+const boxes = node => all(node.root, e => e.tag === 'fieldset');
+const click = (root, label) => { const b = all(root, e => e.tag === 'button' && e.textContent === label)[0]; assert.ok(b, label); b.fire('click'); };
+const input = (root, label) => all(root, e => e.tag === 'label' && e.textContent === `${label} `)[0].children[0];
+
+test('restore all six slots by named state, preserving disabled rows and metadata', () => {
+  const node = makeNode(); node.onNodeCreated(); node.onConfigure({widgets_values_named: {slots_json: JSON.stringify(rows(6))}});
+  assert.deepEqual(saved(node), rows(6)); assert.equal(boxes(node).length, 6);
+  assert.equal(state(node).type, 'converted-widget'); assert.equal(node.widgets.length, 4);
+});
+test('adding slots is unbounded by the old three-slot contract', () => {
+  const node = makeNode('DonutLoRALoader', JSON.stringify(rows(6))); node.onNodeCreated();
+  for (let i = 0; i < 5; i++) click(node.root, '+ Add LoRA');
+  assert.equal(saved(node).length, 11); assert.equal(new Set(saved(node).map(row => row.id)).size, 11);
+  assert.deepEqual(saved(node).slice(0, 6), rows(6));
+});
+test('reorder and removal move complete rows, not just filenames', () => {
+  const node = makeNode('DonutLoRALoader', JSON.stringify(rows(6))); node.onNodeCreated();
+  click(boxes(node)[2], '↑'); const expected = rows(6); [expected[1], expected[2]] = [expected[2], expected[1]];
+  assert.deepEqual(saved(node), expected); click(boxes(node)[4], 'Remove'); expected.splice(4, 1);
+  assert.deepEqual(saved(node), expected);
+});
+test('named and positional serialization roundtrip with parent hooks intact', () => {
+  const original = rows(7); const node = makeNode('DonutDynamicLoRAStack'); node.onNodeCreated();
+  node.onConfigure({widgets_values: ['KREA2', JSON.stringify(original), '1,1']});
+  const output = {}; node.onSerialize(output); assert.equal(output.parent, true);
+  assert.equal(state(node).serializeValue(), JSON.stringify(original));
+  const copy = makeNode(); copy.onNodeCreated(); copy.onConfigure(output); assert.deepEqual(saved(copy), original);
+  assert.deepEqual(node.parentEvents, ['created', 'configured', 'serialized']);
+});
+test('malformed loaded JSON is not replaced with an empty stack', () => {
+  const node = makeNode(); node.onNodeCreated(); node.onConfigure({widgets_values_named: {slots_json: '[broken'}});
+  const output = {}; node.onSerialize(output); assert.equal(output.widgets_values_named.slots_json, '[broken');
+  const repair = all(node.root, e => e.tag === 'textarea')[0]; assert.ok(repair);
+  repair.value = JSON.stringify(rows(1)); repair.fire('change'); assert.deepEqual(saved(node), rows(1));
+});
+test('filename edits clear stale hash and late execution metadata cannot restore it', () => {
+  const node = makeNode('DonutLoRALoader', JSON.stringify(rows(1))); node.onNodeCreated();
+  const filename = input(boxes(node)[0], 'LoRA'); filename.value = 'new.safetensors'; filename.fire('change');
+  assert.equal(saved(node)[0].lora_hash, '');
+  node.onExecuted({donut_loras: [{id: 'row-0', lora_name: 'lora-0', lora_hash: 'OLDHASH'}]});
+  assert.equal(saved(node)[0].lora_hash, '');
+  node.onExecuted({donut_loras: [{id: 'row-0', lora_name: 'new.safetensors', lora_hash: 'NEWHASH'}]});
+  assert.equal(saved(node)[0].lora_hash, 'NEWHASH');
+});
+test('block presets edit the actual vector and disable inheritance', () => {
+  const node = makeNode('DonutLoRALoader', JSON.stringify(rows(2))); node.onNodeCreated();
+  const box = boxes(node)[1]; const select = all(box, e => e.tag === 'select')[0];
+  assert.equal(select.children.some(e => e.value.startsWith('SDXL')), false);
+  select.value = 'KREA2-ALL:1,1'; select.fire('change');
+  assert.equal(saved(node)[1].block_vector, '1,1'); assert.equal(saved(node)[1].inherit_block_vector, false);
+});
+test('invalid number does not corrupt canonical row state', () => {
+  const node = makeNode('DonutLoRALoader', JSON.stringify(rows(1))); node.onNodeCreated();
+  const weight = input(boxes(node)[0], 'Model strength'); weight.value = 'NaN'; weight.fire('change');
+  assert.equal(saved(node)[0].model_weight, 0); weight.value = '0.75'; weight.fire('change'); assert.equal(saved(node)[0].model_weight, .75);
+});
+test('seed controls have unique serialized names', () => {
+  const node = makeNode('DonutSeedPlan'); node.widgets = ['text_seed', 'control_after_generate', 'sampler_seed',
+    'control_after_generate', 'filename_seed', 'control_after_generate'].map(name => ({name})); node.onNodeCreated();
+  assert.deepEqual(node.widgets.map(w => w.name), ['text_seed', 'text_seed_control', 'sampler_seed', 'sampler_seed_control', 'filename_seed', 'filename_seed_control']);
+});
+test('grouped merge hides controls without deleting or changing their values', () => {
+  const node = makeNode('DonutModelMergeKrea2'); node.widgets = [
+    {name: 'ratio_mode', value: 'Grouped'}, {name: 'blocks.0.', value: .45, type: 'number'},
+    {name: 'txtfusion.projector.', value: .35, type: 'number'}, {name: 'tmlp.', value: .95, type: 'number'}];
+  node.onNodeCreated(); assert.equal(node.widgets.length, 4); assert.equal(node.widgets[1].type, 'converted-widget');
+  assert.equal(node.widgets[3].type, 'number'); node.widgets[0].value = 'Per block'; node.widgets[0].callback();
+  assert.equal(node.widgets[1].type, 'number'); assert.equal(node.widgets[1].value, .45);
+});
+test('prompt preview is read-only, not an extra backend input', () => {
+  const node = makeNode('DonutText'); node.onNodeCreated(); node.onExecuted({text: ['resolved prompt']});
+  const preview = node.widgets.find(w => w.name === 'resolved_text');
+  assert.equal(preview.value, 'resolved prompt'); assert.equal(preview.options.serialize, false); assert.equal(preview.inputEl.readOnly, true);
+});

--- a/tools/streamline_workflow.py
+++ b/tools/streamline_workflow.py
@@ -1,0 +1,342 @@
+#!/usr/bin/env python3
+"""Migrate the supplied ComfyUI_00016 workflow without hand-editing links.
+
+This is deliberately a guarded migration, not a heuristic graph optimiser.
+Unknown layouts fail rather than silently dropping settings or functionality.
+"""
+from __future__ import annotations
+import argparse
+from copy import deepcopy
+import hashlib
+import gzip
+import json
+from pathlib import Path
+import uuid
+
+BRANCH = "feat/workflow-streamlining"
+REMOVED_PACKS = {"cg-use-everywhere", "mikey_nodes", "RES4LYF", "derfuu_comfyui_moddednodes", "ComfyUI_Comfyroll_CustomNodes", "rgthree-comfy"}
+
+
+def graphs(workflow):
+    return [workflow, *workflow.get("definitions", {}).get("subgraphs", [])]
+
+
+def unpack(link):
+    if isinstance(link, list):
+        return dict(zip(("id", "origin_id", "origin_slot", "target_id", "target_slot", "type"), link))
+    return deepcopy(link)
+
+
+class Graph:
+    def __init__(self, value, root=False):
+        self.data, self.root = value, root
+        self.nodes = {n["id"]: n for n in value["nodes"]}
+        self.edges = [unpack(link) for link in value["links"]]
+        self.next_id = max([value.get("last_link_id", 0), value.get("state", {}).get("lastLinkId", 0), *(e["id"] for e in self.edges)]) + 1
+
+    def port(self, node, name, output=False):
+        ports = self.data["inputs"] if node == -10 else self.data["outputs"] if node == -20 else self.nodes[node]["outputs" if output else "inputs"]
+        matches = [index for index, p in enumerate(ports) if p["name"] == name]
+        if len(matches) != 1:
+            raise ValueError(f"Expected exactly one port {node}:{name}, found {len(matches)}")
+        return matches[0]
+
+    def connect(self, source, source_slot, target, target_slot, kind):
+        self.edges = [e for e in self.edges if (e["target_id"], e["target_slot"]) != (target, target_slot)]
+        self.edges.append(dict(id=self.next_id, origin_id=source, origin_slot=source_slot,
+                               target_id=target, target_slot=target_slot, type=kind))
+        self.next_id += 1
+
+    def source(self, old_id, old_slot, new_id, new_slot):
+        for edge in self.edges:
+            if (edge["origin_id"], edge["origin_slot"]) == (old_id, old_slot):
+                edge.update(origin_id=new_id, origin_slot=new_slot)
+
+    def remove(self, *ids):
+        self.edges = [e for e in self.edges if e["origin_id"] not in ids and e["target_id"] not in ids]
+        for node_id in ids:
+            self.nodes.pop(node_id)
+
+    def bypass_text(self, node_id):
+        incoming = [e for e in self.edges if e["target_id"] == node_id and e["target_slot"] == self.port(node_id, "prompt")]
+        if len(incoming) != 1:
+            raise ValueError(f"Wildcard {node_id} has no unique prompt source")
+        self.source(node_id, 0, incoming[0]["origin_id"], incoming[0]["origin_slot"])
+        self.remove(node_id)
+
+    def save(self):
+        self.data["nodes"] = list(self.nodes.values())
+        for node in self.nodes.values():
+            node.get("properties", {}).pop("ue_properties", None)
+            for port in node.get("inputs", []): port["link"] = None
+            for port in node.get("outputs", []): port["links"] = []
+        if not self.root:
+            for port in self.data.get("inputs", []) + self.data.get("outputs", []): port["linkIds"] = []
+        for edge in self.edges:
+            source, target = edge["origin_id"], edge["target_id"]
+            if source == -10:
+                self.data["inputs"][edge["origin_slot"]]["linkIds"].append(edge["id"])
+            else:
+                self.nodes[source]["outputs"][edge["origin_slot"]]["links"].append(edge["id"])
+            if target == -20:
+                self.data["outputs"][edge["target_slot"]]["linkIds"].append(edge["id"])
+            else:
+                self.nodes[target]["inputs"][edge["target_slot"]]["link"] = edge["id"]
+        for order, node in enumerate(self.nodes.values()): node["order"] = order
+        self.data["links"] = [[e[k] for k in ("id", "origin_id", "origin_slot", "target_id", "target_slot", "type")] for e in self.edges] if self.root else self.edges
+        if self.root:
+            self.data["last_node_id"] = max(self.nodes)
+            self.data["last_link_id"] = self.next_id - 1
+        else:
+            self.data.setdefault("state", {}).update(lastNodeId=max(self.nodes), lastLinkId=self.next_id - 1)
+        extra = self.data.setdefault("extra", {})
+        for key in ("ue_links", "links_added_by_ue"): extra.pop(key, None)
+
+
+def input_port(name, kind, widget=False, optional=False):
+    result = dict(name=name, type=kind, link=None)
+    if widget: result["widget"] = {"name": name}
+    if optional: result["shape"] = 7
+    return result
+
+
+def make_node(old, kind, inputs, outputs, named, values=None, title=None):
+    node = deepcopy(old)
+    node.update(type=kind, inputs=inputs, outputs=[dict(name=name, type=typ, links=[]) for name, typ in outputs],
+                widgets_values=list(named.values()) if values is None else values, widgets_values_named=named)
+    node["properties"] = {"cnr_id": "donutnodes", "aux_id": "DonutsDelivery/ComfyUI-DonutNodes", "Node name for S&R": kind}
+    if title: node["title"] = title
+    return node
+
+
+def named(node, name):
+    try: return node["widgets_values_named"][name]
+    except KeyError: raise ValueError(f"Node {node['id']} has no named value {name!r}; re-export the supported source workflow") from None
+
+
+def validate(workflow):
+    errors = []
+    subgraphs = {g["id"]: g for g in workflow.get("definitions", {}).get("subgraphs", [])}
+    for graph in graphs(workflow):
+        nodes = {n["id"]: n for n in graph["nodes"]}
+        if len(nodes) != len(graph["nodes"]): errors.append("Duplicate node IDs")
+        edges = {e["id"]: e for e in map(unpack, graph["links"])}
+        if len(edges) != len(graph["links"]): errors.append("Duplicate link IDs")
+        destinations = set()
+        for edge in edges.values():
+            source, target, out_slot, in_slot = (edge[k] for k in ("origin_id", "target_id", "origin_slot", "target_slot"))
+            try:
+                out = graph["inputs"][out_slot] if source == -10 else nodes[source]["outputs"][out_slot]
+                inp = graph["outputs"][in_slot] if target == -20 else nodes[target]["inputs"][in_slot]
+                outgoing = out.get("linkIds", []) if source == -10 else out.get("links", [])
+                incoming = inp.get("linkIds", []) if target == -20 else [inp.get("link")]
+                if edge["id"] not in (outgoing or []) or edge["id"] not in incoming: errors.append(f"Non-reciprocal link {edge['id']}")
+                if (target, in_slot) in destinations: errors.append(f"Multiple drivers on {target}:{in_slot}")
+                destinations.add((target, in_slot))
+                if out["type"] != inp["type"] and "*" not in (out["type"], inp["type"]):
+                    errors.append(f"Type mismatch on {edge['id']}: {out['type']} -> {inp['type']}")
+            except (KeyError, IndexError): errors.append(f"Dangling endpoint on link {edge['id']}")
+        for node in nodes.values():
+            for port in node.get("inputs", []):
+                if port.get("link") is not None and port["link"] not in edges: errors.append(f"Stale input link on {node['id']}")
+            for port in node.get("outputs", []):
+                if any(e not in edges for e in (port.get("links") or [])): errors.append(f"Stale output link on {node['id']}")
+            if node["type"] in subgraphs:
+                definition = subgraphs[node["type"]]
+                names = {p["name"] for p in definition["inputs"]}
+                if any(p["name"] not in names for p in node["inputs"]): errors.append("Unknown subgraph instance input")
+                for port in definition["inputs"]:
+                    instance_ports = [p for p in node["inputs"] if p["name"] == port["name"]]
+                    connected = bool(instance_ports and instance_ports[0].get("link") is not None)
+                    if port.get("linkIds") and not connected and port["name"] not in node.get("widgets_values_named", {}):
+                        errors.append(f"Unresolved subgraph boundary: {port['name']}")
+        # Reject data-flow cycles in both root and subgraph scopes.
+        visiting, visited = set(), set()
+        children = {key: [] for key in nodes}
+        for edge in edges.values():
+            if edge["origin_id"] in nodes and edge["target_id"] in nodes:
+                children[edge["origin_id"]].append(edge["target_id"])
+        def walk(key):
+            if key in visiting: raise ValueError(f"Cycle at node {key}")
+            if key in visited: return
+            visiting.add(key)
+            for child in children[key]: walk(child)
+            visiting.remove(key); visited.add(key)
+        try:
+            for key in nodes: walk(key)
+        except ValueError as error: errors.append(str(error))
+    if errors: raise ValueError("Workflow validation failed:\n" + "\n".join(errors))
+    return True
+
+
+def migrate(original):
+    if original.get("extra", {}).get("donut_streamlining", {}).get("schema") == 1:
+        validate(original)
+        return deepcopy(original), {"already_migrated": True}
+    workflow = deepcopy(original)
+    root = Graph(workflow, True)
+    expected = {195: "SeedGenerator", 777: "Seed String", 855: "DonutLoRAStack", 1116: "DonutLoRAStack", 1055: "DonutApplyLoRAStack",
+                53: "Wildcard Processor", 56: "Wildcard Processor", 57: "Wildcard Processor", 51: "Anything Everywhere", 1005: "Anything Everywhere"}
+    for node_id, kind in expected.items():
+        if root.nodes.get(node_id, {}).get("type") != kind: raise ValueError(f"Unsupported source: expected {node_id} / {kind}")
+    main_id, merge_id = root.nodes[1014]["type"], root.nodes[1124]["type"]
+    definitions = {g["id"]: g for g in workflow["definitions"]["subgraphs"]}
+    main = Graph(definitions[main_id])
+    merge = Graph(definitions[merge_id])
+    report = {"before_nodes": sum(len(g["nodes"]) for g in graphs(original)), "removed_packs": sorted(REMOVED_PACKS),
+              "retained_reasons": {"ComfyUI-bleh": "Exact custom ER-SDE preset behaviour", "was-node-suite-comfyui": "Full configured WebP/history/naming/metadata save behaviour",
+                                   "comfyui-impact-pack": "SAM/detailer implementation", "comfyui-impact-subpack": "Ultralytics detector provider", "krea2-nag": "Keep adjustable Krea2 NAG, even though alpha is currently zero"}}
+    # Materialise the four implicit connections BEFORE discarding UE controllers.
+    for connection in workflow["extra"].get("ue_links", []):
+        target = int(connection["downstream"]); slot = connection["downstream_slot"]
+        if root.nodes[target]["inputs"][slot].get("link") is not None:
+            raise ValueError("Refusing to overwrite an explicit link with a UE connection")
+        root.connect(int(connection["upstream"]), connection["upstream_slot"], target, slot, connection["type"])
+    if len(workflow["extra"].get("ue_links", [])) != 4: raise ValueError("Expected four recorded implicit connections")
+    root.remove(51, 1005)
+
+    text_seed = named(root.nodes[195], "seed")
+    filename_seed = named(root.nodes[777], "seed")
+    seeds = {"text_seed": text_seed, "text_seed_control": "randomize", "sampler_seed": text_seed,
+             "sampler_seed_control": "randomize", "filename_seed": filename_seed, "filename_seed_control": "randomize"}
+    root.nodes[195] = make_node(root.nodes[195], "DonutSeedPlan", [], [("text", "INT"), ("base", "INT"), ("upscale_1", "INT"), ("upscale_2", "INT"), ("face", "INT"), ("filename", "STRING")], seeds, title="Text seed independent of sampling")
+    root.source(777, 1, 195, 5); root.remove(777)
+    for edge in root.edges:
+        if edge["target_id"] == 1014 and edge["target_slot"] == root.port(1014, "seed"):
+            edge["origin_slot"] = 1
+    for node_id in (53, 56, 57):
+        old = root.nodes[node_id]
+        fields = dict(text=named(old, "prompt"), seed=text_seed, control_after_generate="fixed", max_depth=128, missing="error", separator="")
+        root.nodes[node_id] = make_node(old, "DonutText", [input_port("seed", "INT", True), input_port("prefix", "STRING", optional=True), input_port("suffix", "STRING", optional=True)], [("text", "STRING")], fields)
+    injection = root.nodes[891]
+    injection["inputs"].append(input_port("seed", "INT", True))
+    root.connect(195, 0, 891, len(injection["inputs"]) - 1, "INT")
+    injection["widgets_values_named"].update(seed=text_seed, control_after_generate="fixed", wildcard_depth=128, missing_wildcard="error")
+    # Existing order is retained; only the new optional fields are appended.
+    injection["widgets_values"][-2:] = [text_seed, "fixed"]
+    injection["widgets_values"] += [128, "error"]
+
+    # Unlimited LoRA rows retain six slot identities, including disabled rows.
+    stack_nodes = [root.nodes[1116], root.nodes[855]]
+    if len({named(n, "model_type") for n in stack_nodes}) != 1 or len({named(n, "civitai_lookup") for n in stack_nodes}) != 1:
+        raise ValueError("Mixed stack-wide controls require an explicit migration decision")
+    rows = []
+    for node in stack_nodes:
+        for slot in range(1, 4):
+            vector_link = next((p.get("link") for p in node["inputs"] if p["name"] == f"block_vector_{slot}"), None)
+            if vector_link is not None and not any(e["id"] == vector_link and e["origin_id"] == 1036 for e in root.edges):
+                raise ValueError("Unsupported external per-slot block vector source")
+            rows.append(dict(id=f"{node['id']}:{slot}", enabled=named(node, f"switch_{slot}") == "On", lora_name=named(node, f"lora_name_{slot}"),
+                             model_weight=named(node, f"model_weight_{slot}"), clip_weight=named(node, f"clip_weight_{slot}"),
+                             block_preset=named(node, f"block_preset_{slot}"), block_vector=named(node, f"block_vector_{slot}"),
+                             inherit_block_vector=vector_link is not None, lora_hash=node.get("properties", {}).get("lora_hashes", ["", "", ""])[slot - 1]))
+    fields = dict(model_type=named(stack_nodes[0], "model_type"), slots_json=json.dumps(rows, separators=(",", ":")),
+                  global_block_vector=named(root.nodes[1036], "value"), civitai_lookup=named(stack_nodes[0], "civitai_lookup"),
+                  **root.nodes[1055]["widgets_values_named"])
+    root.nodes[1055] = make_node(root.nodes[1055], "DonutLoRALoader", [input_port("model", "MODEL"), input_port("clip", "CLIP"), input_port("lora_stack", "LORA_STACK", optional=True)],
+                                [("model", "MODEL"), ("clip", "CLIP"), ("lora_stack", "LORA_STACK"), ("show_help", "STRING")], fields, title="LoRAs · add / remove / reorder")
+    root.remove(855, 1116, 1036)
+
+    # Preserve all 38 per-block defaults while replacing two primitive fan-outs.
+    old_merge = deepcopy(merge.nodes[1119])
+    old_merge.update(id=1124, pos=root.nodes[1124]["pos"], inputs=deepcopy(root.nodes[1124]["inputs"]))
+    old_merge["widgets_values_named"].update(ratio_mode="Grouped", body_ratio=named(merge.nodes[1123], "value"), fusion_ratio=named(merge.nodes[1121], "value"))
+    old_merge["widgets_values"] += ["Grouped", named(merge.nodes[1123], "value"), named(merge.nodes[1121], "value")]
+    old_merge["title"] = "Krea2 merge · body / text fusion"
+    root.nodes[1124] = old_merge
+    workflow["definitions"]["subgraphs"] = [g for g in workflow["definitions"]["subgraphs"] if g["id"] != merge_id]
+
+    instance = root.nodes[1014]
+    def expose(name, typ, default, source_slot=None, label=None):
+        graph_slot = len(main.data["inputs"])
+        main.data["inputs"].append(dict(id=str(uuid.uuid5(uuid.NAMESPACE_URL, f"donut-streamline/{main_id}/{name}")), name=name, type=typ, linkIds=[], label=label or name,
+                                               pos=[main.data["inputNode"]["bounding"][0] + main.data["inputNode"]["bounding"][2] - 24,
+                                                    main.data["inputNode"]["bounding"][1] + 24 + graph_slot * 20]))
+        main.data["inputNode"]["bounding"][3] = max(main.data["inputNode"]["bounding"][3], 48 + (graph_slot + 1) * 20)
+        instance["inputs"].append(input_port(name, typ, True))
+        if label: instance["inputs"][-1]["label"] = label
+        instance["widgets_values_named"][name] = default
+        instance["widgets_values"].append(default)
+        if source_slot is not None: root.connect(195, source_slot, 1014, len(instance["inputs"]) - 1, typ)
+        return graph_slot
+    ports = {
+        "upscale_1": expose("seed_upscale_1", "INT", text_seed + 2, 2),
+        "upscale_2": expose("seed_upscale_2", "INT", text_seed + 3, 3),
+        "face": expose("seed_face", "INT", text_seed + 4, 4),
+        "text": expose("text_seed", "INT", text_seed, 0),
+        "enable_1": expose("upscale_1_enabled", "BOOLEAN", main.nodes[989]["mode"] != 4, label="Enable first upscale"),
+        "enable_2": expose("upscale_2_enabled", "BOOLEAN", main.nodes[983]["mode"] != 4, label="Enable second upscale"),
+    }
+    for node_id in (998, 1001, 1012, 1010, 1007, 1006, 1013, 1011): main.bypass_text(node_id)
+    for node_id, name in ((989, "upscale_1"), (983, "upscale_2"), (984, "face")):
+        main.connect(-10, ports[name], node_id, main.port(node_id, "seed"), "INT")
+    main.remove(992, 986, 982, 1000)
+
+    fields = dict(edit_negative=named(main.nodes[1008], "Text"), separator=named(main.nodes[996], "separator"), text_seed=text_seed)
+    for old_id, output in ((1008, 2), (995, 3), (990, 4), (994, 5), (1002, 6)):
+        main.source(old_id, 0, 996, output)
+    # Face-specific edit text is not replaced with the combined scene prompt.
+    for edge in main.edges:
+        if edge["target_id"] == 984 and edge["target_slot"] == main.port(984, "edit_prompt"):
+            edge.update(origin_id=996, origin_slot=1)
+    main.nodes[996] = make_node(main.nodes[996], "DonutPromptConditioning", [input_port("clip", "CLIP"), input_port("face", "STRING"), input_port("scene", "STRING"), input_port("negative", "STRING"), input_port("text_seed", "INT", True)],
+                                [("full_text", "STRING"), ("face_text", "STRING"), ("edit_negative", "STRING"), ("positive", "CONDITIONING"), ("face_positive", "CONDITIONING"), ("negative_zeroed", "CONDITIONING"), ("negative_raw", "CONDITIONING")], fields)
+    main.edges = [e for e in main.edges if e["target_id"] != 996]
+    main.remove(1008, 995, 990, 994, 1002, 997)
+    for source_name, target_slot, kind in (("clip", 0, "CLIP"), ("prompt", 1, "STRING"), ("prompt_1", 2, "STRING"), ("text", 3, "STRING")):
+        main.connect(-10, main.port(-10, source_name), 996, target_slot, kind)
+    main.connect(-10, ports["text"], 996, 4, "INT")
+    for node_id, name in ((989, "enable_1"), (983, "enable_2")):
+        node = main.nodes[node_id]
+        enabled = node["mode"] != 4
+        node["mode"] = 0
+        node["inputs"].append(input_port("enabled", "BOOLEAN", True, True))
+        node["widgets_values"].append(enabled); node["widgets_values_named"]["enabled"] = enabled
+        main.connect(-10, ports[name], node_id, len(node["inputs"]) - 1, "BOOLEAN")
+    root.remove(1026)
+    instance["title"] = "Sampling / upscales / face · stage controls"
+    instance["size"] = [350, 1080]
+    main.data["name"] = "Sampling · upscales · face"
+
+    # Compact root layout. Model loading, prompt authoring, stages and previews
+    # remain distinct; no opaque all-in-one sampling supernode is introduced.
+    positions = {1122: (-1900,-1180),1120: (-1900,-1050),1124: (-1550,-1150),1045: (-1900,-890),1042: (-1550,-900),430: (-1900,-700),468: (-1900,-480),942: (-1900,-360),50: (-1900,-210),52: (-1900,-80),487: (-1550,-680),195: (-1550,-490),893: (-1550,-150),1055: (-1200,-1200),53: (-650,-1200),56: (-650,-860),57: (-650,-530),891: (-650,-280),716: (-1900,90),881: (-650,-130),883: (-650,240),1033: (-650,370),897: (-650,470),1014: (-100,-1200),912: (300,-1140),913: (870,-1140),914: (1460,-1140),64: (2030,-1110),759: (300,-1230),63: (590,-1230)}
+    for node_id, pos in positions.items(): root.nodes[node_id]["pos"] = list(pos)
+    root.nodes[1055]["size"] = [480, 960]
+    root.nodes[195]["size"] = [300, 250]
+    for node_id in (53,56): root.nodes[node_id]["size"] = [480,300]
+    root.nodes[57]["size"] = [480,220]
+    root.nodes[487]["flags"]["collapsed"] = True
+    workflow["extra"].pop("linearData", None)  # It pointed at deleted/nonexistent graph IDs.
+    workflow["extra"]["donut_streamlining"] = {"schema": 1, "required_branch": BRANCH,
+        "source_sha256": hashlib.sha256(json.dumps(original, sort_keys=True).encode()).hexdigest(),
+        "retained_packs": sorted(report["retained_reasons"])}
+    workflow["extra"]["ds"] = {"scale": 0.6, "offset": [2020, 1390]}
+    main.save(); root.save()
+    workflow["last_node_id"] = max(n["id"] for g in graphs(workflow) for n in g["nodes"])
+    workflow["revision"] = workflow.get("revision", 0) + 1
+    validate(workflow)
+    remaining = {n.get("properties", {}).get("cnr_id") for g in graphs(workflow) for n in g["nodes"]}
+    if remaining & REMOVED_PACKS: raise ValueError(f"Unexpected remaining utility dependencies: {remaining & REMOVED_PACKS}")
+    report.update(after_nodes=sum(len(g["nodes"]) for g in graphs(workflow)), lora_slots=len(rows),
+                  seeds={"text": text_seed, "base": text_seed, "upscale_1": text_seed + 2, "upscale_2": text_seed + 3, "face": text_seed + 4, "filename": filename_seed},
+                  structural_validation="passed", live_comfyui_gpu_validation="not performed")
+    return workflow, report
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("source", type=Path); parser.add_argument("output", type=Path)
+    args = parser.parse_args()
+    opener = gzip.open if args.source.suffix == ".gz" else open
+    with opener(args.source, "rt", encoding="utf-8") as handle:
+        source = json.load(handle)
+    output, report = migrate(source)
+    if args.output.resolve() == args.source.resolve(): raise ValueError("Choose a new output path; the source is never overwritten")
+    args.output.parent.mkdir(parents=True, exist_ok=True)
+    args.output.write_text(json.dumps(output, indent=2, ensure_ascii=False) + "\n", encoding="utf-8")
+    args.output.with_suffix(".report.json").write_text(json.dumps(report, indent=2) + "\n", encoding="utf-8")
+    print(json.dumps(report, indent=2))
+
+
+if __name__ == "__main__": main()

--- a/web/donut_workflow.js
+++ b/web/donut_workflow.js
@@ -1,0 +1,207 @@
+import { app } from "../../scripts/app.js";
+import { api } from "../../scripts/api.js";
+import { ComfyWidgets } from "../../scripts/widgets.js";
+
+// One STRING is the canonical state. UI rows are never independent positional
+// widgets, so deleting/reordering a slot cannot shift another slot's values.
+export function decodeRows(value) {
+    const rows = JSON.parse(value || "[]");
+    if (!Array.isArray(rows) || rows.some(row => !row || typeof row !== "object" || Array.isArray(row))) {
+        throw new Error("LoRA slots must be an array of objects");
+    }
+    return rows;
+}
+export function moveRow(rows, from, to) {
+    const result = rows.slice();
+    if (from < 0 || from >= rows.length || to < 0 || to >= rows.length) return result;
+    const [row] = result.splice(from, 1);
+    result.splice(to, 0, row);
+    return result;
+}
+const element = (tag, text) => {
+    const el = document.createElement(tag);
+    if (text !== undefined) el.textContent = text;
+    return el;
+};
+function hideWidget(widget) {
+    if (!widget._donutOriginal) widget._donutOriginal = { type: widget.type, computeSize: widget.computeSize };
+    widget.type = "converted-widget";
+    widget.computeSize = () => [0, -4];
+}
+function restoreWidget(widget) {
+    if (widget._donutOriginal) Object.assign(widget, widget._donutOriginal);
+}
+function dirty(node) { node.setDirtyCanvas?.(true, true); app.graph?.change?.(); }
+
+function installRows(node, definition) {
+    const state = node.widgets.find(w => w.name === "slots_json");
+    if (!state) return;
+    hideWidget(state);
+    const options = definition.input.required.slots_json[1];
+    const root = element("div");
+    Object.assign(root.style, { overflow: "auto", padding: "8px", boxSizing: "border-box", font: "12px sans-serif" });
+    const listId = `donut-loras-${globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2)}`;
+    let rows = [], metadata = new Map();
+    state.serializeValue = () => state.value;
+    const commit = () => { state.value = JSON.stringify(rows); dirty(node); };
+    const field = (parent, label, value, type, changed) => {
+        const wrapper = element("label", `${label} `);
+        Object.assign(wrapper.style, { display: "block", margin: "4px 0" });
+        const input = element("input"); input.type = type;
+        if (type === "checkbox") input.checked = !!value;
+        else input.value = value ?? "";
+        if (type === "number") { input.step = "0.01"; input.min = "-1000"; input.max = "1000"; }
+        else if (type !== "checkbox") input.style.width = "95%";
+        input.addEventListener("change", () => {
+            if (type === "number" && (!Number.isFinite(input.valueAsNumber) || !input.checkValidity())) return;
+            changed(type === "checkbox" ? input.checked : type === "number" ? input.valueAsNumber : input.value);
+            commit();
+        });
+        wrapper.append(input); parent.append(wrapper); return input;
+    };
+    const button = (parent, text, fn) => {
+        const b = element("button", text); b.type = "button";
+        b.addEventListener("click", event => { event.preventDefault(); fn(); }); parent.append(b); return b;
+    };
+    function render() {
+        root.replaceChildren();
+        const choices = element("datalist"); choices.id = listId;
+        for (const name of options.donut_loras || ["None"]) { const o = element("option"); o.value = name; choices.append(o); }
+        root.append(choices);
+        const header = element("div", `${rows.length} LoRA slot${rows.length === 1 ? "" : "s"} `);
+        button(header, "+ Add LoRA", () => {
+            rows.push({ id: globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`, enabled: true,
+                lora_name: "None", model_weight: 1, clip_weight: 1, block_vector: "", block_preset: "None",
+                inherit_block_vector: false, lora_hash: "" });
+            commit(); render();
+        });
+        root.append(header);
+        rows.forEach((row, index) => {
+            const box = element("fieldset"); box.append(element("legend", `LoRA ${index + 1}`));
+            const nameInput = field(box, "LoRA", row.lora_name, "text", value => {
+                if (value !== row.lora_name) { row.lora_hash = ""; metadata.delete(String(row.id)); }
+                row.lora_name = value;
+            });
+            nameInput.setAttribute("list", listId);
+            field(box, "Enabled", row.enabled, "checkbox", value => { row.enabled = value; });
+            field(box, "Model strength", row.model_weight, "number", value => { row.model_weight = value; });
+            field(box, "CLIP / text-fusion strength", row.clip_weight, "number", value => { row.clip_weight = value; });
+            const advanced = element("details"); advanced.append(element("summary", "Block weights / metadata"));
+            const inherit = field(advanced, "Inherit global vector", row.inherit_block_vector, "checkbox", value => {
+                row.inherit_block_vector = value; vector.disabled = value;
+            });
+            const presets = element("select");
+            const modelType = node.widgets.find(w => w.name === "model_type")?.value || "Auto";
+            for (const value of options.donut_presets || ["None"]) {
+                if (modelType !== "Auto" && value !== "None" && !value.startsWith(`${modelType}-`)) continue;
+                const o = element("option", value.split(":")[0]); o.value = value; presets.append(o);
+            }
+            presets.value = row.block_preset || "None";
+            presets.addEventListener("change", () => {
+                row.block_preset = presets.value;
+                row.block_vector = presets.value.includes(":") ? presets.value.slice(presets.value.indexOf(":") + 1) : "";
+                row.inherit_block_vector = false; inherit.checked = false;
+                vector.disabled = false; vector.value = row.block_vector; commit();
+            });
+            advanced.append(presets);
+            const vector = field(advanced, "Block vector", row.block_vector, "text", value => { row.block_vector = value; });
+            vector.disabled = !!row.inherit_block_vector;
+            if (row.lora_hash) advanced.append(element("small", `Hash: ${row.lora_hash}`));
+            const info = metadata.get(String(row.id));
+            if (info?.text) { const pre = element("pre", info.text); pre.style.whiteSpace = "pre-wrap"; advanced.append(pre); }
+            if (info?.image?.filename) {
+                const image = element("img"); image.style.maxWidth = "100%"; image.loading = "lazy";
+                image.src = api.apiURL(`/view?${new URLSearchParams(info.image)}`); advanced.append(image);
+            }
+            box.append(advanced);
+            button(box, "↑", () => { rows = moveRow(rows, index, index - 1); commit(); render(); }).disabled = index === 0;
+            button(box, "↓", () => { rows = moveRow(rows, index, index + 1); commit(); render(); }).disabled = index === rows.length - 1;
+            button(box, "Remove", () => { rows.splice(index, 1); commit(); render(); });
+            root.append(box);
+        });
+    }
+    function restore(data) {
+        const index = node.widgets.indexOf(state);
+        const value = data?.widgets_values_named?.slots_json ?? data?.widgets_values?.[index] ?? state.value;
+        state.value = value;
+        try { rows = decodeRows(value); render(); }
+        catch (error) {
+            root.replaceChildren(element("p", `Invalid LoRA state: ${error.message}`));
+            // Never replace malformed/unknown saved state with an empty stack.
+            const edit = element("textarea"); edit.value = value; edit.style.width = "95%";
+            edit.addEventListener("change", () => { state.value = edit.value; restore(); dirty(node); }); root.append(edit);
+        }
+    }
+    const dom = node.addDOMWidget("donut_lora_editor", "div", root, { serialize: false });
+    dom.computeSize = () => [420, Math.min(850, Math.max(260, rows.length * 190 + 50))];
+    const configure = node.onConfigure;
+    node.onConfigure = function(data) { const r = configure?.apply(this, arguments); restore(data); return r; };
+    const serialize = node.onSerialize;
+    node.onSerialize = function(data) {
+        serialize?.apply(this, arguments);
+        (data.widgets_values_named ||= {}).slots_json = state.value;
+    };
+    const executed = node.onExecuted;
+    node.onExecuted = function(message) {
+        executed?.apply(this, arguments);
+        metadata = new Map((message.donut_loras || []).map(item => [String(item.id), item]));
+        let hashChanged = false;
+        for (const row of rows) {
+            const item = metadata.get(String(row.id));
+            // The user may edit a slot while a queued run is executing.
+            if (item?.lora_name === row.lora_name && item.lora_hash && item.lora_hash !== row.lora_hash) {
+                row.lora_hash = item.lora_hash; hashChanged = true;
+            }
+        }
+        if (hashChanged) commit();
+        render();
+    };
+    const modelWidget = node.widgets.find(w => w.name === "model_type");
+    if (modelWidget) { const cb = modelWidget.callback; modelWidget.callback = function() { cb?.apply(this, arguments); render(); }; }
+    restore();
+    node.setSize?.([Math.max(440, node.size?.[0] || 0), Math.max(600, node.size?.[1] || 0)]);
+}
+
+app.registerExtension({
+    name: "Donut.WorkflowStreamlining",
+    async beforeRegisterNodeDef(nodeType, nodeData) {
+        const name = nodeData.name;
+        if (!["DonutDynamicLoRAStack", "DonutLoRALoader", "DonutText", "DonutPromptConditioning", "DonutSeedPlan", "DonutModelMergeKrea2"].includes(name)) return;
+        const created = nodeType.prototype.onNodeCreated;
+        nodeType.prototype.onNodeCreated = function() {
+            const result = created?.apply(this, arguments);
+            if (["DonutDynamicLoRAStack", "DonutLoRALoader"].includes(name)) installRows(this, nodeData);
+            if (["DonutText", "DonutPromptConditioning"].includes(name)) {
+                const preview = ComfyWidgets.STRING(this, "resolved_text", ["STRING", { multiline: true }], app).widget;
+                preview.options ||= {}; preview.options.serialize = false;
+                if (preview.inputEl) preview.inputEl.readOnly = true;
+                const executed = this.onExecuted;
+                this.onExecuted = function(message) { executed?.apply(this, arguments); preview.value = (message.text || []).join("\n"); };
+            }
+            if (name === "DonutSeedPlan") {
+                for (const seedName of ["text_seed", "sampler_seed", "filename_seed"]) {
+                    const index = this.widgets.findIndex(w => w.name === seedName);
+                    const control = this.widgets[index + 1];
+                    if (index >= 0 && control?.name?.includes("control_after_generate")) control.name = `${seedName}_control`;
+                }
+            }
+            if (name === "DonutModelMergeKrea2") {
+                const mode = this.widgets.find(w => w.name === "ratio_mode");
+                const update = () => {
+                    if (!mode) return;
+                    for (const widget of this.widgets) {
+                        if (widget.name === "first." || widget.name === "last." || widget.name.startsWith("blocks.") || widget.name.startsWith("txtfusion.")) {
+                            if (mode.value === "Grouped") hideWidget(widget); else restoreWidget(widget);
+                        }
+                    }
+                    this.setSize?.([this.size[0], this.computeSize()[1]]); this.setDirtyCanvas?.(true, true);
+                };
+                if (mode) { const cb = mode.callback; mode.callback = function() { cb?.apply(this, arguments); update(); }; }
+                const configure = this.onConfigure;
+                this.onConfigure = function() { const r = configure?.apply(this, arguments); update(); return r; };
+                update();
+            }
+            return result;
+        };
+    },
+});


### PR DESCRIPTION
## Purpose
Streamline the supplied `ComfyUI_00016_.json` without replacing the sampling, upscaling, face-detailing, model-merging or saving algorithms. This is executable code plus frontend controls, a guarded workflow migrator and regression tests—not an alias layer around removed node packs.

## Changes
| Area | Before | After |
| --- | --- | --- |
| Serialized nodes, including subgraph proxies | 68 | 40 |
| External node packs besides DonutNodes/core | 11 | 5 |
| Wildcard processors | 11 | 3 recursive Donut Text editors |
| Seed utilities | 5 generators + filename string | 1 explicit text/sampler/filename seed plan |
| LoRA controls | Two fixed three-slot stacks + apply + global-vector primitive | One dynamic loader; all six rows retained, with add/remove/reorder |

- `DonutText`: bounded recursive TXT wildcards, nested choices, numeric randomness, repeated-name modifiers, multi-line selection, filters and macros; local RNG, cache invalidation, path/cycle/size guards and explicit missing-file policies.
- `DonutPromptConditioning`: consolidate concat/edit-negative text/CLIP encoding/negative zeroing/preview, while preserving full versus face prompts and raw versus zeroed negative conditioning.
- `DonutLoRALoader` and standalone `DonutDynamicLoRAStack`: canonical JSON rows with stable IDs, separate model/CLIP strengths, per-row vectors/presets/global inheritance, disabled rows, hashes and CivitAI metadata. Reuse the existing Donut builder and apply the complete stack **once** through the existing safe applier.
- `DonutSeedPlan`: separate text, sampling and filename controls. Sampling stage offsets are 0, 2, 3, 4 modulo 2**53. This intentionally fixes the old second-upscale/face seed collision; face moves from master+3 to master+4.
- Existing Prompt Injection gains recursive output processing. Existing Tiled Upscale gains a lazy enable switch. Existing Krea2 merge gains optional grouped body/fusion controls while retaining all per-block controls.
- Registration retains the isolated-import mechanism and explicit override failure reporting.
- The migration materializes all four recorded implicit links, removes stale connection records, rewires subgraph boundaries, retains current model choices/parameters/disabled LoRA rows and saves to a new file. The original is not overwritten.

## Dependency boundary
Removed from the migrated workflow: `mikey_nodes`, `RES4LYF`, `cg-use-everywhere`, `derfuu_comfyui_moddednodes`, `ComfyUI_Comfyroll_CustomNodes`, `rgthree-comfy`.

Intentionally retained: `ComfyUI-bleh` (exact configured sampler preset), `was-node-suite-comfyui` (configured WebP/history/naming/metadata saver), `comfyui-impact-pack` and `comfyui-impact-subpack` (SAM/detection/detailing), and `krea2-nag` (adjustable NAG, even though current alpha is zero). Hiding these imports would not remove dependencies; algorithm replacements need separate parity validation.

## Workflow handoff
The already-migrated `ComfyUI_00016_Donut_Streamlined.json` is delivered separately with the user-facing response and matches this branch. No manual rewiring is needed. The workflow/model files are not committed to the public repository.

Regenerate from the original when needed:
```sh
python tools/streamline_workflow.py /path/to/ComfyUI_00016_.json workflows/ComfyUI_00016_Donut_Streamlined.json
```

## Validation performed
**45 Python tests and 11 JavaScript contract tests passed** against the local copies; committed code blob hashes were checked against those tested files.
```sh
DONUT_WORKFLOW_SOURCE=/path/to/ComfyUI_00016_.json python -m unittest discover -s tests -p test_streamlining.py -v
node --test tests/test_streamlining_frontend.cjs
```
The eight real-workflow regression tests require the original upload via `DONUT_WORKFLOW_SOURCE`; they explicitly skip without it. The other 37 Python tests run without that file. Tests cover recursive expansion/guards/cache/RNG, distinct seeds, whole-stack delegation, lazy stage bypass, grouped controls, original settings preservation, reciprocal links/types/subgraph boundaries, acyclicity, frontend row operations, serialization/repair and stale-hash races.

## Why draft
No real ComfyUI browser import/queue, model loading, CivitAI network operation, GPU inference, output-image parity check or performance benchmark was available in this environment. CPU mocks and a DOM/Comfy frontend harness do not establish runtime or pixel parity. The node-count/dependency reduction is measured; GPU speedup is not claimed.

Before marking ready, smoke-test import/queue with the provided workflow, editing on/off, each upscale switch, NAG enabled, LoRA add/reorder/save/reload and a fixed-seed run with real nested wildcard files. See `docs/WORKFLOW_STREAMLINING.md` for behavior and installation details.