### PR TITLE
Make LoRA removal visible and clean up the row/CivitAI layout

### DIFF
--- a/docs/LORA_UI_LAYOUT.md
+++ b/docs/LORA_UI_LAYOUT.md
@@ -1,0 +1,70 @@
+# LoRA row controls and information layout
+
+This update is for DonutLoRALoader and DonutDynamicLoRAStack. Keep the existing
+workflow and node instances: input/output sockets, slots_json, backend loading,
+whole-stack safety and the PNG/subgraph reload guard are unchanged.
+
+## Row controls
+
+Each LoRA has a separate header with visible **up**, **down** and **Remove**
+buttons above its native filename picker. Removal no longer requires finding
+an item in a Row actions dropdown. These buttons remain visible for disabled
+rows and when information is collapsed. Remove deletes the slot from the stack,
+not the installed file. The final row can be removed; Add LoRA works on an empty
+stack. Boundary reorder buttons are disabled.
+
+Operations resolve the current row identity, not a cached index or filename.
+Two slots selecting the same file remain independently removable. Add, remove,
+reorder and explicit suggested-weight application are bracketed by graph
+beforeChange/afterChange hooks for the host's undo tracking.
+
+Disabled rows keep their picker and enable toggle, while retaining all strengths,
+vectors, hashes and other saved fields internally. Re-enabling restores those
+controls without resetting values. UI-only toolbars never enter API inputs or
+positional workflow widget arrays.
+
+## Information layout
+
+The normal view is a bordered, compact card, not a long unformatted text dump:
+
+- **Detected weights** is a collapsed summary; expand it for all reported module
+  and block groups. Consecutive indices use lossless ranges such as 0–27. Gaps
+  are preserved, and exact reported indices remain available in tooltips.
+- **CivitAI** starts expanded, with a small thumbnail alongside the model/version,
+  base model, suggested weight and a distinct Open on CivitAI link. Trigger words
+  remain below the overview. Click the thumbnail for the full preview.
+- **More details** contains the full hash on its own wrapping line, author,
+  description, current strengths, Retry metadata and the explicit suggested
+  model-weight action. Suggestions do not automatically change either strength.
+
+Long details scroll within a maximum 360px panel. The natural content height is
+measured using ResizeObserver, so short panels shrink instead of clipping the
+thumbnail or leaving a large blank area. Remove/reorder controls are outside
+that scroll area. Section expansion survives asynchronous metadata updates and
+catalog refreshes during the session. Lookup errors automatically expose retry;
+no network credentials or additional runtime dependencies are introduced.
+
+Native ComfyUI filename/preset dropdowns and strength widgets are retained,
+including their constructor option-list guard. CivitAI lookup, local analysis,
+full-hash preservation and stale-result checks continue using the existing code.
+
+## Tests and installation
+
+```sh
+node --test tests/test_streamlining_frontend.cjs
+python -m unittest discover -s tests -p test_lora_cleanup_browser.py -v
+```
+
+The frontend suite has 39 tests: 38 run without private workflow fixtures; the
+existing original-vs-corrected workflow check runs when DONUT_BROKEN_WORKFLOW and
+DONUT_FIXED_WORKFLOW are provided. All 39 passed with those fixtures. Eight
+additional offline Chromium tests passed, including real toolbar clicks,
+remove-after-reorder, last-row removal/addition, save/reload, disabled-state
+preservation, metadata expansion and non-clipped layouts at 320/420px widths.
+
+Chromium runs the shipped DOM and editor logic with a small Comfy node adapter
+and mock server responses. This is not a complete ComfyUI renderer, live CivitAI
+or GPU test. Playwright/Chromium are development-only test requirements.
+
+Update DonutNodes on main, restart ComfyUI and hard-refresh the browser. Do not
+replace or rewire the workflow for this UI-only change.

