### PR TITLE
Fix LoRA UI: native installed-file dropdowns, compact disabled rows and CivitAI panels

### DIFF
--- a/docs/WORKFLOW_STREAMLINING.md
+++ b/docs/WORKFLOW_STREAMLINING.md
@@ -1,130 +1,134 @@
 # Workflow streamlining
 
-This change targets the supplied `ComfyUI_00016_.json`, not arbitrary graphs.
-It removes glue nodes while keeping model loading/merging, prompt authoring,
-conditioning, sampling, each upscale stage, face detailing and saving separate.
+This targets the supplied `ComfyUI_00016_.json`. It consolidates glue nodes,
+not the sampling algorithms: model loading/merging, text authoring,
+conditioning, sampling, each upscale, face detailing and saving remain distinct.
+The original reduction is 68 to 40 serialized nodes (including subgraph proxies),
+and six fewer external node packs. This is not a measured GPU speedup or a claim
+of pixel-identical output.
 
-## Result
+## Update and load
 
-Across the root and both original subgraphs: **68 -> 40 nodes**, including
-subgraph proxies. Six external node packs are no longer referenced by the
-migrated workflow. This is a graph/dependency reduction, not a measured GPU
-speedup or a claim of pixel-identical output.
-
-| Original | Replacement |
-| --- | --- |
-| Eleven wildcard processors | Three Donut Text editors, each recursively resolves its own text |
-| Two three-slot LoRA stacks + apply + global-vector primitive | One Donut LoRA Loader with six preserved, editable rows and add/remove/reorder |
-| Five seed generators + filename seed string | One Donut Seed Plan with independent text, sampler and filename controls |
-| Concatenation, edit-negative text, three encoders, negative zeroing and display | One Donut Prompt Conditioning node with distinct full/face and raw/zeroed outputs |
-| Two Anything Everywhere controllers | Four explicit, checked links |
-| Group bypass controller | First/second-upscale enable switches, with lazy disabled execution |
-| Merge subgraph with two primitive fan-outs | Grouped body/fusion controls on the existing merge node; per-block controls remain available |
-
-Removed packs: `mikey_nodes`, `RES4LYF`, `cg-use-everywhere`,
-`derfuu_comfyui_moddednodes`, `ComfyUI_Comfyroll_CustomNodes`, `rgthree-comfy`.
-
-Intentionally retained: `ComfyUI-bleh` for the exact configured sampler preset,
-`was-node-suite-comfyui` for the configured WebP/history/naming/metadata saver,
-`comfyui-impact-pack` and `comfyui-impact-subpack` for SAM/detection/detailing,
-and `krea2-nag` for adjustable NAG. Hiding these imports in wrappers would not
-remove a dependency. Replacing these algorithms without validating parity
-would conflict with the requirement to retain functionality.
-
-## Install and load
-
-Use the PR branch `feat/workflow-streamlining` in the existing DonutNodes
-installation, restart ComfyUI, then refresh the browser to load the new
-extension. Load the separately supplied `ComfyUI_00016_Donut_Streamlined.json`; no manual rewiring is
-required. The ordinary model files, source image, wildcard text files and the
-five retained packs must still be present. Do not replace the whole DonutNodes
-installation with only the files changed in this PR.
-
-For reproducibility, the guarded migration can regenerate the graph from the
-original uploaded JSON:
+Use **main** in the existing DonutNodes checkout:
 
 ```sh
-python tools/streamline_workflow.py /path/to/ComfyUI_00016_.json workflows/ComfyUI_00016_Donut_Streamlined.json
+git pull --ff-only origin main
 ```
 
-The source is never overwritten. Unknown layouts or incompatible link sources
-fail rather than silently dropping them. The original workflow remains usable
-with its original packs; the old three-slot LoRA nodes remain registered.
+Restart ComfyUI, then hard-refresh the browser to load the changed JavaScript
+and its new modules. Existing Donut LoRA Loader and Dynamic LoRA Stack nodes
+update in place; do not delete/recreate them. Their inputs and outputs did not
+change. Continue using `ComfyUI_00016_Donut_Streamlined_Fixed.json` supplied
+separately. No further workflow changes are required for the native LoRA UI.
+Model files, wildcard files, the optional source image and retained packs must
+still be present on the local installation.
 
-## Text and seed behavior
+PR47's original schema-1 migration kept obsolete promoted text values, shifting
+later parent-subgraph controls on frontend 1.51.9. The extension now repairs that
+specific migration before graph configuration: it rebuilds sockets by name and
+serializes only actual promoted widgets, producing 37 sockets and 25 widget
+values for the supplied graph. Missing original named values cause a clear
+error instead of guessing. Schema-2 saves are left untouched, so later user
+edits are not overwritten with old defaults. Workflow files are not committed
+to the public repository.
 
-Donut Text supports TXT wildcards in the existing ComfyUI user/root wildcard
-locations, registered wildcard directories and this pack's `wildcards` folder.
-It supports nested `__file__` references, `{a|b}` choices, `<random:min:max>`,
-`N$$__file__`, repeated-name `!`, `+`, `-`, `*` modifiers, whole-word OR filters,
-subfolders, date macros and node/widget macros. File-line selection and
-per-pass seed restarts follow the source processor's convention. Blank lines
-and comment-looking lines still count. The default nesting limit is 128,
-configurable up to 1024, with cycle, expansion-count and output-size guards.
-Missing files default to a clear error rather than disappearing; `keep` and
-legacy-style `empty` policies are available. Paths cannot escape wildcard
-roots. RNG state is local, and file changes invalidate cached results.
+## Native LoRA rows
 
-All authoring text editors, prompt injection and the editable negative text in
-conditioning receive the same **text seed**. Already-expanded face/scene text
-is not expanded again in conditioning. The face prompt is not silently changed
-to the combined scene prompt. Raw negative conditioning still reaches NAG;
-zeroed negative conditioning still reaches the sampling stages.
+The editor uses ComfyUI's native `combo`, `toggle`, `number`, `text` and `button`
+widgets. There is no HTML datalist, select element or custom dropdown menu.
+Installed filenames come directly from `/models/loras`, with the old Donut
+LoRA Stack's standard node schema as a fallback. That schema also supplies the
+block presets. The editor does not depend on custom STRING metadata surviving
+frontend schema normalization. A refresh button reloads the installed list
+without replacing any saved selections. Loading/failure states are visible.
 
-Sampling uses a separate master seed. The four stage seeds are master plus
-`0, 2, 3, 4`, modulo `2**53`, so they remain distinct and lossless in JavaScript.
-The old second-upscale/face collision is intentionally fixed. This changes the
-face stage's seed from the previous master+3 to master+4. Text and sampler
-controls start with the source's current seed but can now be frozen/randomized
-independently. Filename randomness has its own retained control. Per-face and
-per-model variation inside the existing samplers is not rewritten.
+Block preset menus contain short names rather than full comma-separated
+vectors; selecting one still writes its full vector to that row. Model-type
+filtering does not silently alter the saved preset or block vector.
 
-## LoRA behavior
+Each disabled row keeps its filename picker, Enabled toggle and Row actions.
+Strengths, advanced block controls and information panels are hidden and the
+node refits its height. Re-enabling restores their values unchanged. Row
+actions provide move up/down, removal, metadata retry and explicit application
+of a suggested model weight. Add LoRA has no fixed three/six-slot limit.
 
-Rows have stable IDs and are serialized as one canonical JSON value, not as a
-variable list of positional widgets. Reordering/removal therefore moves the
-entire row, including model/CLIP strengths, block preset/vector, global-vector
-inheritance, disabled state and hash. There is no fixed three/six-slot ceiling;
-a two-megabyte configuration limit prevents unreasonable inputs. The editor
-preserves malformed saved JSON for repair rather than replacing it with `[]`.
-Filename edits clear stale hashes; late execution results cannot attach a hash
-to a different filename. CivitAI per-row information/previews are retained.
+All rows remain in one canonical `slots_json` backend input with stable IDs.
+Reordering moves the whole row, including disabled state, separate model/CLIP
+strengths, vector/preset, global inheritance, hash and unknown saved fields.
+Native row controls and information panels are UI-only: they are excluded from
+both positional workflow arrays and API prompt inputs. Malformed JSON is
+retained for repair instead of being replaced by an empty stack. The original
+fixed three-slot node remains registered for existing workflows.
 
-The existing Donut stack builder handles resolution and metadata in chunks;
-**the existing safe applier is called only once, on the complete stack**. This
-preserves whole-stack energy budgeting, duplicate handling, text-fusion weights,
-block weighting, safety options and experimental bypass behavior. The separate
-Donut Dynamic LoRA Stack node remains available for workflows that need a
-reusable stack without loading a model at the same boundary.
+### Information is displayed, not just fetched
 
-## Compatibility and validation
+Enabled, selected rows have a bounded, scrollable information panel independent
+of the advanced block-settings toggle. It shows local weight composition
+(model/text-encoder components, populated block indices and tensor count),
+current strengths, CivitAI model/version, base model and author, suggested
+weight, trigger words, description, hash, a clickable CivitAI version link and
+cached preview images. Clicking a preview opens its full-sized local image.
+Descriptions are inserted as text; links are built from model IDs or hashes.
 
-Existing Tiled Upscale defaults to enabled, and existing Krea2 merge defaults to
-Per block. Their original algorithms remain the implementation. Prompt
-Injection retains its original type and style controls, with recursive output
-processing added. Registration uses Donut's existing isolated-import mechanism;
-a failed override is reported rather than silently exposing an incompatible
-older implementation.
+Local composition uses the existing safetensors-header analysis endpoint.
+Turning CivitAI lookup On or selecting an enabled LoRA requests its metadata
+immediately; no image generation is needed just to populate the panel. Off
+prevents new UI CivitAI lookups, while local analysis remains available and
+previously cached information may still be displayed. The existing server's
+CivitAI configuration/cache and preview handling are reused; no new credentials
+or dependencies are introduced. Loading, unsupported files, HTTP errors,
+not-found results and unavailable previews are shown explicitly. Row actions
+includes Retry metadata. Requests are deduplicated and limited to two in flight.
 