--- a/tests/test_lora_cleanup_browser.py
+++ b/tests/test_lora_cleanup_browser.py
@@ -1,0 +1,209 @@
+"""Real Chromium DOM/layout tests with a SMALL Comfy node adapter and mocked HTTP.
+
+Not a full ComfyUI renderer, live CivitAI, or GPU test. The shipped toolbar,
+metadata renderer, native-editor logic, event handlers and ResizeObserver run
+unchanged. The adapter validates combo construction and serialization contracts.
+Run: python -m unittest discover -s tests -p test_lora_cleanup_browser.py -v
+Requires Playwright and Chromium in the developer/test environment only.
+"""
+import json
+import os
+from pathlib import Path
+import shutil
+import unittest
+
+try:
+    from playwright.sync_api import sync_playwright
+except ImportError:
+    sync_playwright = None
+
+ROOT = Path(__file__).resolve().parents[1]
+PAGE = r'''<!doctype html><html><head><meta charset="utf-8"><style>
+body {background:#202020;color:#ddd;font:12px sans-serif;margin:20px;}
+h1 {font-size:15px;font-weight:500;} .node {width:420px;background:#353535;padding:8px 0;border-radius:7px;}
+.control {box-sizing:border-box;display:flex;justify-content:space-between;align-items:center;gap:12px;
+ margin:0 15px;padding:2px 10px;background:#292929;border:1px solid #595959;border-radius:11px;height:21px;}
+.control span {overflow:hidden;white-space:nowrap;text-overflow:ellipsis;}
+.control span:first-child {color:#aaa;flex-shrink:0;} .control span:last-child {text-align:right;}
+.control button {width:100%;border:0;background:transparent;color:#ddd;cursor:pointer;}
+.hint {max-width:420px;line-height:1.5;color:#aaa;margin-top:14px;} a {color:#91c9f4;}
+</style></head><body><h1>LoRA UI · browser test harness</h1><div id="mount" class="node"></div>
+<div class="hint">Actual toolbar and metadata DOM; native ComfyUI controls represented by a test adapter. Preview and server responses are fixtures.</div>
+<script type="module">
+import { installNativeLoras, createLoraService } from '/web/donut_native_lora.js';
+window.requests = [];
+const api = {
+ apiURL: value => value.startsWith('/donut/loras/preview')
+  ? 'data:image/svg+xml,' + encodeURIComponent('<svg xmlns="http://www.w3.org/2000/svg" width="92" height="112"><rect width="92" height="112" fill="#647384"/><text x="46" y="53" text-anchor="middle" font-family="sans-serif" font-size="12" fill="white">Preview</text><text x="46" y="70" text-anchor="middle" font-family="sans-serif" font-size="10" fill="white">fixture</text></svg>')
+  : '/api' + value,
+ async fetchApi(url) {
+  requests.push(url);
+  let data;
+  if (url === '/models/loras') data = Array.from({length:102}, (_,i)=>`styles/portrait-${i}.safetensors`);
+  else if (url.startsWith('/object_info')) data = {DonutLoRAStack:{input:{required:{
+   lora_name_1:[['None']],block_preset_1:[['None','KREA2-ALL:1,1,1','KREA2-FACE:0,1,0']]}}}};
+  else if (url.includes('/analyze?')) data = {supported:true,tensor_count:512,components:[{name:'UNet',modules:256,
+   groups:[{name:'blocks',indices:Array.from({length:28},(_,i)=>i)},{name:'txtfusion.layerwise',indices:[0,1]}]}]};
+  else data = {hash:'abcdef1234',has_collage:true,civitai:{model_id:12,model_version_id:34,
+   model_name:'Portrait style',version_name:'v1.0',base_model:'Krea 2',creator_username:'Example author',
+   recommended_weight:.8,trained_words:['portrait style'],description: 'Example description. '.repeat(80)}};
+  return {ok:true,status:200,json:async()=>data};
+ }
+};
+const names = ['model_type','slots_json','global_block_vector','civitai_lookup','safe_stack','fusion_aware','max_fusion_boost','safe_limit','execution_mode'];
+const initial = Array.from({length:3},(_,i)=>({id:`row-${i}`,enabled:i===0,lora_name:i===0?'styles/portrait-0.safetensors':'None',
+ model_weight:1,clip_weight:0,block_preset:'None',block_vector:'1,1,1',inherit_block_vector:true,lora_hash:'',custom:{keep:i}}));
+class TestNode {
+ constructor() {
+  this.widgets=[];this.inputs=[];this.properties={};this.size=[420,900];
+  this.graph={beforeChange:()=>{this.undo={};this.onSerialize(this.undo);},afterChange(){}};
+  const values=['KREA2',JSON.stringify(initial),'1,1,1','On','On','Use headroom',2,1,'Experimental bypass'];
+  names.forEach((name,i)=>this.addWidget(name==='slots_json'?'customtext':'text',name,values[i],()=>{},{ }));
+ }
+ addWidget(type,name,value,callback,options={}) {
+  if(type==='combo'&&!Array.isArray(options.values)) throw new Error('Combo requires initial values');
+  const w={type,name,value,callback,options};this.widgets.push(w);
+  return w;
+ }
+ addDOMWidget(name,type,element,options) {const w={name,type,element,options};this.widgets.push(w);return w;}
+ removeWidget(w) {if(!this.widgets.includes(w))throw Error('Unknown widget');w.onRemove?.();w.wrapper?.remove();this.widgets.splice(this.widgets.indexOf(w),1);}
+ computeSize() {return [this.size[0],this.widgets.reduce((h,w)=>h+(w.hidden?0:(w.options.getMinHeight?.()||24)+4),16)];}
+ setSize(size) {this.size=size;this.layout();}
+ setDirtyCanvas() {this.layout();}
+ layout() {
+  const mount=document.getElementById('mount');mount.style.width=this.size[0]+'px';
+  for(const w of this.widgets) {
+   if(!w.wrapper){w.wrapper=document.createElement('div');mount.append(w.wrapper);if(w.element)w.wrapper.append(w.element);}
+   w.wrapper.style.display=w.hidden?'none':'block';
+   w.wrapper.style.height=(w.options.getMinHeight?.()||24)+4+'px';
+   if(w.element){w.element.style.height=w.options.getMinHeight?.()+'px';}
+   else {
+    const bar=document.createElement('div');bar.className='control';
+    if(w.type==='button') {const button=document.createElement('button');button.textContent=w.label||w.name;
+      button.onclick=()=>w.callback();bar.append(button);}
+    else {const label=document.createElement('span'),value=document.createElement('span');label.textContent=w.label||w.name;
+      value.textContent=w.value;bar.append(label,value);}
+    w.wrapper.replaceChildren(bar);
+   }
+  }
+ }
+}
+window.node=new TestNode();installNativeLoras(node,{input:{required:{slots_json:['STRING',{}]}}},
+ {app:{graph:{change(){}}},api,service:createLoraService(api)});
+window.rows=()=>JSON.parse(node.widgets.find(w=>w.name==='slots_json').value);
+window.widget=(id,suffix)=>node.widgets.find(w=>w.name===`donut_row:${id}:${suffix}`);
+window.change=(id,suffix,value)=>{const w=widget(id,suffix);w.value=value;w.callback(value);node.layout();};
+window.ready=true;
+</script></body></html>'''
+
+@unittest.skipUnless(sync_playwright, 'Playwright is a development-only dependency')
+class BrowserTests(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.pw=sync_playwright().start()
+        executable=os.environ.get('CHROMIUM_EXECUTABLE') or shutil.which('chromium')
+        kwargs={'headless':True,'args':['--no-sandbox']}
+        if executable: kwargs['executable_path']=executable
+        cls.browser=cls.pw.chromium.launch(**kwargs)
+
+    @classmethod
+    def tearDownClass(cls):
+        cls.browser.close();cls.pw.stop()
+
+    def setUp(self):
+        self.page=self.browser.new_page(viewport={'width':1000,'height':1200})
+        self.errors=[];self.page.on('pageerror',lambda e:self.errors.append(str(e)))
+        # This test is entirely offline: no local or external HTTP access.
+        # Imports are stripped ONLY to evaluate the exact shipped modules in the
+        # same isolated browser page; the node adapter above is not ComfyUI.
+        import re
+        markup, script = PAGE.split('<script type="module">', 1)
+        script = script.split('</script>', 1)[0]
+        self.page.set_content(markup + '</body></html>')
+        for name in ('donut_lora_ui.js', 'donut_native_lora.js'):
+            source=(ROOT/'web'/name).read_text()
+            source=re.sub(r'^import .*;\n', '', source, flags=re.M).replace('export function ', 'function ')
+            self.page.add_script_tag(content=source)
+        self.page.add_script_tag(content=re.sub(r'^import .*;\n', '', script, flags=re.M))
+        self.page.wait_for_function('window.ready && document.querySelector("img")?.complete')
+        self.page.wait_for_timeout(120)
+
+    def tearDown(self):
+        self.page.close();self.assertEqual(self.errors,[])
+
+    def test_01_visible_remove_for_active_disabled_and_final_slot(self):
+        before=self.page.evaluate('rows()')
+        self.page.get_by_role('button',name='Remove LoRA 2 from this stack (keeps the file)',exact=True).click()
+        self.assertEqual(self.page.evaluate('rows()'),[before[0],before[2]])
+        self.page.get_by_role('button',name='Remove LoRA 1 from this stack (keeps the file)',exact=True).click()
+        self.assertEqual(self.page.evaluate('rows()'),[before[2]])
+        self.page.get_by_role('button',name='Remove LoRA 1 from this stack (keeps the file)',exact=True).click()
+        self.assertEqual(self.page.evaluate('rows()'),[])
+        self.page.get_by_role('button',name='+ Add LoRA',exact=True).click()
+        self.assertEqual(len(self.page.evaluate('rows()')),1)
+        self.assertTrue(self.page.get_by_role('button',name='Remove LoRA 1 from this stack (keeps the file)',exact=True).is_visible())
+
+    def test_02_move_then_remove_correct_row_and_restore_snapshot(self):
+        before=self.page.evaluate('rows()')
+        self.page.get_by_role('button',name='Move LoRA 3 up',exact=True).click()
+        self.assertEqual(self.page.evaluate('rows().map(r=>r.id)'),['row-0','row-2','row-1'])
+        self.page.get_by_role('button',name='Remove LoRA 2 from this stack (keeps the file)',exact=True).click()
+        self.assertEqual(self.page.evaluate('rows()'),before[:2])
+        self.page.evaluate('node.onConfigure(node.undo)')
+        self.assertEqual(self.page.evaluate('rows().map(r=>r.id)'),['row-0','row-2','row-1'])
+
+    def test_03_metadata_is_not_clipped_at_320_and_420_width(self):
+        for width in (320,420):
+            self.page.evaluate('(w)=>node.setSize([w,node.size[1]])',width);self.page.wait_for_timeout(100)
+            bounds=self.page.evaluate('''()=>{
+              const root=widget('row-0','information').element,r=root.getBoundingClientRect();
+              const img=root.querySelector('img').getBoundingClientRect();
+              const link=[...root.querySelectorAll('a')].find(a=>a.textContent.includes('CivitAI')).getBoundingClientRect();
+              return {outer:root.scrollWidth<=root.clientWidth+1,visible:[img,link].every(x=>x.top>=r.top&&x.bottom<=r.bottom&&x.left>=r.left&&x.right<=r.right),height:r.height};}''')
+            self.assertTrue(bounds['outer']);self.assertTrue(bounds['visible']);self.assertLessEqual(bounds['height'],360)
+            self.assertTrue(self.page.get_by_role('button',name='Remove LoRA 1 from this stack (keeps the file)',exact=True).is_visible())
+
+    def test_04_more_details_scrolls_without_expanding_the_whole_node(self):
+        info=self.page.locator('[aria-label="LoRA 1 information"]')
+        info.get_by_text('More details',exact=True).click();self.page.wait_for_timeout(150)
+        size=self.page.evaluate('''()=>{const r=widget('row-0','information').element;return [r.clientHeight,r.scrollHeight,r.scrollWidth,r.clientWidth];}''')
+        self.assertLessEqual(size[0],360);self.assertGreater(size[1],size[0]);self.assertLessEqual(size[2],size[3]+1)
+        self.page.get_by_role('button',name='Remove LoRA 1 from this stack (keeps the file)',exact=True).click()
+        self.assertEqual(len(self.page.evaluate('rows()')),2)
+
+    def test_05_collapsing_row_retains_strengths_and_remove_visibility(self):
+        before=self.page.evaluate('rows()')
+        self.page.evaluate("change('row-0','enabled',false)");self.page.wait_for_timeout(70)
+        self.assertFalse(self.page.locator('[aria-label="LoRA 1 information"]').is_visible())
+        self.assertTrue(self.page.get_by_role('button',name='Remove LoRA 1 from this stack (keeps the file)',exact=True).is_visible())
+        self.page.evaluate("change('row-0','enabled',true)");self.page.wait_for_timeout(70)
+        self.assertEqual(self.page.evaluate('rows()'),before)
+
+    def test_06_dom_controls_are_not_serialized_into_workflow_or_api_inputs(self):
+        out=self.page.evaluate('''()=>{const o={};node.onSerialize(o);return o;}''')
+        self.assertEqual(len(out['widgets_values']),9);self.assertEqual(len(out['widgets_values_named']),9)
+        self.page.evaluate('(o)=>node.onConfigure(o)',out);self.page.wait_for_timeout(50)
+        self.assertEqual(self.page.evaluate('rows()'),json.loads(out['widgets_values_named']['slots_json']))
+        self.assertTrue(self.page.evaluate("node.widgets.filter(w=>w.name.startsWith('donut_row:')).every(w=>w.serialize===false && w.options.serialize===false)"))
+
+    def test_07_sections_preserve_expansion_across_async_metadata_rerenders(self):
+        section=self.page.locator('[aria-label="LoRA 1 information"] details').first
+        section.locator('summary').click();self.page.wait_for_timeout(50)
+        self.assertTrue(section.evaluate('(e)=>e.open'))
+        self.page.evaluate("change('row-0','model_weight',0.7)");self.page.wait_for_timeout(50)
+        self.assertTrue(section.evaluate('(e)=>e.open'))
+        self.assertIn('blocks: 0–27',section.inner_text())
+        self.assertEqual(self.page.evaluate("rows()[0].clip_weight"),0)
+
+    def test_08_layout_preview_and_resize_observer_stability(self):
+        for i in range(6):
+            self.page.evaluate('(w)=>node.setSize([w,node.size[1]])',320 if i%2 else 420)
+            self.page.wait_for_timeout(50)
+        self.page.evaluate('node.setSize([420,node.size[1]])');self.page.wait_for_timeout(120)
+        target=os.environ.get('DONUT_UI_SCREENSHOT')
+        if target:
+            Path(target).parent.mkdir(parents=True,exist_ok=True)
+            self.page.screenshot(path=target,full_page=True)
+        self.assertEqual(self.page.get_by_role('button',name='Remove LoRA',exact=False).count(),3)
+
+if __name__=='__main__': unittest.main()

--- a/tests/test_streamlining_frontend.cjs
+++ b/tests/test_streamlining_frontend.cjs
@@ -12,6 +12,7 @@ class Element {
     replaceChildren(...children) { this.children = children; }
     setAttribute(name, value) { this[name] = value; }
     addEventListener(name, fn) { this.events[name] = fn; }
+    contains(child) { return this === child || this.children.some(c => c.contains(child)); }
 }
 const text = root => root.textContent + root.children.map(text).join(' ');
 const elements = (root, tag) => [root, ...root.children.flatMap(c => elements(c))].filter(e => !tag || e.tag === tag);
@@ -47,7 +48,7 @@ function setup(handler = undefined) {
         document: { createElement: tag => new Element(tag) },
         ComfyWidgets: { STRING(node, name) { const w = node.addWidget('customtext', name, '', () => {}, {}); w.inputEl = {}; return { widget: w }; } }
     });
-    for (const file of ['donut_native_lora.js', 'donut_workflow_repair.js', 'donut_workflow.js']) {
+    for (const file of ['donut_lora_ui.js', 'donut_native_lora.js', 'donut_workflow_repair.js', 'donut_workflow.js']) {
         const source = fs.readFileSync(path.join(__dirname, '../web', file), 'utf8')
             .replace(/^import .*;\n/gm, '').replace(/^export \{.*\} from .*;\n/gm, '').replace(/export function /g, 'function ');
         vm.runInContext(source, context);
@@ -89,6 +90,16 @@ const find = (node, suffix, id = 'row-0') => node.widgets.find(w => w.name === `
 const change = (widget, value) => { widget.value = value; widget.callback(value); };
 const saved = node => JSON.parse(node.widgets.find(w => w.name === 'slots_json').value);
 const panel = (node, id) => find(node, 'information', id).element;
+const click = (root, label) => {
+    const button = elements(root, 'button').find(b => b.textContent === label);
+    assert.ok(button, `Visible button ${label}`);
+    button.events.click({ preventDefault() {}, stopPropagation() {} });
+};
+const rowAction = (node, action, id = 'row-0') => {
+    const label = { 'Move up': '↑', 'Move down': '↓' }[action] || action;
+    const widget = find(node, ['Remove', 'Move up', 'Move down'].includes(action) ? 'actions' : 'information', id);
+    click(widget.element, label);
+};
 
 test('native combo lists installed files even when unknown STRING metadata was stripped', async () => {
     const { make } = setup(); const node = make(); await settle();
@@ -121,12 +132,12 @@ test('disabled rows do not trigger local analysis or CivitAI lookup; Off prevent
 test('lookup shows links, detected components, recommendations, triggers and bounded local previews before queueing', async () => {
     const { make } = setup(); const node = make(rows(1), 'On'); await settle();
     const root = panel(node); const content = text(root);
-    for (const expected of ['Detected weights', '8 tensors', 'blocks: 3, 4', 'Suggested weight: 0.65', 'Test model', 'Triggers: trigger']) assert.ok(content.includes(expected), expected);
+    for (const expected of ['Detected weights', '8 tensors', 'blocks: 3–4', 'Suggested weight: 0.65', 'Test model', 'Triggers: trigger']) assert.ok(content.includes(expected), expected);
     const links = elements(root, 'a'); assert.ok(links.some(a => a.href === 'https://civitai.com/models/123?modelVersionId=456'));
     assert.ok(links.every(a => a.rel === 'noopener noreferrer'));
     assert.equal(elements(root, 'script').length, 0);
-    const image = elements(root, 'img')[0]; assert.equal(image.style.maxHeight, '150px');
-    assert.match(image.src, /^\/api\/donut\/loras\/preview\?/); assert.equal(find(node, 'information').options.getMaxHeight(), 250);
+    const image = elements(root, 'img')[0]; assert.equal(image.style.height, '112px');
+    assert.match(image.src, /^\/api\/donut\/loras\/preview\?/); assert.ok(find(node, 'information').options.getMaxHeight() <= 360);
 });
 test('preset combo labels contain no long vectors and selecting a preset edits only its intended fields', async () => {
     const { make } = setup(); const node = make(); await settle();
@@ -137,16 +148,16 @@ test('preset combo labels contain no long vectors and selecting a preset edits o
 });
 test('suggested weight is never applied silently and explicit action does not touch zero CLIP strength', async () => {
     const { make } = setup(); const node = make(rows(1), 'On'); await settle();
-    assert.equal(saved(node)[0].model_weight, .75); change(find(node, 'actions'), 'Use suggested model weight');
+    assert.equal(saved(node)[0].model_weight, .75); rowAction(node, 'Use suggested model weight');
     assert.equal(saved(node)[0].model_weight, .65); assert.equal(saved(node)[0].clip_weight, 0);
 });
 test('add, reorder and remove preserve complete rows and have no six-row ceiling', async () => {
     const { make } = setup(); const node = make(rows(6)); await settle();
     for (let i = 0; i < 4; i++) node.widgets.find(w => w.name === '+ Add LoRA').callback();
     assert.equal(saved(node).length, 10);
-    change(find(node, 'actions', 'row-2'), 'Move up'); assert.equal(saved(node)[1].id, 'row-2');
+    rowAction(node, 'Move up', 'row-2'); assert.equal(saved(node)[1].id, 'row-2');
     assert.deepEqual(saved(node)[1].custom, { preserved: 2 });
-    change(find(node, 'actions', 'row-2'), 'Remove'); assert.equal(saved(node).length, 9);
+    rowAction(node, 'Remove', 'row-2'); assert.equal(saved(node).length, 9);
 });
 test('workflow and API serializers exclude every row/helper widget; only canonical JSON carries row state', async () => {
     const { make } = setup(); const node = make(rows(6)); await settle();
@@ -298,4 +309,89 @@ test('old PNG loader state with a trailing DOM helper reloads without losing row
     await settle(); assert.deepEqual(saved(node), original);
     const out = {}; node.onSerialize(out); assert.equal(out.widgets_values.length, 9);
     assert.equal('donut_lora_editor' in out.widgets_values_named, false);
+});
+
+test('every row has visible Remove and reorder buttons before its native picker, even while disabled', async () => {
+    const { make } = setup(); const node = make(rows(6)); await settle();
+    for (const row of saved(node)) {
+        const actions = find(node, 'actions', row.id), picker = find(node, 'lora_name', row.id);
+        assert.notEqual(actions.type, 'combo'); assert.ok(!actions.hidden);
+        assert.ok(node.widgets.indexOf(actions) < node.widgets.indexOf(picker));
+        assert.deepEqual(elements(actions.element, 'button').map(b => b.textContent), ['↑', '↓', 'Remove']);
+        assert.ok(elements(actions.element, 'button').find(b => b.textContent === 'Remove').title.includes('keeps the file'));
+    }
+    assert.equal(node.widgets.some(w => w.type === 'combo' && w.options.values?.includes('Row actions')), false);
+    const before = saved(node);
+    rowAction(node, 'Remove', 'row-1');
+    assert.deepEqual(saved(node), before.filter(row => row.id !== 'row-1'));
+});
+test('remove the only row, serialize/reload the empty stack, then add a visible row again', async () => {
+    const { make } = setup(); const node = make(rows(1)); await settle();
+    rowAction(node, 'Remove'); assert.deepEqual(saved(node), []);
+    assert.equal(node.widgets.filter(w => w.name.startsWith('donut_row:')).length, 0);
+    const out = {}; node.onSerialize(out); const copy = make(); copy.onConfigure(out); await settle();
+    assert.deepEqual(saved(copy), []);
+    copy.widgets.find(w => w.name === '+ Add LoRA').callback();
+    assert.equal(saved(copy).length, 1);
+    assert.ok(copy.widgets.some(w => w.name.endsWith(':actions') && !w.hidden));
+});
+test('remove targets row identity after reorder, not a cached position or filename', async () => {
+    const { make } = setup(); const list = rows(3).map(r => ({ ...r, lora_name: 'same.safetensors' }));
+    const node = make(list); await settle();
+    const oldRemove = elements(find(node, 'actions', 'row-2').element, 'button').find(b => b.textContent === 'Remove');
+    rowAction(node, 'Move up', 'row-2');
+    oldRemove.events.click({ preventDefault() {}, stopPropagation() {} });
+    assert.deepEqual(saved(node).map(r => r.id), ['row-0', 'row-1']);
+    oldRemove.events.click({ preventDefault() {}, stopPropagation() {} }); // Deleted-row callback is a no-op.
+    assert.equal(saved(node).length, 2);
+});
+test('first/last reorder arrows are disabled and do not modify canonical state', async () => {
+    const { make } = setup(); const node = make(rows(2)); await settle(); const before = saved(node);
+    assert.equal(elements(find(node, 'actions').element, 'button')[0].disabled, true);
+    assert.equal(elements(find(node, 'actions', 'row-1').element, 'button')[1].disabled, true);
+    rowAction(node, 'Move up'); rowAction(node, 'Move down', 'row-1');
+    assert.deepEqual(saved(node), before);
+});
+test('row changes bracket graph undo hooks; restoring the snapshot restores all removed fields', async () => {
+    const { make } = setup(); const node = make(rows(3)); await settle(); let snapshot, after = 0;
+    const before = saved(node);
+    node.graph = { beforeChange() { snapshot = {}; node.onSerialize(snapshot); }, afterChange() { after++; } };
+    rowAction(node, 'Remove', 'row-1'); assert.equal(after, 1);
+    assert.deepEqual(JSON.parse(snapshot.widgets_values_named.slots_json), before);
+    node.onConfigure(snapshot); await settle(); assert.deepEqual(saved(node), before);
+});
+test('late metadata cannot restore a removed LoRA or reinsert its information panel', async () => {
+    let resolve;
+    const { make } = setup(url => url.includes('/info?') ? new Promise(r => { resolve = r; }) : null);
+    const node = make(rows(1), 'On'); await settle(); rowAction(node, 'Remove');
+    resolve({ ok: true, json: async () => ({ hash: 'b'.repeat(10), civitai: { model_name: 'Deleted' } }) });
+    await settle(); assert.deepEqual(saved(node), []);
+    assert.equal(node.widgets.filter(w => w.name.startsWith('donut_row:')).length, 0);
+});
+test('long block lists compact losslessly without hiding gaps', () => {
+    const { context } = setup();
+    assert.equal(context.compactLoraIndices(Array.from({ length: 28 }, (_, i) => i)), '0–27');
+    assert.equal(context.compactLoraIndices([7, 1, 0, 2, 4, 7, 6]), '0–2, 4, 6–7');
+    assert.equal(context.compactLoraIndices([]), '');
+});
+test('metadata hierarchy defaults to a compact block summary and separate expanded CivitAI card', async () => {
+    const { make } = setup(); const node = make(rows(1), 'On'); await settle();
+    const root = panel(node), sections = elements(root, 'details');
+    assert.equal(sections[0].open, false); assert.equal(sections[1].open, true); assert.equal(sections[2].open, false);
+    assert.equal(elements(root, 'img')[0].style.objectFit, 'contain');
+    const hashElement = elements(sections[2]).find(e => e.textContent.startsWith('Hash:'));
+    assert.ok(hashElement); assert.equal(hashElement.tag, 'div');
+    assert.equal(elements(root, 'a').find(e => e.textContent.includes('CivitAI')).style.display, 'block');
+});
+test('expanded metadata sections survive strength updates and a catalog rerender', async () => {
+    const { make } = setup(); const node = make(rows(1), 'On'); await settle();
+    const weights = elements(panel(node), 'details')[0]; weights.open = true; weights.events.toggle();
+    change(find(node, 'model_weight'), .9); assert.equal(elements(panel(node), 'details')[0].open, true);
+    await node._donutNativeLoras.refresh(); assert.equal(elements(panel(node), 'details')[0].open, true);
+});
+test('toolbar click stops propagation so Remove does not start a canvas drag', async () => {
+    const { make } = setup(); const node = make(rows(1)); await settle(); let stopped = false;
+    const remove = elements(find(node, 'actions').element, 'button')[2];
+    remove.events.click({ preventDefault() {}, stopPropagation() { stopped = true; } });
+    assert.equal(stopped, true); assert.deepEqual(saved(node), []);
 });

--- a/web/donut_lora_ui.js
+++ b/web/donut_lora_ui.js
@@ -1,0 +1,178 @@
+// Presentation only. No model loading, network requests or serialized row state.
+// Filename/preset selectors and numeric controls remain native ComfyUI widgets.
+function loraElement(tag, text, style = {}) {
+    const element = document.createElement(tag);
+    if (text !== undefined) element.textContent = String(text);
+    Object.assign(element.style, style);
+    return element;
+}
+function loraButton(text, title, callback) {
+    const button = loraElement("button", text, {
+        font: "inherit", lineHeight: "20px", minHeight: "26px", padding: "1px 9px",
+        border: "1px solid var(--border-color, #595959)", borderRadius: "4px",
+        background: "var(--comfy-input-bg, #292929)", color: "var(--input-text, #ddd)",
+        cursor: "pointer", flexShrink: "0"
+    });
+    button.type = "button"; button.title = title;
+    button.setAttribute("aria-label", title);
+    button.addEventListener("click", event => {
+        event.preventDefault(); event.stopPropagation();
+        if (!button.disabled) callback();
+    });
+    return button;
+}
+
+export function createLoraToolbar(index, count, onAction) {
+    const root = loraElement("div", undefined, {
+        boxSizing: "border-box", width: "100%", padding: "6px 12px 2px",
+        font: "12px sans-serif", color: "var(--input-text, #ddd)"
+    });
+    root.setAttribute("aria-label", `LoRA ${index + 1} actions`);
+    const bar = loraElement("div", undefined, {
+        display: "flex", alignItems: "center", gap: "5px", paddingTop: "6px",
+        borderTop: "1px solid var(--border-color, #595959)"
+    });
+    bar.append(loraElement("strong", `LoRA ${index + 1}`, { flex: "1", minWidth: "0" }));
+    const up = loraButton("↑", `Move LoRA ${index + 1} up`, () => onAction("Move up"));
+    const down = loraButton("↓", `Move LoRA ${index + 1} down`, () => onAction("Move down"));
+    up.disabled = index === 0; down.disabled = index === count - 1;
+    for (const button of [up, down]) if (button.disabled) {
+        button.style.opacity = "0.35"; button.style.cursor = "default";
+    }
+    const remove = loraButton("Remove", `Remove LoRA ${index + 1} from this stack (keeps the file)`, () => onAction("Remove"));
+    bar.append(up, down, remove); root.append(bar);
+    return root;
+}
+
+// Runs are lossless: [0,1,2,4,6,7] -> "0–2, 4, 6–7", not "0–7".
+export function compactLoraIndices(indices) {
+    const values = [...new Set((indices || []).filter(Number.isInteger))].sort((a, b) => a - b);
+    const ranges = [];
+    for (let i = 0; i < values.length; i++) {
+        const first = values[i];
+        let last = first;
+        while (i + 1 < values.length && values[i + 1] === last + 1) last = values[++i];
+        ranges.push(first === last ? String(first) : `${first}–${last}`);
+    }
+    return ranges.join(", ");
+}
+
+export function renderLoraInformation(root, row, data, { api, lookupOn, view, onAction, onResize }) {
+    root.replaceChildren();
+    Object.assign(root.style, {
+        boxSizing: "border-box", width: "100%", padding: "0 12px 8px",
+        overflow: "auto", font: "12px/1.4 sans-serif", color: "var(--input-text, #ddd)"
+    });
+    const card = loraElement("div", undefined, {
+        boxSizing: "border-box", padding: "8px 10px", display: "grid", gap: "8px",
+        border: "1px solid var(--border-color, #595959)", borderRadius: "5px",
+        background: "var(--comfy-input-bg, #292929)", minWidth: "0", overflowWrap: "anywhere"
+    });
+    root.append(card);
+    const muted = { opacity: "0.75", fontSize: "11px" };
+    const section = (key, title, defaultOpen = false) => {
+        const box = loraElement("details"); box.open = view[key] ?? defaultOpen;
+        const summary = loraElement("summary", title, { cursor: "pointer", fontWeight: "600" });
+        box.append(summary);
+        const body = loraElement("div", undefined, { paddingTop: "7px", display: "grid", gap: "6px", minWidth: "0" });
+        box.append(body);
+        box.addEventListener("toggle", () => {
+            // Ignore events from a panel replaced by an async metadata update.
+            if (!root.contains(box)) return;
+            view[key] = box.open; onResize();
+        });
+        return { box, body };
+    };
+    const analysis = data.analysis;
+    const count = analysis?.components?.length || 0;
+    const detected = section("weightsOpen", analysis?.supported
+        ? `Detected weights · ${analysis.tensor_count} tensors · ${count} component${count === 1 ? "" : "s"}`
+        : "Detected weights");
+    if (analysis?.supported) {
+        for (const component of analysis.components || []) {
+            const group = loraElement("div", undefined, { display: "grid", gap: "2px" });
+            group.append(loraElement("strong", `${component.name} · ${component.modules} modules`));
+            for (const block of component.groups || []) {
+                const line = loraElement("div", `${block.name}: ${compactLoraIndices(block.indices)}`);
+                line.title = (block.indices || []).join(", "); group.append(line);
+            }
+            if (component.ungrouped_names?.length) group.append(loraElement("div", component.ungrouped_names.join(", "), muted));
+            detected.body.append(group);
+        }
+    } else detected.body.append(loraElement("div", analysis?.error || data.analysisError || "Inspecting local file…", muted));
+    // Keep errors visible even while the long block list is collapsed.
+    if (data.analysisError || analysis?.error) detected.box.open = true;
+    card.append(detected.box);
+
+    const info = data.info?.civitai;
+    const civitai = section("civitaiOpen", lookupOn ? "CivitAI" : "CivitAI · automatic lookup off", true);
+    card.append(civitai.box);
+    const overview = loraElement("div", undefined, {
+        display: "grid", gridTemplateColumns: "minmax(0, 1fr)", gap: "10px", alignItems: "start"
+    });
+    const text = loraElement("div", undefined, { display: "grid", gap: "5px", minWidth: "0" });
+    overview.append(text); civitai.body.append(overview);
+    if (info) {
+        text.append(loraElement("strong", info.model_name || row.lora_name));
+        text.append(loraElement("div", [info.version_name, info.base_model].filter(Boolean).join(" · "), muted));
+        if (typeof info.recommended_weight === "number" && Number.isFinite(info.recommended_weight)) {
+            const weight = loraElement("div", `Suggested weight: ${info.recommended_weight}`);
+            weight.title = "CivitAI example/cache hint, not an optimum. Never applied automatically.";
+            text.append(weight);
+        }
+    } else text.append(loraElement("div", data.info?.error || data.infoError || (lookupOn
+        ? "Looking up hash and previews…" : "Enable CivitAI lookup to fetch metadata automatically."), muted));
+
+    const isHash = value => typeof value === "string" && /^[a-f\d]{10,128}$/i.test(value);
+    const hash = isHash(row.lora_hash) ? row.lora_hash : data.info?.hash;
+    if (info || (lookupOn && isHash(hash))) {
+        const id = Number(info?.model_id), version = Number(info?.model_version_id);
+        const link = loraElement("a", info ? "Open on CivitAI ↗" : "Search hash on CivitAI ↗", { display: "block" });
+        link.href = Number.isSafeInteger(id) && id > 0 ? `https://civitai.com/models/${id}${Number.isSafeInteger(version) && version > 0 ? "?modelVersionId=" + version : ""}`
+            : `https://civitai.com/search/models?query=${encodeURIComponent(isHash(hash) ? hash : row.lora_name)}`;
+        link.target = "_blank"; link.rel = "noopener noreferrer";
+        text.append(link);
+    }
+    let previewURL;
+    if (isHash(data.info?.hash) && (data.info.has_collage || data.info.preview_count > 0)) {
+        // The local preview cache is indexed by the lookup prefix, not a saved full hash.
+        previewURL = api.apiURL(`/donut/loras/preview?${new URLSearchParams({ hash: data.info.hash, type: data.info.has_collage ? "collage" : "0" })}`);
+    } else if (data.execution?.image?.filename) {
+        const image = data.execution.image;
+        previewURL = api.apiURL(`/view?${new URLSearchParams({ filename: image.filename, subfolder: image.subfolder || "", type: image.type || "temp" })}`);
+    }
+    if (previewURL) {
+        overview.style.gridTemplateColumns = "minmax(0, 1fr) 92px";
+        const link = loraElement("a", undefined, { display: "block", width: "92px" });
+        link.href = previewURL; link.target = "_blank"; link.rel = "noopener noreferrer";
+        const image = loraElement("img", undefined, {
+            display: "block", width: "92px", height: "112px", maxWidth: "100%", objectFit: "contain", borderRadius: "3px"
+        });
+        image.src = previewURL; image.alt = "LoRA preview (click to open)"; image.loading = "lazy";
+        image.addEventListener("error", () => {
+            link.replaceChildren(loraElement("span", "Preview unavailable", muted)); onResize();
+        });
+        link.append(image); overview.append(link);
+    } else if (info) text.append(loraElement("div", "No cached preview image available.", muted));
+    if (info?.trained_words?.length) civitai.body.append(loraElement("div", `Triggers: ${info.trained_words.join(", ")}`));
+    const more = section("moreOpen", "More details");
+    if (info?.creator_username) more.body.append(loraElement("div", `Author: ${info.creator_username}`));
+    if (isHash(hash)) more.body.append(loraElement("div", `Hash: ${hash}`, { fontSize: "11px", overflowWrap: "anywhere" }));
+    more.body.append(loraElement("div", `Your strengths: model ${row.model_weight} · CLIP/text fusion ${row.clip_weight}`));
+    if (info?.description) more.body.append(loraElement("div", String(info.description).replace(/<[^>]*>/g, "")));
+    if (!info && data.execution?.text) more.body.append(loraElement("div", data.execution.text));
+    if (typeof info?.recommended_weight === "number" && Number.isFinite(info.recommended_weight)) {
+        more.body.append(loraElement("small", "Suggested weight is an example/cache hint, not a measured optimum."));
+        more.body.append(loraButton("Use suggested model weight", "Use the suggested model weight; leave CLIP strength unchanged", () => onAction("Use suggested model weight")));
+    }
+    more.body.append(loraButton("Retry metadata", "Retry metadata (CivitAI requests require lookup On)", () => onAction("Retry metadata")));
+    civitai.body.append(more.box);
+    if (data.infoError || data.info?.error) {
+        // A failure is actionable without opening More details.
+        more.box.open = true;
+        text.append(loraElement("small", "Retry metadata below to try again."));
+    }
+    // The caller observes this natural-height child, not its constrained parent.
+    // Short panels shrink; long descriptions scroll within the measured cap.
+    return { content: card, preferredHeight: previewURL ? 220 : info ? 178 : 125 };
+}

--- a/web/donut_native_lora.js
+++ b/web/donut_native_lora.js
@@ -1,3 +1,5 @@
+import { createLoraToolbar, renderLoraInformation } from "./donut_lora_ui.js";
+
 // Native ComfyUI controls; slots_json remains the ONLY serialized row state.
 // No datalist, HTML select or hand-built dropdown menu.
 export function decodeRows(value) {
@@ -107,7 +109,7 @@ export function installNativeLoras(node, definition, { app, api, service }) {
         presets: unique(["None", ...(options.donut_presets || [])]) };
     let rows = [], ui = [], disposed = false, invalid = false, listError = "";
     let generation = 0, catalogLoading = true;
-    const panels = new Map(), details = new Map(), expanded = new Set();
+    const panels = new Map(), details = new Map(), expanded = new Set(), panelViews = new Map();
     const get = name => backend.find(w => w.name === name)?.value;
     const lookupOn = () => get("civitai_lookup") === "On";
     const dirty = () => { node.setDirtyCanvas?.(true, true); app.graph?.change?.(); };
@@ -132,6 +134,7 @@ export function installNativeLoras(node, definition, { app, api, service }) {
         return element;
     };
     function clearUI() {
+        for (const panel of panels.values()) panel.dispose?.();
         for (const widget of ui) {
             if (node.removeWidget) node.removeWidget(widget);
             else { widget.onRemove?.(); const i = node.widgets.indexOf(widget); if (i >= 0) node.widgets.splice(i, 1); }
@@ -145,72 +148,43 @@ export function installNativeLoras(node, definition, { app, api, service }) {
         const info = details.get(String(row.id));
         return info?.name === row.lora_name ? info : undefined;
     }
+    function changeRows(change) {
+        const graph = node.graph || app.graph;
+        graph?.beforeChange?.();
+        try { change(); commit(); render(); }
+        finally { graph?.afterChange?.(); }
+    }
+    function rowAction(row, action) {
+        // Resolve identity at click time. Reorder/refresh must never make a stale
+        // index remove the neighbour, including two slots with the same filename.
+        const index = rows.indexOf(row), key = String(row.id);
+        if (index < 0 || disposed || invalid) return;
+        if (action === "Retry metadata") { requestDetails(row, true); return; }
+        if (action === "Move up" || action === "Move down") {
+            const to = index + (action === "Move up" ? -1 : 1);
+            if (to < 0 || to >= rows.length) return;
+            changeRows(() => { rows = moveRow(rows, index, to); });
+        } else if (action === "Remove") {
+            changeRows(() => { rows.splice(index, 1); details.delete(key); expanded.delete(key); panelViews.delete(key); });
+        } else if (action === "Use suggested model weight") {
+            const weight = validInfo(row)?.info?.civitai?.recommended_weight;
+            if (typeof weight !== "number" || !Number.isFinite(weight) || Math.abs(weight) > 1000) return;
+            changeRows(() => { row.model_weight = weight; }); // CLIP/text fusion stays unchanged.
+        }
+    }
     function updatePanel(row) {
         const panel = panels.get(String(row.id));
         if (!panel) return;
-        const { root, widget } = panel;
-        root.replaceChildren();
-        const data = validInfo(row) || {};
-        root.append(el("strong", "Detected weights"));
-        const analysis = data.analysis;
-        if (analysis?.supported) {
-            root.append(el("div", `${analysis.tensor_count} tensors · ${analysis.components?.length || 0} components`));
-            for (const component of analysis.components || []) {
-                const groups = (component.groups || []).map(g => `${g.name}: ${g.indices.join(", ")}`).join("; ");
-                root.append(el("div", `${component.name} (${component.modules} modules)${groups ? " · " + groups : ""}`));
-            }
-        } else root.append(el("div", analysis?.error || data.analysisError || "Inspecting local file…"));
-        root.append(el("div", `Your strengths: model ${row.model_weight} · CLIP/text fusion ${row.clip_weight}`));
-        const info = data.info?.civitai;
-        root.append(el("strong", lookupOn() ? "CivitAI" : "CivitAI lookup is off"));
-        if (info) {
-            root.append(el("div", `${info.model_name || ""}${info.version_name ? " · " + info.version_name : ""}`));
-            root.append(el("div", `${info.base_model || ""}${info.creator_username ? " · " + info.creator_username : ""}`));
-            const weight = info.recommended_weight;
-            if (typeof weight === "number" && Number.isFinite(weight)) {
-                root.append(el("div", `Suggested weight: ${weight} (CivitAI example/cache hint; not applied automatically)`));
-            }
-            if (info.trained_words?.length) root.append(el("div", `Triggers: ${info.trained_words.join(", ")}`));
-            // Remote descriptions are text, never executable HTML.
-            if (info.description) {
-                const more = el("details"), summary = el("summary", "Description");
-                more.append(summary, el("div", String(info.description).replace(/<[^>]*>/g, "")));
-                root.append(more);
-            }
-        } else if (lookupOn()) root.append(el("div", data.info?.error || data.infoError || "Looking up hash and previews…"));
-        if (!info && data.execution?.text) root.append(el("div", data.execution.text));
-        const hash = data.info?.hash || row.lora_hash;
-        if (hexHash(hash)) root.append(el("small", `Hash: ${hash}`));
-        if (info || (lookupOn() && hexHash(hash))) {
-            const link = el("a", info ? "Open on CivitAI ↗" : "Search hash on CivitAI ↗");
-            // Construct links from IDs/hashes; never trust an arbitrary metadata URL.
-            const id = Number(info?.model_id), version = Number(info?.model_version_id);
-            link.href = Number.isSafeInteger(id) && id > 0 ? `https://civitai.com/models/${id}${Number.isSafeInteger(version) && version > 0 ? "?modelVersionId=" + version : ""}`
-                : `https://civitai.com/search/models?query=${encodeURIComponent(hexHash(hash) ? hash : row.lora_name)}`;
-            link.target = "_blank"; link.rel = "noopener noreferrer";
-            root.append(link);
-        }
-        let previewURL;
-        if (hexHash(hash) && (data.info?.has_collage || data.info?.preview_count > 0)) {
-            previewURL = api.apiURL(`/donut/loras/preview?${new URLSearchParams({ hash, type: data.info.has_collage ? "collage" : "0" })}`);
-        } else if (data.execution?.image?.filename) {
-            const image = data.execution.image;
-            previewURL = api.apiURL(`/view?${new URLSearchParams({ filename: image.filename, subfolder: image.subfolder || "", type: image.type || "temp" })}`);
-        }
-        if (previewURL) {
-            const link = el("a"), image = el("img");
-            link.href = previewURL; link.target = "_blank"; link.rel = "noopener noreferrer";
-            image.src = previewURL; image.alt = "LoRA preview (click to open)"; image.loading = "lazy";
-            Object.assign(image.style, { display: "block", maxWidth: "100%", maxHeight: "150px", objectFit: "contain" });
-            image.addEventListener("error", () => { link.replaceChildren(el("span", "Preview unavailable; retry lookup from row actions.")); });
-            link.append(image); root.append(link);
-        } else if (info) root.append(el("div", "No cached preview image available."));
-        if (data.infoError || data.info?.error) root.append(el("small", "Use Row actions → Retry metadata to try again."));
-        panel.height = previewURL ? 250 : info ? 150 : 85;
-        widget.options.getMinHeight = widget.options.getMaxHeight = () => panel.height;
-        widget.options.getHeight = () => panel.height;
-        setHidden(widget, !enabled(row) || !hasFile(row));
-        fit();
+        panel.observer?.disconnect();
+        const result = renderLoraInformation(panel.root, row, validInfo(row) || {}, {
+            api, lookupOn: lookupOn(), view: panel.view,
+            onAction: action => rowAction(row, action), onResize: () => panel.measure()
+        });
+        panel.content = result.content;
+        panel.height = result.preferredHeight;
+        panel.observer?.observe(panel.content);
+        setHidden(panel.widget, !enabled(row) || !hasFile(row));
+        panel.measure(); fit();
     }
     function requestDetails(row, force = false) {
         if (!enabled(row) || !hasFile(row) || disposed) return;
@@ -236,10 +210,9 @@ export function installNativeLoras(node, definition, { app, api, service }) {
     function render() {
         clearUI();
         const add = make("button", "+ Add LoRA", null, () => {
-            if (invalid) return;
-            rows.push({ id: globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`, enabled: true,
-                lora_name: "None", model_weight: 1, clip_weight: 1, block_preset: "None", block_vector: "", inherit_block_vector: false, lora_hash: "" });
-            commit(); render();
+            if (invalid || disposed) return;
+            changeRows(() => rows.push({ id: globalThis.crypto?.randomUUID?.() || `${Date.now()}-${Math.random()}`, enabled: true,
+                lora_name: "None", model_weight: 1, clip_weight: 1, block_preset: "None", block_vector: "", inherit_block_vector: false, lora_hash: "" }));
         });
         add.disabled = invalid;
         make("button", listError || (catalogLoading ? "Loading installed LoRAs…" : `Refresh installed LoRAs (${catalog.loras.filter(n => n !== "None").length})`), null, () => { void refresh(true); });
@@ -251,6 +224,12 @@ export function installNativeLoras(node, definition, { app, api, service }) {
         rows.forEach((row, index) => {
             const key = String(row.id);
             const prefix = `donut_row:${key}:`;
+            const toolbar = createLoraToolbar(index, rows.length, action => rowAction(row, action));
+            const actions = node.addDOMWidget(prefix + "actions", "div", toolbar, {
+                serialize: false, margin: 0, getMinHeight: () => 43, getMaxHeight: () => 43, getHeight: () => 43
+            });
+            actions.serialize = false; ui.push(actions);
+            actions.computeSize = () => [280, 43];
             const name = make("combo", prefix + "lora_name", row.lora_name || "None", value => {
                 if (value === row.lora_name) return;
                 row.lora_name = value; row.lora_hash = ""; details.delete(key);
@@ -303,27 +282,36 @@ export function installNativeLoras(node, definition, { app, api, service }) {
             const vector = make("text", prefix + "block_vector", row.block_vector || "", value => { row.block_vector = value; commit(); });
             vector.label = "Block vector"; vector.disabled = !!row.inherit_block_vector;
             const root = el("div");
-            Object.assign(root.style, { overflow: "auto", boxSizing: "border-box", padding: "6px", font: "12px sans-serif", whiteSpace: "normal", overflowWrap: "anywhere" });
             root.setAttribute("aria-label", `LoRA ${index + 1} information`);
-            const panel = { root, height: 85 };
+            if (!panelViews.has(key)) panelViews.set(key, {});
+            const panel = { root, height: 125, view: panelViews.get(key), content: null, frame: null };
             const dom = node.addDOMWidget(prefix + "information", "div", root, {
-                serialize: false, getMinHeight: () => panel.height, getMaxHeight: () => panel.height, getHeight: () => panel.height
+                serialize: false, margin: 0,
+                getMinHeight: () => panel.height, getMaxHeight: () => panel.height, getHeight: () => panel.height
             });
             dom.serialize = false; ui.push(dom); panel.widget = dom; panels.set(key, panel);
             dom.computeSize = () => [280, panel.height];
-            const action = make("combo", prefix + "actions", "Row actions", value => {
-                action.value = "Row actions";
-                if (value === "Move up" || value === "Move down") rows = moveRow(rows, index, index + (value === "Move up" ? -1 : 1));
-                else if (value === "Remove") { rows.splice(index, 1); details.delete(key); expanded.delete(key); }
-                else if (value === "Retry metadata") { requestDetails(row, true); return; }
-                else if (value === "Use suggested model weight") {
-                    const weight = validInfo(row)?.info?.civitai?.recommended_weight;
-                    if (typeof weight !== "number" || !Number.isFinite(weight) || Math.abs(weight) > 1000) return;
-                    row.model_weight = weight; // CLIP/text-fusion strength is deliberately unchanged.
-                } else return;
-                commit(); render();
-            }, { values: ["Row actions", "Move up", "Move down", "Remove", "Retry metadata", "Use suggested model weight"] });
-            action.label = `LoRA ${index + 1} actions`;
+            const measure = () => {
+                panel.frame = null;
+                if (disposed || panels.get(key) !== panel || !panel.content?.isConnected) return;
+                const natural = panel.content.scrollHeight;
+                if (!natural) return; // Hidden/collapsed nodes cannot be measured yet.
+                const height = Math.max(56, Math.min(360, Math.ceil(natural) + 10));
+                if (height !== panel.height) { panel.height = height; fit(); }
+            };
+            panel.measure = () => {
+                if (panel.frame != null) return;
+                if (typeof requestAnimationFrame === "function") panel.frame = requestAnimationFrame(measure);
+                else measure();
+            };
+            if (typeof ResizeObserver === "function") panel.observer = new ResizeObserver(panel.measure);
+            panel.dispose = () => {
+                panel.observer?.disconnect();
+                if (panel.frame != null && typeof cancelAnimationFrame === "function") cancelAnimationFrame(panel.frame);
+                panel.frame = null;
+            };
+            const removedPanel = dom.onRemove;
+            dom.onRemove = function() { panel.dispose(); removedPanel?.apply(this, arguments); };
             function visibility() {
                 dependent.forEach(widget => setHidden(widget, !enabled(row)));
                 [preset, inherit, vector].forEach(widget => setHidden(widget, !enabled(row) || !expanded.has(key)));


### PR DESCRIPTION
## Summary

Publishes the previously prepared LoRA UI cleanup as an actual, non-draft PR targeting `main`, ready for the repository owner to review and merge. Based on `2bd5f1a`; the existing Add LoRA constructor and PNG/subgraph reload fixes are retained.

## Visible controls

- Add a separate header above every LoRA's native filename picker, with visible **up**, **down**, and **Remove** buttons. Removal is no longer buried in the Row actions dropdown.
- Keep removal/reordering available for disabled rows and outside the metadata scroll area. Remove deletes the stack slot, never the installed file. Removing the final row and adding a new one are supported.
- Resolve operations by row identity, including after reordering and when several rows select the same filename. Use the graph's beforeChange/afterChange hooks for undo tracking.
- Preserve disabled rows' strengths, vectors, presets, hashes, IDs, and additional saved fields. Re-enabling restores their controls without resetting values.

## Cleaner information layout

- Compact, expandable **Detected weights** summary with lossless block ranges (for example, `0–27`); gaps and exact reported indices are preserved.
- Bordered **CivitAI** panel, initially expanded, with thumbnail beside the model/version, base model, suggested weight, and clearly separated model link. Trigger words remain available.
- **More details** holds the full wrapping hash, author, description, current strengths, retry, and explicit suggested-model-weight action. Neither model nor CLIP strength is changed automatically.
- Measure natural content height with ResizeObserver and cap long panels at 360px. Keep Remove/reorder above and outside the scrolling content. Preserve section expansion across asynchronous metadata updates and catalog refreshes during the session.

## Compatibility and scope

Native ComfyUI filename/preset dropdowns and strength widgets remain in use. `slots_json` is still the canonical backend row state; UI-only controls are excluded from workflow widget arrays and API inputs. No changes to Python loader/applier behavior, node sockets, workflow wiring, or the PNG serialization guard. Existing workflow files and loader instances stay compatible; no manual rewiring or node replacement is required.

Five changed files: the native editor, a shared UI helper, frontend contract tests, a Chromium test harness, and layout/installation documentation. No private workflows, images, logs, or credentials are committed.

## Validation

The prepared change's local test logs report **39 frontend-contract tests passed** with the private original/corrected workflow fixtures, plus **8 Chromium DOM/layout tests passed**. Without those private fixtures, one existing contract test is explicitly skipped. Browser tests cover direct removal on enabled/disabled/final rows, remove-after-reorder, saved-state restoration, bounded layouts at 320px and 420px, metadata expansion, and UI-state serialization exclusion.

```sh
node --test tests/test_streamlining_frontend.cjs
python -m unittest discover -s tests -p test_lora_cleanup_browser.py -v
```

These are frontend contracts and an offline Chromium harness using a small Comfy node adapter and fixture HTTP responses. **Not validated:** a complete live ComfyUI renderer/server, real CivitAI requests, GPU inference, or image-output parity. Playwright/Chromium are development-only test requirements.

## After merging

Update the existing DonutNodes installation on `main`, restart ComfyUI, and hard-refresh the browser. Continue using the current recovered workflow without changing its connections.