-Run the dependency-free tests from the repository root:
+Suggested weights are existing CivitAI example/cache hints, not proof of an
+optimal value (the cache can default to 1). They never overwrite strengths
+without an explicit row action, and applying one leaves CLIP/text-fusion strength
+unchanged. Filename edits clear stale hashes; late responses cannot attach to
+another selection. A ten-character lookup hash does not overwrite a full hash.
+
+The backend builder/applier is unchanged. It still resolves the entire dynamic
+stack through existing Donut code and calls the safe applier once, preserving
+whole-stack budgeting, duplicates, fused-text strengths and block behavior.
+
+## Other boundaries
+
+Three Donut Text editors replace eleven wildcard processors. Each editor
+resolves nested TXT wildcards and choices with bounded recursion, local RNG,
+cycle/path/size guards, file cache invalidation and explicit missing-file policy.
+Resolved text is a read-only, collapsible preview; advanced text settings can
+also be collapsed without changing their values. Prompt conditioning keeps
+full versus face text and raw versus zeroed negative conditioning separate.
+
+The seed plan keeps independently controlled text, sampler-master and filename
+seeds. Sampling stage offsets are 0, 2, 3 and 4 modulo 2**53, intentionally fixing
+the old second-upscale/face collision. Grouped body/fusion merge controls retain
+all per-block values. Upscale enable switches retain the existing algorithms
+and lazy pass-through when disabled.
+
+Removed workflow packs: mikey_nodes, RES4LYF, cg-use-everywhere,
+derfuu_comfyui_moddednodes, ComfyUI_Comfyroll_CustomNodes and rgthree-comfy.
+Retained: ComfyUI-bleh (configured sampler), WAS Node Suite (saving), Impact Pack
+and Subpack (SAM/detection/detailing), and krea2-nag (adjustable NAG).
+
+The separate fusion-aware warning is not suppressed: the safe applier needs a
+model carrying Fusion Control metadata upstream. This UI fix does not change
+that model execution order.
+
+## Validation
 
 ```sh
-DONUT_WORKFLOW_SOURCE=/path/to/ComfyUI_00016_.json python -m unittest discover -s tests -p test_streamlining.py -v
+node --test tests/test_streamlining_frontend.cjs
+# Also test the supplied private graph pair (not committed):
+DONUT_BROKEN_WORKFLOW=/path/to/ComfyUI_00016_Donut_Streamlined.json \
+DONUT_FIXED_WORKFLOW=/path/to/ComfyUI_00016_Donut_Streamlined_Fixed.json \
 node --test tests/test_streamlining_frontend.cjs
 ```
 
-At preparation: **45 Python tests and 11 JavaScript contract tests pass**.
-Python checks reciprocal links/types, subgraph boundaries, acyclicity,
-parameter and bypass preservation against the original upload, seed routing,
-recursive wildcard safety and mocked legacy delegation. JavaScript executes
-the extension against a small DOM/Comfy harness, covering row operations,
-serialization, repair, hash races, presets, seed controls and grouped widgets.
-The eight real-workflow tests require `DONUT_WORKFLOW_SOURCE`; without it they
-are explicitly skipped and the 37 other Python tests still run. No workflow
-fixture is committed; the workflow files are delivered separately.
-
-Not performed: a real ComfyUI browser import/queue, model loading, CivitAI
-network access, GPU inference or image-output parity testing. The PR is a draft
-until those are checked. In particular, test both upscale toggles, editing on
-and off, NAG enabled, LoRA add/reorder/save/reload, and a fixed-seed queue with
-real nested wildcard files. No claim is made that CPU mocks prove GPU parity.
+The native-UI update has 25 passing regression tests with the graph pair
+provided (24 pass and one skips without it). They exercise the actual extension
+against a small native-widget/DOM harness with mocked HTTP responses, including
+catalog fallback, native widget types, collapsed rows, JSON/positional/API
+serialization, metadata content/links/previews, stale results, request limiting
+and the original shifted-widget failure. Existing Python backend tests remain
+unchanged. These tests do not constitute a complete ComfyUI browser session,
+a live CivitAI API test, GPU inference, output-image parity or a benchmark.

--- a/tests/test_streamlining_frontend.cjs
+++ b/tests/test_streamlining_frontend.cjs
@@ -1,127 +1,257 @@
-// Dependency-free frontend contract tests, not a real ComfyUI browser session.
+// Contract tests for the real extension against a small native-widget/DOM harness.
+// This is not a full ComfyUI renderer or a GPU test.
 const assert = require('node:assert/strict');
 const fs = require('node:fs');
 const path = require('node:path');
 const vm = require('node:vm');
 const test = require('node:test');
+const clean = value => JSON.parse(JSON.stringify(value));
 class Element {
-  constructor(tag) { this.tag = tag; this.children = []; this.style = {}; this.events = {}; this.textContent = ''; }
-  append(...children) { this.children.push(...children); }
-  replaceChildren(...children) { this.children = [...children]; }
-  setAttribute(key, value) { this[key] = value; }
-  addEventListener(name, callback) { this.events[name] = callback; }
-  fire(name) { this.events[name]?.({preventDefault() {}}); }
-  checkValidity() { return Number.isFinite(this.valueAsNumber) && this.valueAsNumber >= -1000 && this.valueAsNumber <= 1000; }
-  get valueAsNumber() { return Number(this.value); }
+    constructor(tag) { this.tag = tag; this.children = []; this.style = {}; this.events = {}; this.textContent = ''; }
+    append(...children) { this.children.push(...children); }
+    replaceChildren(...children) { this.children = children; }
+    setAttribute(name, value) { this[name] = value; }
+    addEventListener(name, fn) { this.events[name] = fn; }
 }
-function all(root, predicate) { return [root, ...root.children.flatMap(child => all(child, () => true))].filter(predicate); }
-let extension;
-const context = vm.createContext({ console, URLSearchParams, Math, Date,
-  document: {createElement: tag => new Element(tag)},
-  app: {registerExtension: value => { extension = value; }, graph: {change() {}}},
-  api: {apiURL: value => value},
-  ComfyWidgets: {STRING(node, name) { const widget = {name, value: '', inputEl: {}}; node.widgets.push(widget); return {widget}; }},
-});
-const source = fs.readFileSync(path.join(__dirname, '../web/donut_workflow.js'), 'utf8')
-  .replace(/^import .*;\n/gm, '').replace(/export function /g, 'function ');
-vm.runInContext(source, context);
-const definition = {name: 'DonutLoRALoader', input: {required: {slots_json: ['STRING', {
-  donut_loras: ['None', 'a.safetensors', 'b.safetensors'], donut_presets: ['None', 'KREA2-ALL:1,1', 'SDXL-ALL:1,1'],
-}]}}};
-const rows = count => Array.from({length: count}, (_, index) => ({id: `row-${index}`, enabled: index % 2 === 0,
-  lora_name: `lora-${index}`, model_weight: index / 10, clip_weight: index === 0 ? 0 : -index / 10, block_vector: `${index},1`,
-  block_preset: 'None', inherit_block_vector: index % 2 !== 0, lora_hash: `HASH${index}`, custom: {keep: index}}));
-function makeNode(name = definition.name, initial = '[]') {
-  class Node {
-    constructor() {
-      this.widgets = [{name: 'model_type', value: 'KREA2'}, {name: 'slots_json', value: initial, type: 'customtext'},
-        {name: 'global_block_vector', value: '1,1'}]; this.size = [400, 600]; this.parentEvents = [];
+const text = root => root.textContent + root.children.map(text).join(' ');
+const elements = (root, tag) => [root, ...root.children.flatMap(c => elements(c))].filter(e => !tag || e.tag === tag);
+const settle = async () => { for (let i = 0; i < 16; i++) await new Promise(r => setImmediate(r)); };
+const rows = count => Array.from({ length: count }, (_, i) => ({ id: `row-${i}`, enabled: i % 2 === 0,
+    lora_name: `folder/model-${i}.safetensors`, model_weight: .75, clip_weight: 0,
+    block_vector: '0,1,0', block_preset: 'KREA2-TEST:0,1,0', inherit_block_vector: true,
+    lora_hash: '', custom: { preserved: i } }));
+function setup(handler = undefined) {
+    const requests = []; let extension;
+    const api = {
+        apiURL: value => `/api${value}`,
+        async fetchApi(url, options) {
+            requests.push(url);
+            if (handler) { const result = await handler(url, options); if (result) return result; }
+            const value = url === '/models/loras' ? ['folder/a.safetensors', 'folder/b.safetensors']
+                : url.startsWith('/object_info') ? { DonutLoRAStack: { input: { required: {
+                    lora_name_1: [['None', 'fallback.safetensors']],
+                    block_preset_1: [['None', 'KREA2-TEST:0,1,0', 'KREA2-ALL:1,1,1', 'SDXL-ALL:1,1']]
+                } } } }
+                : url.includes('/analyze?') ? { found: true, supported: true, tensor_count: 8,
+                    components: [{ name: 'UNet', modules: 4, groups: [{ name: 'blocks', indices: [3, 4] }] }] }
+                : { name: new URL(url, 'http://local').searchParams.get('name'), hash: 'a'.repeat(10), has_collage: true,
+                    civitai: { model_id: 123, model_version_id: 456, model_name: 'Test model', version_name: 'v2',
+                        base_model: 'Krea2', recommended_weight: .65, trained_words: ['trigger'], creator_username: 'Author',
+                        description: '<script>not executable</script>', model_url: 'javascript:bad()' } };
+            return { ok: true, status: 200, json: async () => value };
+        }
+    };
+    const app = { registerExtension: x => { extension = x; }, graph: { change() {} } };
+    const context = vm.createContext({ console: { warn() {}, log() {} }, app, api, URLSearchParams, URL,
+        Math, Date, AbortController, setTimeout, clearTimeout, queueMicrotask,
+        document: { createElement: tag => new Element(tag) },
+        ComfyWidgets: { STRING(node, name) { const w = node.addWidget('customtext', name, '', () => {}, {}); w.inputEl = {}; return { widget: w }; } }
+    });
+    for (const file of ['donut_native_lora.js', 'donut_workflow_repair.js', 'donut_workflow.js']) {
+        const source = fs.readFileSync(path.join(__dirname, '../web', file), 'utf8')
+            .replace(/^import .*;\n/gm, '').replace(/^export \{.*\} from .*;\n/gm, '').replace(/export function /g, 'function ');
+        vm.runInContext(source, context);
     }
-    onNodeCreated() { this.parentEvents.push('created'); }
-    onConfigure() { this.parentEvents.push('configured'); }
-    onExecuted() { this.parentEvents.push('executed'); }
-    onSerialize(data) { this.parentEvents.push('serialized'); data.parent = true; }
-    addDOMWidget(name, type, root, options) { this.root = root; const w = {name, type, options}; this.widgets.push(w); return w; }
-    setDirtyCanvas() {}
-    setSize(size) { this.size = size; }
-    computeSize() { return this.size; }
-  }
-  extension.beforeRegisterNodeDef(Node, {...definition, name});
-  return new Node();
+    const backendNames = ['model_type', 'slots_json', 'global_block_vector', 'civitai_lookup', 'safe_stack', 'fusion_aware', 'max_fusion_boost', 'safe_limit', 'execution_mode'];
+    function make(initial = rows(3), lookup = 'Off', type = 'DonutLoRALoader') {
+        class Node {
+            constructor() {
+                this.widgets = []; this.inputs = []; this.properties = {}; this.size = [360, 900]; this.parent = [];
+                const values = ['KREA2', JSON.stringify(initial), '1,1,1', lookup, 'On', 'Use headroom', 2, 1, 'Experimental bypass'];
+                backendNames.forEach((name, i) => this.addWidget(name === 'slots_json' ? 'customtext' : 'combo', name, values[i], () => {}, {}));
+            }
+            addWidget(type, name, value, callback, options) { const w = { type, name, value, callback, options }; this.widgets.push(w); return w; }
+            addDOMWidget(name, type, element, options) { const w = { type, name, element, options }; this.widgets.push(w); return w; }
+            removeWidget(widget) { widget.onRemove?.(); this.widgets.splice(this.widgets.indexOf(widget), 1); }
+            computeSize() { return [this.size[0], 70 + this.widgets.reduce((sum, w) => sum + (w.hidden ? 0 : w.options?.getMinHeight?.() || 24), 0)]; }
+            setSize(value) { this.size = value; }
+            setDirtyCanvas() {}
+            onConfigure() { this.parent.push('configured'); }
+            onSerialize(data) { data.parent = true; }
+            onExecuted() { this.parent.push('executed'); }
+            onRemoved() { this.parent.push('removed'); }
+        }
+        extension.beforeRegisterNodeDef(Node, { name: type, input: { required: { slots_json: ['STRING', {}] } } });
+        const node = new Node(); node.onNodeCreated(); return node;
+    }
+    return { make, requests, api, context, get extension() { return extension; } };
 }
-const state = node => node.widgets.find(w => w.name === 'slots_json');
-const saved = node => JSON.parse(state(node).value);
-const boxes = node => all(node.root, e => e.tag === 'fieldset');
-const click = (root, label) => { const b = all(root, e => e.tag === 'button' && e.textContent === label)[0]; assert.ok(b, label); b.fire('click'); };
-const input = (root, label) => all(root, e => e.tag === 'label' && e.textContent === `${label} `)[0].children[0];
+const find = (node, suffix, id = 'row-0') => node.widgets.find(w => w.name === `donut_row:${id}:${suffix}`);
+const change = (widget, value) => { widget.value = value; widget.callback(value); };
+const saved = node => JSON.parse(node.widgets.find(w => w.name === 'slots_json').value);
+const panel = (node, id) => find(node, 'information', id).element;
 
-test('restore all six slots by named state, preserving disabled rows and metadata', () => {
-  const node = makeNode(); node.onNodeCreated(); node.onConfigure({widgets_values_named: {slots_json: JSON.stringify(rows(6))}});
-  assert.deepEqual(saved(node), rows(6)); assert.equal(boxes(node).length, 6);
-  assert.equal(state(node).type, 'converted-widget'); assert.equal(node.widgets.length, 4);
+test('native combo lists installed files even when unknown STRING metadata was stripped', async () => {
+    const { make } = setup(); const node = make(); await settle();
+    const picker = find(node, 'lora_name'); assert.equal(picker.type, 'combo');
+    assert.deepEqual(clean(picker.options.values), ['None', 'folder/a.safetensors', 'folder/b.safetensors', 'folder/model-0.safetensors']);
+    assert.equal(node.widgets.some(w => w.element && elements(w.element).some(e => ['select', 'datalist', 'input'].includes(e.tag))), false);
 });
-test('adding slots is unbounded by the old three-slot contract', () => {
-  const node = makeNode('DonutLoRALoader', JSON.stringify(rows(6))); node.onNodeCreated();
-  for (let i = 0; i < 5; i++) click(node.root, '+ Add LoRA');
-  assert.equal(saved(node).length, 11); assert.equal(new Set(saved(node).map(row => row.id)).size, 11);
-  assert.deepEqual(saved(node).slice(0, 6), rows(6));
+test('catalog falls back to the old loader schema when the core models route is unavailable', async () => {
+    const { make } = setup(url => url === '/models/loras' ? { ok: false, status: 404 } : null);
+    const node = make(); await settle(); assert.ok(find(node, 'lora_name').options.values.includes('fallback.safetensors'));
 });
-test('reorder and removal move complete rows, not just filenames', () => {
-  const node = makeNode('DonutLoRALoader', JSON.stringify(rows(6))); node.onNodeCreated();
-  click(boxes(node)[2], '↑'); const expected = rows(6); [expected[1], expected[2]] = [expected[2], expected[1]];
-  assert.deepEqual(saved(node), expected); click(boxes(node)[4], 'Remove'); expected.splice(4, 1);
-  assert.deepEqual(saved(node), expected);
+test('disabled rows retain native picker, enable and actions but hide every dependent parameter', async () => {
+    const { make } = setup(); const node = make(); await settle();
+    change(find(node, 'advanced'), true); const before = saved(node); const height = node.size[1];
+    change(find(node, 'enabled'), false);
+    for (const suffix of ['model_weight', 'clip_weight', 'advanced', 'block_preset', 'inherit', 'block_vector', 'information']) assert.equal(find(node, suffix).hidden, true, suffix);
+    for (const suffix of ['lora_name', 'enabled', 'actions']) assert.notEqual(find(node, suffix).hidden, true, suffix);
+    assert.ok(node.size[1] < height);
+    change(find(node, 'enabled'), true); assert.deepEqual(saved(node), before);
+    assert.equal(find(node, 'block_vector').value, '0,1,0'); assert.equal(find(node, 'clip_weight').value, 0);
 });
-test('named and positional serialization roundtrip with parent hooks intact', () => {
-  const original = rows(7); const node = makeNode('DonutDynamicLoRAStack'); node.onNodeCreated();
-  node.onConfigure({widgets_values: ['KREA2', JSON.stringify(original), '1,1']});
-  const output = {}; node.onSerialize(output); assert.equal(output.parent, true);
-  assert.equal(state(node).serializeValue(), JSON.stringify(original));
-  const copy = makeNode(); copy.onNodeCreated(); copy.onConfigure(output); assert.deepEqual(saved(copy), original);
-  assert.deepEqual(node.parentEvents, ['created', 'configured', 'serialized']);
+test('disabled rows do not trigger local analysis or CivitAI lookup; Off prevents network lookup', async () => {
+    const { make, requests } = setup(); make([{ ...rows(1)[0], enabled: false }], 'On'); await settle();
+    assert.equal(requests.some(u => /\/(info|analyze)\?/.test(u)), false);
+    const node = make(rows(1), 'Off'); await settle();
+    assert.ok(requests.some(u => u.includes('/analyze?'))); assert.equal(requests.some(u => u.includes('/info?')), false);
+    change(node.widgets.find(w => w.name === 'civitai_lookup'), 'On'); await settle();
+    assert.ok(requests.some(u => u.includes('/info?')));
 });
-test('malformed loaded JSON is not replaced with an empty stack', () => {
-  const node = makeNode(); node.onNodeCreated(); node.onConfigure({widgets_values_named: {slots_json: '[broken'}});
-  const output = {}; node.onSerialize(output); assert.equal(output.widgets_values_named.slots_json, '[broken');
-  const repair = all(node.root, e => e.tag === 'textarea')[0]; assert.ok(repair);
-  repair.value = JSON.stringify(rows(1)); repair.fire('change'); assert.deepEqual(saved(node), rows(1));
+test('lookup shows links, detected components, recommendations, triggers and bounded local previews before queueing', async () => {
+    const { make } = setup(); const node = make(rows(1), 'On'); await settle();
+    const root = panel(node); const content = text(root);
+    for (const expected of ['Detected weights', '8 tensors', 'blocks: 3, 4', 'Suggested weight: 0.65', 'Test model', 'Triggers: trigger']) assert.ok(content.includes(expected), expected);
+    const links = elements(root, 'a'); assert.ok(links.some(a => a.href === 'https://civitai.com/models/123?modelVersionId=456'));
+    assert.ok(links.every(a => a.rel === 'noopener noreferrer'));
+    assert.equal(elements(root, 'script').length, 0);
+    const image = elements(root, 'img')[0]; assert.equal(image.style.maxHeight, '150px');
+    assert.match(image.src, /^\/api\/donut\/loras\/preview\?/); assert.equal(find(node, 'information').options.getMaxHeight(), 250);
 });
-test('filename edits clear stale hash and late execution metadata cannot restore it', () => {
-  const node = makeNode('DonutLoRALoader', JSON.stringify(rows(1))); node.onNodeCreated();
-  const filename = input(boxes(node)[0], 'LoRA'); filename.value = 'new.safetensors'; filename.fire('change');
-  assert.equal(saved(node)[0].lora_hash, '');
-  node.onExecuted({donut_loras: [{id: 'row-0', lora_name: 'lora-0', lora_hash: 'OLDHASH'}]});
-  assert.equal(saved(node)[0].lora_hash, '');
-  node.onExecuted({donut_loras: [{id: 'row-0', lora_name: 'new.safetensors', lora_hash: 'NEWHASH'}]});
-  assert.equal(saved(node)[0].lora_hash, 'NEWHASH');
+test('preset combo labels contain no long vectors and selecting a preset edits only its intended fields', async () => {
+    const { make } = setup(); const node = make(); await settle();
+    const preset = find(node, 'block_preset'); assert.ok(preset.options.values.every(v => !v.includes(':') && !v.includes(',')));
+    assert.ok(!preset.options.values.includes('SDXL-ALL'));
+    change(preset, 'KREA2-ALL'); assert.equal(saved(node)[0].block_preset, 'KREA2-ALL:1,1,1');
+    assert.equal(saved(node)[0].block_vector, '1,1,1'); assert.equal(saved(node)[0].inherit_block_vector, false);
 });
-test('block presets edit the actual vector and disable inheritance', () => {
-  const node = makeNode('DonutLoRALoader', JSON.stringify(rows(2))); node.onNodeCreated();
-  const box = boxes(node)[1]; const select = all(box, e => e.tag === 'select')[0];
-  assert.equal(select.children.some(e => e.value.startsWith('SDXL')), false);
-  select.value = 'KREA2-ALL:1,1'; select.fire('change');
-  assert.equal(saved(node)[1].block_vector, '1,1'); assert.equal(saved(node)[1].inherit_block_vector, false);
+test('suggested weight is never applied silently and explicit action does not touch zero CLIP strength', async () => {
+    const { make } = setup(); const node = make(rows(1), 'On'); await settle();
+    assert.equal(saved(node)[0].model_weight, .75); change(find(node, 'actions'), 'Use suggested model weight');
+    assert.equal(saved(node)[0].model_weight, .65); assert.equal(saved(node)[0].clip_weight, 0);
 });
-test('invalid number does not corrupt canonical row state', () => {
-  const node = makeNode('DonutLoRALoader', JSON.stringify(rows(1))); node.onNodeCreated();
-  const weight = input(boxes(node)[0], 'Model strength'); weight.value = 'NaN'; weight.fire('change');
-  assert.equal(saved(node)[0].model_weight, 0); weight.value = '0.75'; weight.fire('change'); assert.equal(saved(node)[0].model_weight, .75);
+test('add, reorder and remove preserve complete rows and have no six-row ceiling', async () => {
+    const { make } = setup(); const node = make(rows(6)); await settle();
+    for (let i = 0; i < 4; i++) node.widgets.find(w => w.name === '+ Add LoRA').callback();
+    assert.equal(saved(node).length, 10);
+    change(find(node, 'actions', 'row-2'), 'Move up'); assert.equal(saved(node)[1].id, 'row-2');
+    assert.deepEqual(saved(node)[1].custom, { preserved: 2 });
+    change(find(node, 'actions', 'row-2'), 'Remove'); assert.equal(saved(node).length, 9);
 });
-test('seed controls have unique serialized names', () => {
-  const node = makeNode('DonutSeedPlan'); node.widgets = ['text_seed', 'control_after_generate', 'sampler_seed',
-    'control_after_generate', 'filename_seed', 'control_after_generate'].map(name => ({name})); node.onNodeCreated();
-  assert.deepEqual(node.widgets.map(w => w.name), ['text_seed', 'text_seed_control', 'sampler_seed', 'sampler_seed_control', 'filename_seed', 'filename_seed_control']);
+test('workflow and API serializers exclude every row/helper widget; only canonical JSON carries row state', async () => {
+    const { make } = setup(); const node = make(rows(6)); await settle();
+    const output = {}; node.onSerialize(output); assert.equal(output.parent, true);
+    assert.equal(output.widgets_values.length, 9);
+    assert.equal(Object.keys(output.widgets_values_named).length, 9);
+    assert.equal(node.widgets.filter(w => w.name.startsWith('donut_row:')).every(w => w.serialize === false && w.options.serialize === false), true);
+    const copy = make([]); copy.onConfigure(output); await settle(); assert.deepEqual(saved(copy), saved(node));
+    const positional = make([]); positional.onConfigure({ widgets_values: output.widgets_values }); await settle(); assert.deepEqual(saved(positional), saved(node));
 });
-test('grouped merge hides controls without deleting or changing their values', () => {
-  const node = makeNode('DonutModelMergeKrea2'); node.widgets = [
-    {name: 'ratio_mode', value: 'Grouped'}, {name: 'blocks.0.', value: .45, type: 'number'},
-    {name: 'txtfusion.projector.', value: .35, type: 'number'}, {name: 'tmlp.', value: .95, type: 'number'}];
-  node.onNodeCreated(); assert.equal(node.widgets.length, 4); assert.equal(node.widgets[1].type, 'converted-widget');
-  assert.equal(node.widgets[3].type, 'number'); node.widgets[0].value = 'Per block'; node.widgets[0].callback();
-  assert.equal(node.widgets[1].type, 'number'); assert.equal(node.widgets[1].value, .45);
+test('invalid saved JSON is preserved for repair rather than replaced by an empty stack', async () => {
+    const { make } = setup(); const node = make(); node.onConfigure({ widgets_values_named: { slots_json: '[broken' } }); await settle();
+    const output = {}; node.onSerialize(output); assert.equal(output.widgets_values_named.slots_json, '[broken');
+    assert.equal(node.widgets.find(w => w.name === '+ Add LoRA').disabled, true);
+    change(node.widgets.find(w => w.name === 'Repair slots_json'), JSON.stringify(rows(2))); assert.equal(saved(node).length, 2);
 });
-test('prompt preview is read-only, not an extra backend input', () => {
-  const node = makeNode('DonutText'); node.onNodeCreated(); node.onExecuted({text: ['resolved prompt']});
-  const preview = node.widgets.find(w => w.name === 'resolved_text');
-  assert.equal(preview.value, 'resolved prompt'); assert.equal(preview.options.serialize, false); assert.equal(preview.inputEl.readOnly, true);
+test('changing filename clears its hash; stale execution metadata cannot attach to the new selection', async () => {
+    const { make } = setup(); const node = make([{ ...rows(1)[0], lora_hash: 'a'.repeat(64) }]); await settle();
+    change(find(node, 'lora_name'), 'folder/b.safetensors'); assert.equal(saved(node)[0].lora_hash, '');
+    node.onExecuted({ donut_loras: [{ id: 'row-0', lora_name: 'folder/model-0.safetensors', lora_hash: 'b'.repeat(64) }] });
+    assert.equal(saved(node)[0].lora_hash, '');
+    node.onExecuted({ donut_loras: [{ id: 'row-0', lora_name: 'folder/b.safetensors', lora_hash: 'c'.repeat(64) }] });
+    assert.equal(saved(node)[0].lora_hash, 'c'.repeat(64));
+});
+test('metadata responses arriving after a row was replaced cannot change its name or hash', async () => {
+    let resolveOld;
+    const { make } = setup(url => url.includes('/info?') && url.includes('model-0') ? new Promise(resolve => { resolveOld = resolve; }) : null);
+    const node = make(rows(1), 'On'); await settle();
+    change(find(node, 'lora_name'), 'folder/b.safetensors'); await settle();
+    resolveOld({ ok: true, json: async () => ({ hash: 'b'.repeat(10), civitai: { model_name: 'OLD' } }) }); await settle();
+    assert.equal(saved(node)[0].lora_name, 'folder/b.safetensors'); assert.equal(saved(node)[0].lora_hash, 'a'.repeat(10));
+    assert.ok(!text(panel(node)).includes('OLD'));
+});
+test('full stored hashes are not downgraded to ten-character UI lookup prefixes', async () => {
+    const { make } = setup(); const node = make([{ ...rows(1)[0], lora_hash: 'b'.repeat(64) }], 'On'); await settle();
+    assert.equal(saved(node)[0].lora_hash, 'b'.repeat(64));
+});
+test('failed catalog requests display retry state and never reset saved names', async () => {
+    const { make } = setup(url => /models\/loras|object_info/.test(url) ? { ok: false, status: 503 } : null);
+    const node = make(); await settle(); assert.ok(node.widgets.some(w => w.name.includes('LoRA list unavailable')));
+    assert.equal(saved(node)[0].lora_name, 'folder/model-0.safetensors');
+});
+test('network errors are visible and the row provides retry instead of a blank metadata panel', async () => {
+    const { make } = setup(url => url.includes('/info?') ? { ok: false, status: 503 } : null);
+    const node = make(rows(1), 'On'); await settle(); assert.ok(text(panel(node)).includes('503'));
+    assert.ok(text(panel(node)).includes('Retry metadata'));
+});
+test('metadata calls are deduplicated by filename and limited to two simultaneous requests', async () => {
+    let active = 0, peak = 0;
+    const { context, api } = setup(async url => {
+        if (url.includes('/info?')) {
+            active++; peak = Math.max(peak, active); await new Promise(r => setTimeout(r, 2)); active--;
+        }
+    });
+    const service = context.createLoraService(api);
+    const promises = Array.from({ length: 10 }, (_, i) => service.details('info', `file-${i % 5}`));
+    await Promise.all(promises); assert.equal(peak, 2);
+});
+test('read-only promoted widget types can be hidden and restored without changing values', () => {
+    const { context } = setup(); const widget = { get type() { return 'number'; }, value: 8 };
+    context.setHidden(widget, true); assert.equal(widget.hidden, true); assert.equal(widget.value, 8);
+    context.setHidden(widget, false); assert.equal(widget.hidden, false); assert.equal(widget.type, 'number');
+});
+test('removed nodes ignore pending results and leave the refresh registry', async () => {
+    const { make, extension } = setup(); const node = make(rows(1), 'On'); node.onRemoved(); await settle();
+    const before = saved(node); await extension.refreshComboInNodes(); assert.deepEqual(saved(node), before);
+});
+
+test('v1 workflow widget/port repair matches the delivered corrected workflow and is idempotent', { skip: !process.env.DONUT_BROKEN_WORKFLOW || !process.env.DONUT_FIXED_WORKFLOW }, () => {
+    const { context } = setup();
+    const broken = JSON.parse(fs.readFileSync(process.env.DONUT_BROKEN_WORKFLOW));
+    const fixed = JSON.parse(fs.readFileSync(process.env.DONUT_FIXED_WORKFLOW));
+    assert.equal(context.repairStreamlinedWorkflow(broken), true);
+    const actual = broken.nodes.find(n => n.id === 1014), expected = fixed.nodes.find(n => n.id === 1014);
+    assert.equal(actual.inputs.length, 37); assert.equal(actual.widgets_values.length, 25);
+    assert.deepEqual(clean(actual.widgets_values), expected.widgets_values);
+    assert.deepEqual(clean(actual.widgets_values_named), expected.widgets_values_named);
+    assert.deepEqual(clean(actual.inputs.map(p => [p.name, p.link, p.widget?.name])), expected.inputs.map(p => [p.name, p.link, p.widget?.name ?? null]));
+    assert.deepEqual(clean(broken.links), fixed.links);
+    assert.equal(context.repairStreamlinedWorkflow(broken), false);
+});
+test('already-repaired workflows retain later user edits rather than reapplying stale named defaults', () => {
+    const { context } = setup(); const workflow = { extra: { donut_streamlining: { schema: 2 } }, nodes: [{ widgets_values: [16], widgets_values_named: { steps: 8 } }] };
+    assert.equal(context.repairStreamlinedWorkflow(workflow), false); assert.equal(workflow.nodes[0].widgets_values[0], 16);
+});
+
+test('nonfinite numeric edits restore the previous displayed and canonical value', async () => {
+    const { make } = setup(); const node = make(); await settle();
+    change(find(node, 'model_weight'), NaN); assert.equal(find(node, 'model_weight').value, .75);
+    assert.equal(saved(node)[0].model_weight, .75);
+});
+test('text previews are UI-only, collapsed initially, and reveal the resolved text without changing backend values', async () => {
+    const { make } = setup(); const node = make([], 'Off', 'DonutText'); await settle();
+    const preview = node.widgets.find(w => w.name === 'resolved_text');
+    assert.equal(preview.hidden, true); assert.equal(preview.serialize, false); assert.equal(preview.options.serialize, false);
+    node.onExecuted({ text: ['resolved'] }); assert.equal(preview.value, 'resolved');
+    node.widgets.find(w => w.name === 'Show / hide resolved text').callback(); assert.equal(preview.hidden, false);
+});
+test('UI lookup errors still expose backend execution preview data when available', async () => {
+    const { make } = setup(url => url.includes('/info?') ? { ok: false, status: 503 } : null);
+    const node = make(rows(1), 'On'); await settle();
+    node.onExecuted({ donut_loras: [{ id: 'row-0', lora_name: 'folder/model-0.safetensors', lora_hash: 'd'.repeat(64),
+        text: 'Cached trigger words', image: { filename: 'preview.jpg', type: 'temp', subfolder: '' } }] });
+    assert.ok(text(panel(node)).includes('Cached trigger words'));
+    assert.match(elements(panel(node), 'img')[0].src, /^\/api\/view\?/);
+});
+test('seed widgets keep separate serialized control names', () => {
+    const { make } = setup(); const node = make([], 'Off', 'DonutSeedPlan');
+    node.widgets = ['text_seed', 'control_after_generate', 'sampler_seed', 'control_after_generate', 'filename_seed', 'control_after_generate'].map(name => ({ name }));
+    node.onNodeCreated(); assert.deepEqual(node.widgets.map(w => w.name), ['text_seed', 'text_seed_control', 'sampler_seed', 'sampler_seed_control', 'filename_seed', 'filename_seed_control']);
+});
+test('grouped merge still hides and restores original per-block controls without losing values', () => {
+    const { make } = setup(); const node = make([], 'Off', 'DonutModelMergeKrea2');
+    node.widgets = [{ name: 'ratio_mode', value: 'Grouped' }, { name: 'blocks.0.', value: .3, type: 'number' }, { name: 'tmlp.', value: .8, type: 'number' }];
+    node.onNodeCreated(); assert.equal(node.widgets[1].hidden, true); assert.notEqual(node.widgets[2].hidden, true);
+    change(node.widgets[0], 'Per block'); assert.equal(node.widgets[1].hidden, false); assert.equal(node.widgets[1].value, .3);
 });

--- a/web/donut_native_lora.js
+++ b/web/donut_native_lora.js
@@ -1,0 +1,391 @@
+// Native ComfyUI controls; slots_json remains the ONLY serialized row state.
+// No datalist, HTML select or hand-built dropdown menu.
+export function decodeRows(value) {
+    const rows = JSON.parse(value || "[]");
+    if (!Array.isArray(rows) || rows.some(row => !row || typeof row !== "object" || Array.isArray(row))) {
+        throw new Error("LoRA slots must be an array of objects");
+    }
+    return rows;
+}
+export function moveRow(rows, from, to) {
+    const result = rows.slice();
+    if (from < 0 || from >= rows.length || to < 0 || to >= rows.length) return result;
+    result.splice(to, 0, result.splice(from, 1)[0]);
+    return result;
+}
+const unique = values => [...new Set(values.filter(v => typeof v === "string" && v.length))];
+const titleOf = value => String(value || "None").split(":")[0];
+const hasFile = row => !!row.lora_name && row.lora_name !== "None";
+const enabled = row => row.enabled !== false;
+const hexHash = value => typeof value === "string" && /^[a-f\d]{10,128}$/i.test(value);
+
+// Shared per-extension service: no requests per row just to list the same files.
+// Two in-flight metadata requests avoid flooding a local server on workflow load.
+export function createLoraService(api) {
+    let catalog, catalogJob, active = 0;
+    const waiters = [], jobs = new Map();
+    async function json(path) {
+        const controller = new AbortController();
+        const timer = setTimeout(() => controller.abort(), 120_000);
+        try {
+            const response = await api.fetchApi(path, { cache: "no-store", signal: controller.signal });
+            if (!response.ok) {
+                let reason = "Request failed";
+                try { const data = await response.json(); if (typeof data.error === "string") reason = data.error; } catch { /* Non-JSON error response. */ }
+                throw new Error(`${reason} (${response.status})`);
+            }
+            return await response.json();
+        } finally { clearTimeout(timer); }
+    }
+    async function limited(path) {
+        if (active >= 2) await new Promise(resolve => waiters.push(resolve));
+        else active++;
+        try { return await json(path); }
+        finally {
+            const next = waiters.shift();
+            if (next) next(); else active--;
+        }
+    }
+    return {
+        async catalog(force = false) {
+            if (catalogJob) return catalogJob;
+            if (catalog && !force) return catalog;
+            catalogJob = (async () => {
+                const [files, schema] = await Promise.allSettled([
+                    json("/models/loras"), json("/object_info/DonutLoRAStack")
+                ]);
+                const required = schema.status === "fulfilled"
+                    ? schema.value?.DonutLoRAStack?.input?.required : undefined;
+                const names = files.status === "fulfilled" && Array.isArray(files.value)
+                    ? files.value : required?.lora_name_1?.[0];
+                if (!Array.isArray(names)) throw new Error("Cannot list installed LoRAs. Use Refresh installed LoRAs to retry.");
+                catalog = { loras: unique(["None", ...names]),
+                    presets: unique(["None", ...(required?.block_preset_1?.[0] || catalog?.presets || [])]) };
+                return catalog;
+            })();
+            try { return await catalogJob; } finally { catalogJob = undefined; }
+        },
+        details(kind, name, force = false) {
+            const key = `${kind}:${name}`;
+            if (force) jobs.delete(key);
+            if (!jobs.has(key)) {
+                const job = limited(`/donut/loras/${kind}?name=${encodeURIComponent(name)}`);
+                jobs.set(key, job);
+                job.catch(() => { if (jobs.get(key) === job) jobs.delete(key); });
+            }
+            return jobs.get(key);
+        }
+    };
+}
+
+export function setHidden(widget, hide) {
+    if (!widget._donutVisible) widget._donutVisible = {
+        type: widget.type, computeSize: widget.computeSize, computeLayoutSize: widget.computeLayoutSize
+    };
+    widget.hidden = !!hide;
+    if (hide) {
+        const descriptor = Object.getOwnPropertyDescriptor(widget, "type");
+        if (!descriptor?.get || descriptor.set) widget.type = "hidden";
+        widget.computeSize = () => [0, -4]; // Legacy canvas accounts for a 4px gap.
+        widget.computeLayoutSize = () => ({ minHeight: 0, maxHeight: 0, minWidth: 0 });
+    } else {
+        const descriptor = Object.getOwnPropertyDescriptor(widget, "type");
+        if (!descriptor?.get || descriptor.set) widget.type = widget._donutVisible.type;
+        widget.computeSize = widget._donutVisible.computeSize;
+        widget.computeLayoutSize = widget._donutVisible.computeLayoutSize;
+    }
+}
+
+export function installNativeLoras(node, definition, { app, api, service }) {
+    if (node._donutNativeLoras) return;
+    const state = node.widgets?.find(w => w.name === "slots_json");
+    if (!state) return;
+    // Capture backend widgets BEFORE adding UI-only controls. Never address the
+    // JSON by its index in the changing live widget array.
+    const backend = node.widgets.slice();
+    const stateIndex = backend.indexOf(state);
+    const options = definition.input?.required?.slots_json?.[1] || {};
+    let catalog = { loras: unique(["None", ...(options.donut_loras || [])]),
+        presets: unique(["None", ...(options.donut_presets || [])]) };
+    let rows = [], ui = [], disposed = false, invalid = false, listError = "";
+    let generation = 0, catalogLoading = true;
+    const panels = new Map(), details = new Map(), expanded = new Set();
+    const get = name => backend.find(w => w.name === name)?.value;
+    const lookupOn = () => get("civitai_lookup") === "On";
+    const dirty = () => { node.setDirtyCanvas?.(true, true); app.graph?.change?.(); };
+    const fit = () => {
+        const size = node.computeSize?.();
+        if (size && Number.isFinite(size[1])) node.setSize?.([Math.max(320, node.size?.[0] || 320), size[1]]);
+        node.setDirtyCanvas?.(true, true);
+    };
+    const commit = () => { state.value = JSON.stringify(rows); dirty(); };
+    setHidden(state, true);
+    state.serializeValue = () => state.value;
+    const make = (type, name, value, callback, options = {}) => {
+        const widget = node.addWidget(type, name, value, callback, { ...options, serialize: false });
+        widget.serialize = false; // Exclude from workflow arrays as well as API inputs.
+        widget.options.serialize = false;
+        ui.push(widget);
+        return widget;
+    };
+    const el = (tag, text) => {
+        const element = document.createElement(tag);
+        if (text !== undefined) element.textContent = String(text);
+        return element;
+    };
+    function clearUI() {
+        for (const widget of ui) {
+            if (node.removeWidget) node.removeWidget(widget);
+            else { widget.onRemove?.(); const i = node.widgets.indexOf(widget); if (i >= 0) node.widgets.splice(i, 1); }
+        }
+        ui = []; panels.clear();
+    }
+    function current(row, epoch) {
+        return !disposed && epoch === generation && rows.includes(row) && enabled(row) && hasFile(row);
+    }
+    function validInfo(row) {
+        const info = details.get(String(row.id));
+        return info?.name === row.lora_name ? info : undefined;
+    }
+    function updatePanel(row) {
+        const panel = panels.get(String(row.id));
+        if (!panel) return;
+        const { root, widget } = panel;
+        root.replaceChildren();
+        const data = validInfo(row) || {};
+        root.append(el("strong", "Detected weights"));
+        const analysis = data.analysis;
+        if (analysis?.supported) {
+            root.append(el("div", `${analysis.tensor_count} tensors · ${analysis.components?.length || 0} components`));
+            for (const component of analysis.components || []) {
+                const groups = (component.groups || []).map(g => `${g.name}: ${g.indices.join(", ")}`).join("; ");
+                root.append(el("div", `${component.name} (${component.modules} modules)${groups ? " · " + groups : ""}`));
+            }
+        } else root.append(el("div", analysis?.error || data.analysisError || "Inspecting local file…"));
+        root.append(el("div", `Your strengths: model ${row.model_weight} · CLIP/text fusion ${row.clip_weight}`));
+        const info = data.info?.civitai;
+        root.append(el("strong", lookupOn() ? "CivitAI" : "CivitAI lookup is off"));
+        if (info) {
+            root.append(el("div", `${info.model_name || ""}${info.version_name ? " · " + info.version_name : ""}`));
+            root.append(el("div", `${info.base_model || ""}${info.creator_username ? " · " + info.creator_username : ""}`));
+            const weight = info.recommended_weight;
+            if (typeof weight === "number" && Number.isFinite(weight)) {
+                root.append(el("div", `Suggested weight: ${weight} (CivitAI example/cache hint; not applied automatically)`));
+            }
+            if (info.trained_words?.length) root.append(el("div", `Triggers: ${info.trained_words.join(", ")}`));
+            // Remote descriptions are text, never executable HTML.
+            if (info.description) {
+                const more = el("details"), summary = el("summary", "Description");
+                more.append(summary, el("div", String(info.description).replace(/<[^>]*>/g, "")));
+                root.append(more);
+            }
+        } else if (lookupOn()) root.append(el("div", data.info?.error || data.infoError || "Looking up hash and previews…"));
+        if (!info && data.execution?.text) root.append(el("div", data.execution.text));
+        const hash = data.info?.hash || row.lora_hash;
+        if (hexHash(hash)) root.append(el("small", `Hash: ${hash}`));
+        if (info || (lookupOn() && hexHash(hash))) {
+            const link = el("a", info ? "Open on CivitAI ↗" : "Search hash on CivitAI ↗");
+            // Construct links from IDs/hashes; never trust an arbitrary metadata URL.
+            const id = Number(info?.model_id), version = Number(info?.model_version_id);
+            link.href = Number.isSafeInteger(id) && id > 0 ? `https://civitai.com/models/${id}${Number.isSafeInteger(version) && version > 0 ? "?modelVersionId=" + version : ""}`
+                : `https://civitai.com/search/models?query=${encodeURIComponent(hexHash(hash) ? hash : row.lora_name)}`;
+            link.target = "_blank"; link.rel = "noopener noreferrer";
+            root.append(link);
+        }
+        let previewURL;
+        if (hexHash(hash) && (data.info?.has_collage || data.info?.preview_count > 0)) {
+            previewURL = api.apiURL(`/donut/loras/preview?${new URLSearchParams({ hash, type: data.info.has_collage ? "collage" : "0" })}`);
+        } else if (data.execution?.image?.filename) {
+            const image = data.execution.image;
+            previewURL = api.apiURL(`/view?${new URLSearchParams({ filename: image.filename, subfolder: image.subfolder || "", type: image.type || "temp" })}`);
+        }
+        if (previewURL) {
+            const link = el("a"), image = el("img");
+            link.href = previewURL; link.target = "_blank"; link.rel = "noopener noreferrer";
+            image.src = previewURL; image.alt = "LoRA preview (click to open)"; image.loading = "lazy";
+            Object.assign(image.style, { display: "block", maxWidth: "100%", maxHeight: "150px", objectFit: "contain" });
+            image.addEventListener("error", () => { link.replaceChildren(el("span", "Preview unavailable; retry lookup from row actions.")); });
+            link.append(image); root.append(link);
+        } else if (info) root.append(el("div", "No cached preview image available."));
+        if (data.infoError || data.info?.error) root.append(el("small", "Use Row actions → Retry metadata to try again."));
+        panel.height = previewURL ? 250 : info ? 150 : 85;
+        widget.options.getMinHeight = widget.options.getMaxHeight = () => panel.height;
+        widget.options.getHeight = () => panel.height;
+        setHidden(widget, !enabled(row) || !hasFile(row));
+        fit();
+    }
+    function requestDetails(row, force = false) {
+        if (!enabled(row) || !hasFile(row) || disposed) return;
+        const epoch = generation, name = row.lora_name;
+        const entry = validInfo(row) || { name };
+        details.set(String(row.id), entry);
+        const accept = () => current(row, epoch) && row.lora_name === name && validInfo(row) === entry;
+        const load = (kind, target) => {
+            if (!force && (entry[target] || entry[`${target}Loading`] || entry[`${target}Error`])) return;
+            entry[`${target}Loading`] = true; delete entry[`${target}Error`];
+            service.details(kind, name, force).then(result => {
+                if (!accept()) return;
+                entry[target] = result;
+                // Never replace a full hash by the shorter prefix returned by UI lookup.
+                if (target === "info" && hexHash(result.hash) && !row.lora_hash) { row.lora_hash = result.hash; commit(); }
+            }, error => { if (accept()) entry[`${target}Error`] = error.message; })
+                .finally(() => { entry[`${target}Loading`] = false; if (accept()) updatePanel(row); });
+        };
+        load("analyze", "analysis");
+        if (lookupOn()) load("info", "info");
+        updatePanel(row);
+    }
+    function render() {
+        clearUI();
+        const add = make("button", "+ Add LoRA", null, () => {
+            if (invalid) return;
+            rows.push({ id: globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`, enabled: true,
+                lora_name: "None", model_weight: 1, clip_weight: 1, block_preset: "None", block_vector: "", inherit_block_vector: false, lora_hash: "" });
+            commit(); render();
+        });
+        add.disabled = invalid;
+        make("button", listError || (catalogLoading ? "Loading installed LoRAs…" : `Refresh installed LoRAs (${catalog.loras.filter(n => n !== "None").length})`), null, () => { void refresh(true); });
+        if (invalid) {
+            const editor = make("text", "Repair slots_json", state.value, value => { state.value = value; restore(); dirty(); });
+            editor.tooltip = "Malformed saved JSON is retained. Correct it here; no rows have been discarded.";
+            fit(); return;
+        }
+        rows.forEach((row, index) => {
+            const key = String(row.id);
+            const prefix = `donut_row:${key}:`;
+            const name = make("combo", prefix + "lora_name", row.lora_name || "None", value => {
+                if (value === row.lora_name) return;
+                row.lora_name = value; row.lora_hash = ""; details.delete(key);
+                commit(); render();
+            });
+            name.label = `LoRA ${index + 1}`;
+            // Getter uses fresh catalog without replacing the selected/saved name.
+            Object.defineProperty(name.options, "values", { configurable: true,
+                get: () => unique([...catalog.loras, row.lora_name]), set: () => {} });
+            const dependent = [];
+            const on = make("toggle", prefix + "enabled", enabled(row), value => {
+                row.enabled = !!value; commit(); visibility();
+                if (enabled(row)) requestDetails(row);
+            }, { on: "Enabled", off: "Disabled" });
+            on.label = "Enabled";
+            for (const [field, label] of [["model_weight", "Model strength"], ["clip_weight", "CLIP / text-fusion strength"]]) {
+                const weight = make("number", prefix + field, row[field] ?? 1, value => {
+                    if (!Number.isFinite(value) || Math.abs(value) > 1000) { weight.value = row[field] ?? 1; return; }
+                    row[field] = value; commit(); updatePanel(row);
+                }, { min: -1000, max: 1000, step: 0.1, precision: 2 });
+                weight.label = label; dependent.push(weight);
+            }
+            const advanced = make("toggle", prefix + "advanced", expanded.has(key), value => {
+                if (value) expanded.add(key); else expanded.delete(key);
+                visibility();
+            }, { on: "Shown", off: "Hidden" });
+            advanced.label = "Block weights"; dependent.push(advanced);
+            const preset = make("combo", prefix + "block_preset", titleOf(row.block_preset), value => {
+                const raw = catalog.presets.find(p => titleOf(p) === value);
+                if (!raw) return;
+                row.block_preset = raw;
+                row.block_vector = raw.includes(":") ? raw.slice(raw.indexOf(":") + 1) : "";
+                row.inherit_block_vector = false;
+                vector.value = row.block_vector; inherit.value = false; vector.disabled = false; commit();
+            });
+            preset.label = "Block preset";
+            Object.defineProperty(preset.options, "values", { configurable: true, get: () => unique([
+                ...catalog.presets.filter(p => p === "None" || get("model_type") === "Auto" || p.startsWith(`${get("model_type")}-`)).map(titleOf),
+                titleOf(row.block_preset)
+            ]), set: () => {} });
+            const inherit = make("toggle", prefix + "inherit", !!row.inherit_block_vector, value => {
+                row.inherit_block_vector = !!value; vector.disabled = !!value; commit();
+            });
+            inherit.label = "Inherit global vector";
+            const vector = make("text", prefix + "block_vector", row.block_vector || "", value => { row.block_vector = value; commit(); });
+            vector.label = "Block vector"; vector.disabled = !!row.inherit_block_vector;
+            const root = el("div");
+            Object.assign(root.style, { overflow: "auto", boxSizing: "border-box", padding: "6px", font: "12px sans-serif", whiteSpace: "normal", overflowWrap: "anywhere" });
+            root.setAttribute("aria-label", `LoRA ${index + 1} information`);
+            const panel = { root, height: 85 };
+            const dom = node.addDOMWidget(prefix + "information", "div", root, {
+                serialize: false, getMinHeight: () => panel.height, getMaxHeight: () => panel.height, getHeight: () => panel.height
+            });
+            dom.serialize = false; ui.push(dom); panel.widget = dom; panels.set(key, panel);
+            dom.computeSize = () => [280, panel.height];
+            const action = make("combo", prefix + "actions", "Row actions", value => {
+                action.value = "Row actions";
+                if (value === "Move up" || value === "Move down") rows = moveRow(rows, index, index + (value === "Move up" ? -1 : 1));
+                else if (value === "Remove") { rows.splice(index, 1); details.delete(key); expanded.delete(key); }
+                else if (value === "Retry metadata") { requestDetails(row, true); return; }
+                else if (value === "Use suggested model weight") {
+                    const weight = validInfo(row)?.info?.civitai?.recommended_weight;
+                    if (typeof weight !== "number" || !Number.isFinite(weight) || Math.abs(weight) > 1000) return;
+                    row.model_weight = weight; // CLIP/text-fusion strength is deliberately unchanged.
+                } else return;
+                commit(); render();
+            }, { values: ["Row actions", "Move up", "Move down", "Remove", "Retry metadata", "Use suggested model weight"] });
+            action.label = `LoRA ${index + 1} actions`;
+            function visibility() {
+                dependent.forEach(widget => setHidden(widget, !enabled(row)));
+                [preset, inherit, vector].forEach(widget => setHidden(widget, !enabled(row) || !expanded.has(key)));
+                setHidden(dom, !enabled(row) || !hasFile(row));
+                fit();
+            }
+            updatePanel(row); visibility(); requestDetails(row);
+        });
+        fit();
+    }
+    async function refresh(force = false) {
+        catalogLoading = true;
+        try { catalog = await service.catalog(force); listError = ""; }
+        catch (error) { listError = "LoRA list unavailable · click to retry"; console.warn("[Donut LoRA]", error); }
+        catalogLoading = false;
+        if (!disposed) render();
+    }
+    function restore(data) {
+        generation++;
+        const value = data?.widgets_values_named?.slots_json ?? data?.widgets_values?.[stateIndex] ?? state.value;
+        state.value = value;
+        try {
+            rows = decodeRows(value);
+            const ids = new Set();
+            rows.forEach((row, index) => {
+                row.id = String(row.id ?? index + 1);
+                if (!row.id || ids.has(row.id)) throw new Error("Duplicate/empty row ID");
+                ids.add(row.id);
+                if (row.enabled !== undefined && typeof row.enabled !== "boolean") throw new Error("Enabled must be boolean");
+            });
+            invalid = false;
+        } catch (error) { invalid = true; rows = []; console.warn("[Donut LoRA] Saved row JSON needs repair:", error.message); }
+        // Pending results from a previous configure must not attach to new rows.
+        for (const value of details.values()) { value.analysisLoading = false; value.infoLoading = false; }
+        render();
+    }
+    const configured = node.onConfigure;
+    node.onConfigure = function(data) { const result = configured?.apply(this, arguments); restore(data); return result; };
+    const serialized = node.onSerialize;
+    node.onSerialize = function(data) {
+        serialized?.apply(this, arguments);
+        data.widgets_values = backend.map(widget => widget.value);
+        data.widgets_values_named = Object.fromEntries(backend.map(widget => [widget.name, widget.value]));
+    };
+    const executed = node.onExecuted;
+    node.onExecuted = function(message) {
+        executed?.apply(this, arguments);
+        for (const result of message.donut_loras || []) {
+            const row = rows.find(row => String(row.id) === String(result.id) && row.lora_name === result.lora_name);
+            if (!row) continue;
+            const entry = validInfo(row) || { name: row.lora_name };
+            entry.execution = result; details.set(String(row.id), entry);
+            if (hexHash(result.lora_hash) && result.lora_hash !== row.lora_hash) { row.lora_hash = result.lora_hash; commit(); }
+            updatePanel(row);
+        }
+    };
+    for (const name of ["civitai_lookup", "model_type"]) {
+        const widget = backend.find(w => w.name === name);
+        if (widget) {
+            const callback = widget.callback;
+            widget.callback = function(value) { callback?.apply(this, arguments); if (value !== undefined) widget.value = value; render(); };
+        }
+    }
+    const removed = node.onRemoved;
+    node.onRemoved = function() { disposed = true; generation++; return removed?.apply(this, arguments); };
+    node._donutNativeLoras = { refresh, get rows() { return rows; } };
+    restore(); void refresh();
+}

--- a/web/donut_workflow.js
+++ b/web/donut_workflow.js
@@ -1,182 +1,75 @@
 import { app } from "../../scripts/app.js";
 import { api } from "../../scripts/api.js";
 import { ComfyWidgets } from "../../scripts/widgets.js";
+import { createLoraService, installNativeLoras, setHidden } from "./donut_native_lora.js";
+import { repairStreamlinedWorkflow } from "./donut_workflow_repair.js";
+export { decodeRows, moveRow } from "./donut_native_lora.js";
 
-// One STRING is the canonical state. UI rows are never independent positional
-// widgets, so deleting/reordering a slot cannot shift another slot's values.
-export function decodeRows(value) {
-    const rows = JSON.parse(value || "[]");
-    if (!Array.isArray(rows) || rows.some(row => !row || typeof row !== "object" || Array.isArray(row))) {
-        throw new Error("LoRA slots must be an array of objects");
+const service = createLoraService(api);
+const loaders = new Set();
+const fit = node => { node.setSize?.([node.size[0], node.computeSize()[1]]); node.setDirtyCanvas?.(true, true); };
+function connectedControls(node) {
+    for (const widget of node.widgets || []) {
+        const input = node.inputs?.find(p => p.widget?.name === widget.name || p.name === widget.name);
+        if (input?.widget && input.link != null) setHidden(widget, true);
+        else if (widget._donutVisible) setHidden(widget, false);
     }
-    return rows;
 }
-export function moveRow(rows, from, to) {
-    const result = rows.slice();
-    if (from < 0 || from >= rows.length || to < 0 || to >= rows.length) return result;
-    const [row] = result.splice(from, 1);
-    result.splice(to, 0, row);
-    return result;
-}
-const element = (tag, text) => {
-    const el = document.createElement(tag);
-    if (text !== undefined) el.textContent = text;
-    return el;
-};
-function hideWidget(widget) {
-    if (!widget._donutOriginal) widget._donutOriginal = { type: widget.type, computeSize: widget.computeSize };
-    widget.type = "converted-widget";
-    widget.computeSize = () => [0, -4];
-}
-function restoreWidget(widget) {
-    if (widget._donutOriginal) Object.assign(widget, widget._donutOriginal);
-}
-function dirty(node) { node.setDirtyCanvas?.(true, true); app.graph?.change?.(); }
-
-function installRows(node, definition) {
-    const state = node.widgets.find(w => w.name === "slots_json");
-    if (!state) return;
-    hideWidget(state);
-    const options = definition.input.required.slots_json[1];
-    const root = element("div");
-    Object.assign(root.style, { overflow: "auto", padding: "8px", boxSizing: "border-box", font: "12px sans-serif" });
-    const listId = `donut-loras-${globalThis.crypto?.randomUUID?.() || Math.random().toString(36).slice(2)}`;
-    let rows = [], metadata = new Map();
-    state.serializeValue = () => state.value;
-    const commit = () => { state.value = JSON.stringify(rows); dirty(node); };
-    const field = (parent, label, value, type, changed) => {
-        const wrapper = element("label", `${label} `);
-        Object.assign(wrapper.style, { display: "block", margin: "4px 0" });
-        const input = element("input"); input.type = type;
-        if (type === "checkbox") input.checked = !!value;
-        else input.value = value ?? "";
-        if (type === "number") { input.step = "0.01"; input.min = "-1000"; input.max = "1000"; }
-        else if (type !== "checkbox") input.style.width = "95%";
-        input.addEventListener("change", () => {
-            if (type === "number" && (!Number.isFinite(input.valueAsNumber) || !input.checkValidity())) return;
-            changed(type === "checkbox" ? input.checked : type === "number" ? input.valueAsNumber : input.value);
-            commit();
-        });
-        wrapper.append(input); parent.append(wrapper); return input;
-    };
-    const button = (parent, text, fn) => {
-        const b = element("button", text); b.type = "button";
-        b.addEventListener("click", event => { event.preventDefault(); fn(); }); parent.append(b); return b;
-    };
-    function render() {
-        root.replaceChildren();
-        const choices = element("datalist"); choices.id = listId;
-        for (const name of options.donut_loras || ["None"]) { const o = element("option"); o.value = name; choices.append(o); }
-        root.append(choices);
-        const header = element("div", `${rows.length} LoRA slot${rows.length === 1 ? "" : "s"} `);
-        button(header, "+ Add LoRA", () => {
-            rows.push({ id: globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`, enabled: true,
-                lora_name: "None", model_weight: 1, clip_weight: 1, block_vector: "", block_preset: "None",
-                inherit_block_vector: false, lora_hash: "" });
-            commit(); render();
-        });
-        root.append(header);
-        rows.forEach((row, index) => {
-            const box = element("fieldset"); box.append(element("legend", `LoRA ${index + 1}`));
-            const nameInput = field(box, "LoRA", row.lora_name, "text", value => {
-                if (value !== row.lora_name) { row.lora_hash = ""; metadata.delete(String(row.id)); }
-                row.lora_name = value;
-            });
-            nameInput.setAttribute("list", listId);
-            field(box, "Enabled", row.enabled, "checkbox", value => { row.enabled = value; });
-            field(box, "Model strength", row.model_weight, "number", value => { row.model_weight = value; });
-            field(box, "CLIP / text-fusion strength", row.clip_weight, "number", value => { row.clip_weight = value; });
-            const advanced = element("details"); advanced.append(element("summary", "Block weights / metadata"));
-            const inherit = field(advanced, "Inherit global vector", row.inherit_block_vector, "checkbox", value => {
-                row.inherit_block_vector = value; vector.disabled = value;
-            });
-            const presets = element("select");
-            const modelType = node.widgets.find(w => w.name === "model_type")?.value || "Auto";
-            for (const value of options.donut_presets || ["None"]) {
-                if (modelType !== "Auto" && value !== "None" && !value.startsWith(`${modelType}-`)) continue;
-                const o = element("option", value.split(":")[0]); o.value = value; presets.append(o);
-            }
-            presets.value = row.block_preset || "None";
-            presets.addEventListener("change", () => {
-                row.block_preset = presets.value;
-                row.block_vector = presets.value.includes(":") ? presets.value.slice(presets.value.indexOf(":") + 1) : "";
-                row.inherit_block_vector = false; inherit.checked = false;
-                vector.disabled = false; vector.value = row.block_vector; commit();
-            });
-            advanced.append(presets);
-            const vector = field(advanced, "Block vector", row.block_vector, "text", value => { row.block_vector = value; });
-            vector.disabled = !!row.inherit_block_vector;
-            if (row.lora_hash) advanced.append(element("small", `Hash: ${row.lora_hash}`));
-            const info = metadata.get(String(row.id));
-            if (info?.text) { const pre = element("pre", info.text); pre.style.whiteSpace = "pre-wrap"; advanced.append(pre); }
-            if (info?.image?.filename) {
-                const image = element("img"); image.style.maxWidth = "100%"; image.loading = "lazy";
-                image.src = api.apiURL(`/view?${new URLSearchParams(info.image)}`); advanced.append(image);
-            }
-            box.append(advanced);
-            button(box, "↑", () => { rows = moveRow(rows, index, index - 1); commit(); render(); }).disabled = index === 0;
-            button(box, "↓", () => { rows = moveRow(rows, index, index + 1); commit(); render(); }).disabled = index === rows.length - 1;
-            button(box, "Remove", () => { rows.splice(index, 1); commit(); render(); });
-            root.append(box);
-        });
-    }
-    function restore(data) {
-        const index = node.widgets.indexOf(state);
-        const value = data?.widgets_values_named?.slots_json ?? data?.widgets_values?.[index] ?? state.value;
-        state.value = value;
-        try { rows = decodeRows(value); render(); }
-        catch (error) {
-            root.replaceChildren(element("p", `Invalid LoRA state: ${error.message}`));
-            // Never replace malformed/unknown saved state with an empty stack.
-            const edit = element("textarea"); edit.value = value; edit.style.width = "95%";
-            edit.addEventListener("change", () => { state.value = edit.value; restore(); dirty(node); }); root.append(edit);
-        }
-    }
-    const dom = node.addDOMWidget("donut_lora_editor", "div", root, { serialize: false });
-    dom.computeSize = () => [420, Math.min(850, Math.max(260, rows.length * 190 + 50))];
-    const configure = node.onConfigure;
-    node.onConfigure = function(data) { const r = configure?.apply(this, arguments); restore(data); return r; };
-    const serialize = node.onSerialize;
-    node.onSerialize = function(data) {
-        serialize?.apply(this, arguments);
-        (data.widgets_values_named ||= {}).slots_json = state.value;
-    };
-    const executed = node.onExecuted;
-    node.onExecuted = function(message) {
-        executed?.apply(this, arguments);
-        metadata = new Map((message.donut_loras || []).map(item => [String(item.id), item]));
-        let hashChanged = false;
-        for (const row of rows) {
-            const item = metadata.get(String(row.id));
-            // The user may edit a slot while a queued run is executing.
-            if (item?.lora_name === row.lora_name && item.lora_hash && item.lora_hash !== row.lora_hash) {
-                row.lora_hash = item.lora_hash; hashChanged = true;
-            }
-        }
-        if (hashChanged) commit();
-        render();
-    };
-    const modelWidget = node.widgets.find(w => w.name === "model_type");
-    if (modelWidget) { const cb = modelWidget.callback; modelWidget.callback = function() { cb?.apply(this, arguments); render(); }; }
-    restore();
-    node.setSize?.([Math.max(440, node.size?.[0] || 0), Math.max(600, node.size?.[1] || 0)]);
-}
-
 app.registerExtension({
     name: "Donut.WorkflowStreamlining",
+    beforeConfigureGraph(graphData) { repairStreamlinedWorkflow(graphData); },
+    loadedGraphNode(node) {
+        if (!node.properties?.donut_stage_controls) return;
+        const update = () => { connectedControls(node); fit(node); };
+        const changed = node.onConnectionsChange;
+        node.onConnectionsChange = function() {
+            const result = changed?.apply(this, arguments); queueMicrotask(update); return result;
+        };
+        update();
+    },
+    async refreshComboInNodes() {
+        // Refresh only the catalog. Saved row choices/strengths are not reset.
+        if (!loaders.size) return;
+        try { await service.catalog(true); } catch (error) { console.warn("[Donut LoRA]", error); }
+        await Promise.all([...loaders].map(node => node._donutNativeLoras?.refresh()));
+    },
     async beforeRegisterNodeDef(nodeType, nodeData) {
         const name = nodeData.name;
         if (!["DonutDynamicLoRAStack", "DonutLoRALoader", "DonutText", "DonutPromptConditioning", "DonutSeedPlan", "DonutModelMergeKrea2"].includes(name)) return;
         const created = nodeType.prototype.onNodeCreated;
         nodeType.prototype.onNodeCreated = function() {
             const result = created?.apply(this, arguments);
-            if (["DonutDynamicLoRAStack", "DonutLoRALoader"].includes(name)) installRows(this, nodeData);
+            if (["DonutDynamicLoRAStack", "DonutLoRALoader"].includes(name)) {
+                installNativeLoras(this, nodeData, { app, api, service }); loaders.add(this);
+                const removed = this.onRemoved;
+                this.onRemoved = function() { loaders.delete(this); return removed?.apply(this, arguments); };
+            }
             if (["DonutText", "DonutPromptConditioning"].includes(name)) {
                 const preview = ComfyWidgets.STRING(this, "resolved_text", ["STRING", { multiline: true }], app).widget;
-                preview.options ||= {}; preview.options.serialize = false;
+                preview.options ||= {}; preview.options.serialize = false; preview.serialize = false;
                 if (preview.inputEl) preview.inputEl.readOnly = true;
+                setHidden(preview, true);
+                const button = this.addWidget("button", "Show / hide resolved text", null, () => { setHidden(preview, !preview.hidden); fit(this); }, { serialize: false });
+                button.serialize = false;
                 const executed = this.onExecuted;
                 this.onExecuted = function(message) { executed?.apply(this, arguments); preview.value = (message.text || []).join("\n"); };
+                if (name === "DonutText") {
+                    let advanced = false;
+                    const update = () => {
+                        const linked = this.inputs?.some(p => p.name === "seed" && p.link != null);
+                        for (const widget of this.widgets) {
+                            if (["max_depth", "missing", "separator"].includes(widget.name)) setHidden(widget, !advanced);
+                            if (["seed", "control_after_generate"].includes(widget.name)) setHidden(widget, !!linked);
+                        }
+                        fit(this);
+                    };
+                    const settings = this.addWidget("button", "Show / hide text settings", null, () => { advanced = !advanced; update(); }, { serialize: false });
+                    settings.serialize = false;
+                    const configure = this.onConfigure, changed = this.onConnectionsChange;
+                    this.onConfigure = function() { const r = configure?.apply(this, arguments); update(); return r; };
+                    this.onConnectionsChange = function() { const r = changed?.apply(this, arguments); queueMicrotask(update); return r; };
+                    update();
+                }
             }
             if (name === "DonutSeedPlan") {
                 for (const seedName of ["text_seed", "sampler_seed", "filename_seed"]) {
@@ -190,11 +83,9 @@ app.registerExtension({
                 const update = () => {
                     if (!mode) return;
                     for (const widget of this.widgets) {
-                        if (widget.name === "first." || widget.name === "last." || widget.name.startsWith("blocks.") || widget.name.startsWith("txtfusion.")) {
-                            if (mode.value === "Grouped") hideWidget(widget); else restoreWidget(widget);
-                        }
+                        if (widget.name === "first." || widget.name === "last." || widget.name.startsWith("blocks.") || widget.name.startsWith("txtfusion.")) setHidden(widget, mode.value === "Grouped");
                     }
-                    this.setSize?.([this.size[0], this.computeSize()[1]]); this.setDirtyCanvas?.(true, true);
+                    fit(this);
                 };
                 if (mode) { const cb = mode.callback; mode.callback = function() { cb?.apply(this, arguments); update(); }; }
                 const configure = this.onConfigure;

--- a/web/donut_workflow_repair.js
+++ b/web/donut_workflow_repair.js
@@ -1,0 +1,51 @@
+// Repair only the v1 migration from PR47, before ComfyUI can shift positional
+// widget values into different promoted controls. v2 saves are left untouched.
+export function repairStreamlinedWorkflow(workflow) {
+    if (workflow.extra?.donut_streamlining?.schema !== 1) return false;
+    const definitions = new Map((workflow.definitions?.subgraphs || []).map(g => [g.id, g]));
+    const changes = [];
+    for (const node of workflow.nodes || []) {
+        const graph = definitions.get(node.type);
+        if (!graph?.nodes.some(n => n.type === "DonutPromptConditioning")) continue;
+        const nodes = new Map(graph.nodes.map(n => [n.id, n]));
+        const links = new Map(graph.links.map(link => [link.id, link]));
+        const saved = new Map(node.inputs.map(p => [p.name, p]));
+        const named = node.widgets_values_named;
+        if (!named) throw new Error("Donut v1 repair needs the original named widget values. Load the corrected workflow file.");
+        const order = [];
+        const inputs = graph.inputs.map(port => {
+            const input = { ...(saved.get(port.name) || {}), name: port.name, type: port.type, link: saved.get(port.name)?.link ?? null };
+            if (port.label) input.label = port.label;
+            if (port.shape) input.shape = port.shape;
+            const promoted = (port.linkIds || []).some(id => {
+                const link = links.get(id);
+                if (!link || link.origin_id !== -10) return false;
+                return !!nodes.get(link.target_id)?.inputs?.[link.target_slot]?.widget;
+            });
+            if (promoted) {
+                if (!(port.name in named)) throw new Error(`Donut v1 repair: missing value for ${port.name}`);
+                input.widget = { name: port.name }; order.push(port.name);
+            } else delete input.widget;
+            return input;
+        });
+        const remaps = (workflow.links || []).filter(link => link[3] === node.id).map(link => {
+            const oldName = node.inputs[link[4]]?.name;
+            const slot = inputs.findIndex(port => port.name === oldName);
+            if (slot < 0) throw new Error(`Donut v1 repair: unknown input ${oldName}`);
+            return [link, slot];
+        });
+        changes.push({ node, inputs, order, named, remaps });
+    }
+    if (!changes.length) return false;
+    // Commit changes only after every instance is validated.
+    for (const { node, inputs, order, named, remaps } of changes) {
+        node.inputs = inputs;
+        node.widgets_values = order.map(name => named[name]);
+        node.widgets_values_named = Object.fromEntries(order.map(name => [name, named[name]]));
+        node.properties = { ...node.properties, donut_widget_order: order, donut_stage_controls: true };
+        for (const [link, slot] of remaps) link[4] = slot;
+    }
+    workflow.extra.donut_streamlining.schema = 2;
+    workflow.extra.donut_streamlining.required_branch = "main";
+    return true;
+}


### PR DESCRIPTION
## Fixes requested from the user's screenshots

- Replace the browser datalist/HTML input editor with ComfyUI's native combo, toggle, number, text and button widgets. LoRA selection uses the same native dropdown mechanism as ordinary ComfyUI loaders, not a custom oversized menu.
- Fetch the installed catalog from `/models/loras`, falling back to the old DonutLoRAStack node schema. Refresh the catalog without resetting saved selections. Use short block-preset labels while retaining their full vectors.
- Disabled rows retain only the filename picker, enable toggle and compact Row actions control. Hide strengths, advanced block settings and information panels; refit the node height. Re-enabling restores all saved settings. Add, move up/down and remove remain available.
- Restore a separate, visible per-row information panel: detected local model/text-encoder components and populated blocks; current strengths; CivitAI model/version, author/base model, suggested weight, trigger words, description, hash, clickable model/version links, and cached preview images. Panels and preview heights are bounded and scrollable. The block-settings toggle does not hide CivitAI details.
- With lookup On, selecting/enabling a LoRA populates metadata without requiring an image-generation queue. Off prevents new UI CivitAI requests. Local safetensors-header analysis remains available. Reuse existing server routes/config/cache; no new dependencies or credentials.
- Show loading, lookup errors, missing previews and a retry action. Deduplicate metadata requests, cap concurrency at two, and reject late results for changed/deleted rows. Do not downgrade full hashes to short prefixes.
- Suggested weights remain hints, never automatic changes. The explicit apply action changes model strength only, preserving CLIP/text-fusion strength, including zero.

## Earlier reported migration/UI errors

Repair only PR47's schema-1 parent-subgraph serialization before configuration: remove the three obsolete promoted text values, rebuild sockets by name, and remap links. Against the supplied graph this matches the already-delivered corrected file: 37 sockets and 25 widget values. Already-repaired schema-2 saves are left untouched so later edits are preserved. Also make resolved-text previews/settings collapsible, use proper widget visibility, and hide connected duplicate stage controls.

## Serialization and compatibility

`slots_json` remains the only backend row state. UI helpers are explicitly excluded from both positional workflow arrays and API prompt inputs. Disabled rows, IDs, hashes, strengths, vectors and extra saved fields survive save/load/reorder. Malformed JSON is retained for repair. Python loader/applier behavior and node sockets are unchanged. Existing loader nodes update in place; the user does not need to recreate them or rewire the corrected workflow.

## Validation

**25 regression tests passed** locally with the supplied workflow pair; **24 pass and one skips** without that private pair. Tests execute the real extension using native-widget/DOM contracts and mocked HTTP responses. They cover the catalog, native widget types, collapsed-state preservation, metadata content/links/images, async races, request limiting, API/workflow serialization and the exact prior promoted-widget shift. All five committed file blob hashes match the locally tested copies.

Not performed: a complete live ComfyUI browser session, actual CivitAI network requests, GPU inference or output-image parity. Existing Python backend tests/code were not changed. The unrelated fusion-aware upstream-metadata warning is documented, not suppressed or claimed fixed.

## Delivery

Merge into **main**, as explicitly requested in the conversation; no user branch switch. Update DonutNodes on main, restart ComfyUI and hard-refresh the browser. Continue using the already-delivered `ComfyUI_00016_Donut_Streamlined_Fixed.json`. No uploaded workflows or logs are included in the public repository.